### PR TITLE
[Feat] 로그인/로그아웃 API 및 JWT 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
     // Database
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/mzc/lp/common/config/SecurityConfig.java
+++ b/src/main/java/com/mzc/lp/common/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.mzc.lp.common.config;
 
+import com.mzc.lp.common.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -9,10 +11,14 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -27,6 +33,7 @@ public class SecurityConfig {
                         .anyRequest().authenticated())
                 .headers(headers -> headers
                         .frameOptions(frame -> frame.sameOrigin()))
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 

--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -24,7 +24,9 @@ public enum ErrorCode {
 
     // Auth
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "Unauthorized"),
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "A002", "Access denied");
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "A002", "Access denied"),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "A003", "Invalid email or password"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "Invalid or expired token");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/mzc/lp/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/mzc/lp/common/entity/BaseTimeEntity.java
@@ -8,7 +8,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @MappedSuperclass
@@ -17,8 +17,8 @@ public abstract class BaseTimeEntity extends BaseEntity {
 
     @CreatedDate
     @Column(updatable = false)
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 }

--- a/src/main/java/com/mzc/lp/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mzc/lp/common/security/JwtAuthenticationFilter.java
@@ -1,0 +1,64 @@
+package com.mzc.lp.common.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && jwtProvider.validateToken(token)) {
+            Long userId = jwtProvider.getUserId(token);
+            String email = jwtProvider.getEmail(token);
+            String role = jwtProvider.getRole(token);
+
+            UserPrincipal principal = new UserPrincipal(userId, email, role);
+            List<SimpleGrantedAuthority> authorities = List.of(
+                    new SimpleGrantedAuthority("ROLE_" + role)
+            );
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(principal, null, authorities);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug("Authenticated user: {}", email);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/mzc/lp/common/security/JwtProvider.java
+++ b/src/main/java/com/mzc/lp/common/security/JwtProvider.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -49,6 +50,7 @@ public class JwtProvider {
         Date expiry = new Date(now.getTime() + refreshTokenExpiry);
 
         return Jwts.builder()
+                .id(UUID.randomUUID().toString())
                 .subject(String.valueOf(userId))
                 .issuedAt(now)
                 .expiration(expiry)

--- a/src/main/java/com/mzc/lp/common/security/JwtProvider.java
+++ b/src/main/java/com/mzc/lp/common/security/JwtProvider.java
@@ -1,0 +1,97 @@
+package com.mzc.lp.common.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+    private final SecretKey secretKey;
+    private final long accessTokenExpiry;
+    private final long refreshTokenExpiry;
+
+    public JwtProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-expiration}") long accessTokenExpiry,
+            @Value("${jwt.refresh-expiration}") long refreshTokenExpiry
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpiry = accessTokenExpiry;
+        this.refreshTokenExpiry = refreshTokenExpiry;
+    }
+
+    public String createAccessToken(Long userId, String email, String role) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + accessTokenExpiry);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("email", email)
+                .claim("role", role)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String createRefreshToken(Long userId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + refreshTokenExpiry);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.warn("Expired JWT token");
+        } catch (Exception e) {
+            log.warn("Invalid JWT token: {}", e.getMessage());
+        }
+        return false;
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    public Long getUserId(String token) {
+        return Long.parseLong(getClaims(token).getSubject());
+    }
+
+    public String getEmail(String token) {
+        return getClaims(token).get("email", String.class);
+    }
+
+    public String getRole(String token) {
+        return getClaims(token).get("role", String.class);
+    }
+
+    public long getRefreshTokenExpiry() {
+        return refreshTokenExpiry;
+    }
+}

--- a/src/main/java/com/mzc/lp/common/security/UserPrincipal.java
+++ b/src/main/java/com/mzc/lp/common/security/UserPrincipal.java
@@ -1,0 +1,7 @@
+package com.mzc.lp.common.security;
+
+public record UserPrincipal(
+        Long id,
+        String email,
+        String role
+) {}

--- a/src/main/java/com/mzc/lp/domain/user/controller/AuthController.java
+++ b/src/main/java/com/mzc/lp/domain/user/controller/AuthController.java
@@ -1,7 +1,10 @@
 package com.mzc.lp.domain.user.controller;
 
 import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.dto.request.RefreshTokenRequest;
 import com.mzc.lp.domain.user.dto.request.RegisterRequest;
+import com.mzc.lp.domain.user.dto.response.TokenResponse;
 import com.mzc.lp.domain.user.dto.response.UserResponse;
 import com.mzc.lp.domain.user.service.AuthService;
 import jakarta.validation.Valid;
@@ -28,5 +31,29 @@ public class AuthController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(response));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<TokenResponse>> login(
+            @Valid @RequestBody LoginRequest request
+    ) {
+        TokenResponse response = authService.login(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<TokenResponse>> refresh(
+            @Valid @RequestBody RefreshTokenRequest request
+    ) {
+        TokenResponse response = authService.refresh(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @Valid @RequestBody RefreshTokenRequest request
+    ) {
+        authService.logout(request.refreshToken());
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.mzc.lp.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "이메일은 필수입니다")
+        @Email(message = "유효한 이메일 형식이 아닙니다")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다")
+        String password
+) {}

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,8 @@
+package com.mzc.lp.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshTokenRequest(
+        @NotBlank(message = "Refresh token은 필수입니다")
+        String refreshToken
+) {}

--- a/src/main/java/com/mzc/lp/domain/user/dto/response/TokenResponse.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/response/TokenResponse.java
@@ -1,0 +1,12 @@
+package com.mzc.lp.domain.user.dto.response;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken,
+        String tokenType,
+        long expiresIn
+) {
+    public static TokenResponse of(String accessToken, String refreshToken, long expiresIn) {
+        return new TokenResponse(accessToken, refreshToken, "Bearer", expiresIn);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/response/UserResponse.java
@@ -3,14 +3,14 @@ package com.mzc.lp.domain.user.dto.response;
 import com.mzc.lp.domain.user.constant.TenantRole;
 import com.mzc.lp.domain.user.entity.User;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record UserResponse(
         Long userId,
         String email,
         String name,
         TenantRole role,
-        LocalDateTime createdAt
+        Instant createdAt
 ) {
     public static UserResponse from(User entity) {
         return new UserResponse(

--- a/src/main/java/com/mzc/lp/domain/user/entity/RefreshToken.java
+++ b/src/main/java/com/mzc/lp/domain/user/entity/RefreshToken.java
@@ -1,0 +1,51 @@
+package com.mzc.lp.domain.user.entity;
+
+import com.mzc.lp.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refresh_tokens", indexes = {
+        @Index(name = "idx_refresh_tokens_token", columnList = "token"),
+        @Index(name = "idx_refresh_tokens_user_id", columnList = "user_id"),
+        @Index(name = "idx_refresh_tokens_expires_at", columnList = "expires_at")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken extends BaseTimeEntity {
+
+    @Column(nullable = false, unique = true, length = 500)
+    private String token;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false)
+    private boolean revoked = false;
+
+    private RefreshToken(String token, Long userId, LocalDateTime expiresAt) {
+        this.token = token;
+        this.userId = userId;
+        this.expiresAt = expiresAt;
+    }
+
+    public static RefreshToken create(String token, Long userId, long expiryMillis) {
+        LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(expiryMillis / 1000);
+        return new RefreshToken(token, userId, expiresAt);
+    }
+
+    public void revoke() {
+        this.revoked = true;
+    }
+
+    public boolean isValid() {
+        return !revoked && expiresAt.isAfter(LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/entity/RefreshToken.java
+++ b/src/main/java/com/mzc/lp/domain/user/entity/RefreshToken.java
@@ -6,7 +6,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(name = "refresh_tokens", indexes = {
@@ -25,19 +25,19 @@ public class RefreshToken extends BaseTimeEntity {
     private Long userId;
 
     @Column(name = "expires_at", nullable = false)
-    private LocalDateTime expiresAt;
+    private Instant expiresAt;
 
     @Column(nullable = false)
     private boolean revoked = false;
 
-    private RefreshToken(String token, Long userId, LocalDateTime expiresAt) {
+    private RefreshToken(String token, Long userId, Instant expiresAt) {
         this.token = token;
         this.userId = userId;
         this.expiresAt = expiresAt;
     }
 
     public static RefreshToken create(String token, Long userId, long expiryMillis) {
-        LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(expiryMillis / 1000);
+        Instant expiresAt = Instant.now().plusMillis(expiryMillis);
         return new RefreshToken(token, userId, expiresAt);
     }
 
@@ -46,6 +46,6 @@ public class RefreshToken extends BaseTimeEntity {
     }
 
     public boolean isValid() {
-        return !revoked && expiresAt.isAfter(LocalDateTime.now());
+        return !revoked && expiresAt.isAfter(Instant.now());
     }
 }

--- a/src/main/java/com/mzc/lp/domain/user/exception/InvalidCredentialsException.java
+++ b/src/main/java/com/mzc/lp/domain/user/exception/InvalidCredentialsException.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.user.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class InvalidCredentialsException extends BusinessException {
+
+    public InvalidCredentialsException() {
+        super(ErrorCode.INVALID_CREDENTIALS);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/exception/InvalidTokenException.java
+++ b/src/main/java/com/mzc/lp/domain/user/exception/InvalidTokenException.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.user.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class InvalidTokenException extends BusinessException {
+
+    public InvalidTokenException() {
+        super(ErrorCode.INVALID_TOKEN);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/mzc/lp/domain/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,20 @@
+package com.mzc.lp.domain.user.repository;
+
+import com.mzc.lp.domain.user.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByTokenAndRevokedFalse(String token);
+
+    @Modifying
+    @Query("UPDATE RefreshToken rt SET rt.revoked = true WHERE rt.userId = :userId")
+    void revokeAllByUserId(@Param("userId") Long userId);
+
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/mzc/lp/domain/user/service/AuthService.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/AuthService.java
@@ -1,12 +1,22 @@
 package com.mzc.lp.domain.user.service;
 
+import com.mzc.lp.common.security.JwtProvider;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.dto.request.RefreshTokenRequest;
 import com.mzc.lp.domain.user.dto.request.RegisterRequest;
+import com.mzc.lp.domain.user.dto.response.TokenResponse;
 import com.mzc.lp.domain.user.dto.response.UserResponse;
+import com.mzc.lp.domain.user.entity.RefreshToken;
 import com.mzc.lp.domain.user.entity.User;
 import com.mzc.lp.domain.user.exception.DuplicateEmailException;
+import com.mzc.lp.domain.user.exception.InvalidCredentialsException;
+import com.mzc.lp.domain.user.exception.InvalidTokenException;
+import com.mzc.lp.domain.user.exception.UserNotFoundException;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
 import com.mzc.lp.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +28,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    @Value("${jwt.access-expiration}")
+    private long accessTokenExpiry;
 
     @Transactional
     public UserResponse register(RegisterRequest request) {
@@ -41,5 +56,88 @@ public class AuthService {
         log.info("User registered: {}", savedUser.getEmail());
 
         return UserResponse.from(savedUser);
+    }
+
+    @Transactional
+    public TokenResponse login(LoginRequest request) {
+        // 사용자 조회
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(InvalidCredentialsException::new);
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new InvalidCredentialsException();
+        }
+
+        // 토큰 생성
+        String accessToken = jwtProvider.createAccessToken(
+                user.getId(),
+                user.getEmail(),
+                user.getRole().name()
+        );
+        String refreshToken = jwtProvider.createRefreshToken(user.getId());
+
+        // Refresh Token 저장
+        RefreshToken refreshTokenEntity = RefreshToken.create(
+                refreshToken,
+                user.getId(),
+                jwtProvider.getRefreshTokenExpiry()
+        );
+        refreshTokenRepository.save(refreshTokenEntity);
+
+        log.info("User logged in: {}", user.getEmail());
+
+        return TokenResponse.of(accessToken, refreshToken, accessTokenExpiry);
+    }
+
+    @Transactional
+    public TokenResponse refresh(RefreshTokenRequest request) {
+        // Refresh Token 유효성 검증
+        if (!jwtProvider.validateToken(request.refreshToken())) {
+            throw new InvalidTokenException();
+        }
+
+        // DB에서 Refresh Token 조회
+        RefreshToken storedToken = refreshTokenRepository
+                .findByTokenAndRevokedFalse(request.refreshToken())
+                .orElseThrow(InvalidTokenException::new);
+
+        if (!storedToken.isValid()) {
+            throw new InvalidTokenException();
+        }
+
+        // 사용자 조회
+        User user = userRepository.findById(storedToken.getUserId())
+                .orElseThrow(UserNotFoundException::new);
+
+        // 기존 Refresh Token 무효화
+        storedToken.revoke();
+
+        // 새 토큰 생성
+        String newAccessToken = jwtProvider.createAccessToken(
+                user.getId(),
+                user.getEmail(),
+                user.getRole().name()
+        );
+        String newRefreshToken = jwtProvider.createRefreshToken(user.getId());
+
+        // 새 Refresh Token 저장
+        RefreshToken newRefreshTokenEntity = RefreshToken.create(
+                newRefreshToken,
+                user.getId(),
+                jwtProvider.getRefreshTokenExpiry()
+        );
+        refreshTokenRepository.save(newRefreshTokenEntity);
+
+        log.info("Token refreshed for user: {}", user.getEmail());
+
+        return TokenResponse.of(newAccessToken, newRefreshToken, accessTokenExpiry);
+    }
+
+    @Transactional
+    public void logout(String refreshToken) {
+        refreshTokenRepository.findByTokenAndRevokedFalse(refreshToken)
+                .ifPresent(RefreshToken::revoke);
+        log.info("User logged out");
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,5 +29,5 @@ server:
 
 jwt:
   secret: ${JWT_SECRET:default-secret-key-for-development-only}
-  access-expiration: ${JWT_ACCESS_EXPIRATION:3600000}
+  access-expiration: ${JWT_ACCESS_EXPIRATION:900000}
   refresh-expiration: ${JWT_REFRESH_EXPIRATION:604800000}

--- a/src/test/java/com/mzc/lp/domain/user/controller/AuthControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/user/controller/AuthControllerTest.java
@@ -1,17 +1,23 @@
 package com.mzc.lp.domain.user.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.dto.request.RefreshTokenRequest;
 import com.mzc.lp.domain.user.dto.request.RegisterRequest;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
 import com.mzc.lp.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -29,9 +35,42 @@ class AuthControllerTest {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
     @BeforeEach
     void setUp() {
+        refreshTokenRepository.deleteAll();
         userRepository.deleteAll();
+    }
+
+    // 테스트용 유저 생성 헬퍼
+    private void createTestUser() throws Exception {
+        RegisterRequest request = new RegisterRequest(
+                "test@example.com",
+                "Password123!",
+                "홍길동",
+                null
+        );
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+    }
+
+    // 로그인 후 토큰 추출 헬퍼
+    private String[] loginAndGetTokens() throws Exception {
+        LoginRequest request = new LoginRequest("test@example.com", "Password123!");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        String accessToken = objectMapper.readTree(response).get("data").get("accessToken").asText();
+        String refreshToken = objectMapper.readTree(response).get("data").get("refreshToken").asText();
+        return new String[]{accessToken, refreshToken};
     }
 
     @Test
@@ -122,5 +161,137 @@ class AuthControllerTest {
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false));
+    }
+
+    // ==================== 로그인 테스트 ====================
+
+    @Test
+    @DisplayName("로그인 성공")
+    void login_success() throws Exception {
+        // given
+        createTestUser();
+        LoginRequest request = new LoginRequest("test@example.com", "Password123!");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.accessToken").exists())
+                .andExpect(jsonPath("$.data.refreshToken").exists())
+                .andExpect(jsonPath("$.data.tokenType").value("Bearer"));
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 잘못된 이메일")
+    void login_fail_wrong_email() throws Exception {
+        // given
+        createTestUser();
+        LoginRequest request = new LoginRequest("wrong@example.com", "Password123!");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("A003"));
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 잘못된 비밀번호")
+    void login_fail_wrong_password() throws Exception {
+        // given
+        createTestUser();
+        LoginRequest request = new LoginRequest("test@example.com", "WrongPassword123!");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("A003"));
+    }
+
+    // ==================== 토큰 갱신 테스트 ====================
+
+    @Test
+    @DisplayName("토큰 갱신 성공")
+    void refresh_success() throws Exception {
+        // given
+        createTestUser();
+        String[] tokens = loginAndGetTokens();
+        String refreshToken = tokens[1];
+
+        RefreshTokenRequest request = new RefreshTokenRequest(refreshToken);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.accessToken").exists())
+                .andExpect(jsonPath("$.data.refreshToken").exists());
+    }
+
+    @Test
+    @DisplayName("토큰 갱신 실패 - 잘못된 토큰")
+    void refresh_fail_invalid_token() throws Exception {
+        // given
+        RefreshTokenRequest request = new RefreshTokenRequest("invalid-token");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("A004"));
+    }
+
+    // ==================== 로그아웃 테스트 ====================
+
+    @Test
+    @DisplayName("로그아웃 성공")
+    void logout_success() throws Exception {
+        // given
+        createTestUser();
+        String[] tokens = loginAndGetTokens();
+        String refreshToken = tokens[1];
+
+        RefreshTokenRequest request = new RefreshTokenRequest(refreshToken);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        // 로그아웃 후 같은 토큰으로 갱신 시도 - 실패해야 함
+        mockMvc.perform(post("/api/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ==================== 인증 필요 API 접근 테스트 ====================
+
+    @Test
+    @DisplayName("인증 없이 보호된 API 접근 - 실패")
+    void access_protected_api_without_token() throws Exception {
+        // when & then - 인증 없이 접근 (Spring Security 기본: 403 Forbidden)
+        mockMvc.perform(get("/api/users/me"))
+                .andDo(print())
+                .andExpect(status().isForbidden());
     }
 }


### PR DESCRIPTION
## Summary
- JWT 기반 로그인/로그아웃 API 구현 (Access Token 15분, Refresh Token 7일)
- Refresh Token DB 저장 방식으로 토큰 무효화 지원
- BaseTimeEntity 시간 타입 `Instant`로 변경 (글로벌 서비스 대응)
- 전체 API 테스트 코드 작성 (11개 테스트 케이스)

## Changes

### 신규 파일 (12개)
| 파일 | 설명 |
|------|------|
| `JwtProvider.java` | JWT 토큰 생성/검증 (UUID jti로 유일성 보장) |
| `JwtAuthenticationFilter.java` | 요청별 JWT 인증 필터 |
| `UserPrincipal.java` | 인증된 사용자 정보 |
| `RefreshToken.java` | Refresh Token Entity |
| `RefreshTokenRepository.java` | Refresh Token 저장소 |
| `LoginRequest.java` | 로그인 요청 DTO |
| `RefreshTokenRequest.java` | 토큰 갱신/로그아웃 요청 DTO |
| `TokenResponse.java` | 토큰 응답 DTO |
| `InvalidCredentialsException.java` | 인증 실패 예외 |
| `InvalidTokenException.java` | 토큰 오류 예외 |
| `AuthControllerTest.java` | 인증 API 통합 테스트 (11개) |

### 수정 파일 (7개)
| 파일 | 변경 내용 |
|------|----------|
| `build.gradle` | jjwt 의존성 추가 |
| `SecurityConfig.java` | JWT 필터 추가 |
| `ErrorCode.java` | `INVALID_CREDENTIALS`, `INVALID_TOKEN` 추가 |
| `BaseTimeEntity.java` | `LocalDateTime` → `Instant` |
| `UserResponse.java` | `Instant` 타입 적용 |
| `AuthController.java` | login, refresh, logout 엔드포인트 추가 |
| `AuthService.java` | 로그인/토큰갱신/로그아웃 비즈니스 로직 |

## API Endpoints

| Method | Endpoint | 설명 | 인증 |
|--------|----------|------|------|
| POST | `/api/auth/login` | 로그인 (토큰 발급) | X |
| POST | `/api/auth/refresh` | 토큰 갱신 | X |
| POST | `/api/auth/logout` | 로그아웃 (토큰 무효화) | X |

## Test Results
BUILD SUCCESSFUL 11 tests completed, 0 failed

| 카테고리 | 테스트 케이스 | 결과 |
|---------|-------------|------|
| 회원가입 | 성공, 중복이메일, 유효성검증 (3개) | ✅ |
| 로그인 | 성공, 잘못된 이메일, 잘못된 비밀번호 (3개) | ✅ |
| 토큰갱신 | 성공, 잘못된 토큰 (2개) | ✅ |
| 로그아웃 | 성공 + 토큰무효화 검증 (1개) | ✅ |
| 인증 | 토큰없이 접근 실패 (1개) | ✅ |

## Related
- Base: `feat/user-register`
- 보안 컨벤션: `docs/conventions/21-SECURITY-CONVENTIONS.md`