### PR TITLE
[Feat] User API 확장 (/me 엔드포인트) - #11

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -17,7 +17,8 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "User not found"),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "U002", "Email already exists"),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "U003", "Invalid password format"),
-    PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "U004", "Password mismatch"),
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "U004", "Current password is incorrect"),
+    USER_ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "U005", "User already withdrawn"),
 
     // Course
     COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "CR001", "Course not found"),

--- a/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
+++ b/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
@@ -1,0 +1,59 @@
+package com.mzc.lp.domain.user.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.user.dto.request.ChangePasswordRequest;
+import com.mzc.lp.domain.user.dto.request.UpdateProfileRequest;
+import com.mzc.lp.domain.user.dto.request.WithdrawRequest;
+import com.mzc.lp.domain.user.dto.response.UserDetailResponse;
+import com.mzc.lp.domain.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+@Validated
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserDetailResponse>> getMe(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        UserDetailResponse response = userService.getMe(principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PutMapping("/me")
+    public ResponseEntity<ApiResponse<UserDetailResponse>> updateMe(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody UpdateProfileRequest request
+    ) {
+        UserDetailResponse response = userService.updateMe(principal.id(), request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PutMapping("/me/password")
+    public ResponseEntity<ApiResponse<Void>> changePassword(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody ChangePasswordRequest request
+    ) {
+        userService.changePassword(principal.id(), request);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> withdraw(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody WithdrawRequest request
+    ) {
+        userService.withdraw(principal.id(), request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/ChangePasswordRequest.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/ChangePasswordRequest.java
@@ -1,0 +1,18 @@
+package com.mzc.lp.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record ChangePasswordRequest(
+        @NotBlank(message = "현재 비밀번호는 필수입니다")
+        String currentPassword,
+
+        @NotBlank(message = "새 비밀번호는 필수입니다")
+        @Size(min = 8, max = 50, message = "비밀번호는 8자 이상 50자 이하여야 합니다")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&]).+$",
+                message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다"
+        )
+        String newPassword
+) {}

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/UpdateProfileRequest.java
@@ -1,0 +1,14 @@
+package com.mzc.lp.domain.user.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record UpdateProfileRequest(
+        @Size(max = 50, message = "이름은 50자 이하여야 합니다")
+        String name,
+
+        @Size(max = 20, message = "전화번호는 20자 이하여야 합니다")
+        String phone,
+
+        @Size(max = 500, message = "프로필 이미지 URL은 500자 이하여야 합니다")
+        String profileImageUrl
+) {}

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/WithdrawRequest.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/WithdrawRequest.java
@@ -1,0 +1,12 @@
+package com.mzc.lp.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record WithdrawRequest(
+        @NotBlank(message = "비밀번호는 필수입니다")
+        String password,
+
+        @Size(max = 500, message = "탈퇴 사유는 500자 이하여야 합니다")
+        String reason
+) {}

--- a/src/main/java/com/mzc/lp/domain/user/dto/response/UserDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/response/UserDetailResponse.java
@@ -1,0 +1,33 @@
+package com.mzc.lp.domain.user.dto.response;
+
+import com.mzc.lp.domain.user.entity.User;
+
+import java.time.Instant;
+
+public record UserDetailResponse(
+        Long userId,
+        String email,
+        String name,
+        String phone,
+        String profileImageUrl,
+        String role,
+        String status,
+        Long tenantId,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static UserDetailResponse from(User user) {
+        return new UserDetailResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getPhone(),
+                user.getProfileImageUrl(),
+                user.getRole().name(),
+                user.getStatus().name(),
+                user.getTenantId(),
+                user.getCreatedAt(),
+                user.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/exception/PasswordMismatchException.java
+++ b/src/main/java/com/mzc/lp/domain/user/exception/PasswordMismatchException.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.user.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class PasswordMismatchException extends BusinessException {
+
+    public PasswordMismatchException() {
+        super(ErrorCode.PASSWORD_MISMATCH);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/service/AuthService.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/AuthService.java
@@ -8,6 +8,7 @@ import com.mzc.lp.domain.user.dto.response.TokenResponse;
 import com.mzc.lp.domain.user.dto.response.UserResponse;
 import com.mzc.lp.domain.user.entity.RefreshToken;
 import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.constant.UserStatus;
 import com.mzc.lp.domain.user.exception.DuplicateEmailException;
 import com.mzc.lp.domain.user.exception.InvalidCredentialsException;
 import com.mzc.lp.domain.user.exception.InvalidTokenException;
@@ -66,6 +67,11 @@ public class AuthService {
 
         // 비밀번호 검증
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new InvalidCredentialsException();
+        }
+
+        // 탈퇴/정지 사용자 체크
+        if (user.getStatus() == UserStatus.WITHDRAWN || user.getStatus() == UserStatus.SUSPENDED) {
             throw new InvalidCredentialsException();
         }
 

--- a/src/main/java/com/mzc/lp/domain/user/service/UserService.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserService.java
@@ -1,0 +1,17 @@
+package com.mzc.lp.domain.user.service;
+
+import com.mzc.lp.domain.user.dto.request.ChangePasswordRequest;
+import com.mzc.lp.domain.user.dto.request.UpdateProfileRequest;
+import com.mzc.lp.domain.user.dto.request.WithdrawRequest;
+import com.mzc.lp.domain.user.dto.response.UserDetailResponse;
+
+public interface UserService {
+
+    UserDetailResponse getMe(Long userId);
+
+    UserDetailResponse updateMe(Long userId, UpdateProfileRequest request);
+
+    void changePassword(Long userId, ChangePasswordRequest request);
+
+    void withdraw(Long userId, WithdrawRequest request);
+}

--- a/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,73 @@
+package com.mzc.lp.domain.user.service;
+
+import com.mzc.lp.domain.user.dto.request.ChangePasswordRequest;
+import com.mzc.lp.domain.user.dto.request.UpdateProfileRequest;
+import com.mzc.lp.domain.user.dto.request.WithdrawRequest;
+import com.mzc.lp.domain.user.dto.response.UserDetailResponse;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.exception.PasswordMismatchException;
+import com.mzc.lp.domain.user.exception.UserNotFoundException;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public UserDetailResponse getMe(Long userId) {
+        log.debug("Getting user info: userId={}", userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+        return UserDetailResponse.from(user);
+    }
+
+    @Override
+    @Transactional
+    public UserDetailResponse updateMe(Long userId, UpdateProfileRequest request) {
+        log.info("Updating user profile: userId={}", userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+        user.updateProfile(request.name(), request.phone(), request.profileImageUrl());
+        return UserDetailResponse.from(user);
+    }
+
+    @Override
+    @Transactional
+    public void changePassword(Long userId, ChangePasswordRequest request) {
+        log.info("Changing password: userId={}", userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        if (!passwordEncoder.matches(request.currentPassword(), user.getPassword())) {
+            throw new PasswordMismatchException();
+        }
+
+        user.changePassword(passwordEncoder.encode(request.newPassword()));
+        log.info("Password changed: userId={}", userId);
+    }
+
+    @Override
+    @Transactional
+    public void withdraw(Long userId, WithdrawRequest request) {
+        log.info("Withdrawing user: userId={}", userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new PasswordMismatchException();
+        }
+
+        user.withdraw();
+        log.info("User withdrawn: userId={}", userId);
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,319 @@
+package com.mzc.lp.domain.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.domain.user.dto.request.*;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @BeforeEach
+    void setUp() {
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // 테스트용 유저 생성 헬퍼
+    private void createTestUser() throws Exception {
+        RegisterRequest request = new RegisterRequest(
+                "test@example.com",
+                "Password123!",
+                "홍길동",
+                "010-1234-5678"
+        );
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+    }
+
+    // 로그인 후 액세스 토큰 추출 헬퍼
+    private String loginAndGetAccessToken() throws Exception {
+        LoginRequest request = new LoginRequest("test@example.com", "Password123!");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("data").get("accessToken").asText();
+    }
+
+    // ==================== 내 정보 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/users/me - 내 정보 조회")
+    class GetMe {
+
+        @Test
+        @DisplayName("성공 - 내 정보 조회")
+        void getMe_success() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken();
+
+            // when & then
+            mockMvc.perform(get("/api/users/me")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.email").value("test@example.com"))
+                    .andExpect(jsonPath("$.data.name").value("홍길동"))
+                    .andExpect(jsonPath("$.data.phone").value("010-1234-5678"))
+                    .andExpect(jsonPath("$.data.role").value("USER"))
+                    .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+        }
+
+        @Test
+        @DisplayName("실패 - 인증 없이 접근")
+        void getMe_fail_unauthorized() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/users/me"))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 내 정보 수정 테스트 ====================
+
+    @Nested
+    @DisplayName("PUT /api/users/me - 내 정보 수정")
+    class UpdateMe {
+
+        @Test
+        @DisplayName("성공 - 프로필 수정")
+        void updateMe_success() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken();
+            UpdateProfileRequest request = new UpdateProfileRequest(
+                    "김철수",
+                    "010-9876-5432",
+                    "https://cdn.example.com/profile.jpg"
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/users/me")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.name").value("김철수"))
+                    .andExpect(jsonPath("$.data.phone").value("010-9876-5432"))
+                    .andExpect(jsonPath("$.data.profileImageUrl").value("https://cdn.example.com/profile.jpg"));
+        }
+
+        @Test
+        @DisplayName("성공 - 부분 수정 (이름만)")
+        void updateMe_success_partial() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken();
+            UpdateProfileRequest request = new UpdateProfileRequest("김철수", null, null);
+
+            // when & then
+            mockMvc.perform(put("/api/users/me")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.name").value("김철수"));
+        }
+
+        @Test
+        @DisplayName("실패 - 인증 없이 접근")
+        void updateMe_fail_unauthorized() throws Exception {
+            // given
+            UpdateProfileRequest request = new UpdateProfileRequest("김철수", null, null);
+
+            // when & then
+            mockMvc.perform(put("/api/users/me")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 비밀번호 변경 테스트 ====================
+
+    @Nested
+    @DisplayName("PUT /api/users/me/password - 비밀번호 변경")
+    class ChangePassword {
+
+        @Test
+        @DisplayName("성공 - 비밀번호 변경")
+        void changePassword_success() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken();
+            ChangePasswordRequest request = new ChangePasswordRequest(
+                    "Password123!",
+                    "NewPassword456!"
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/users/me/password")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+
+            // 변경된 비밀번호로 로그인 성공 확인
+            LoginRequest loginRequest = new LoginRequest("test@example.com", "NewPassword456!");
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(loginRequest)))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("실패 - 현재 비밀번호 불일치")
+        void changePassword_fail_wrongCurrentPassword() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken();
+            ChangePasswordRequest request = new ChangePasswordRequest(
+                    "WrongPassword123!",
+                    "NewPassword456!"
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/users/me/password")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("U004"));
+        }
+
+        @Test
+        @DisplayName("실패 - 새 비밀번호 형식 오류")
+        void changePassword_fail_invalidNewPassword() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken();
+            ChangePasswordRequest request = new ChangePasswordRequest(
+                    "Password123!",
+                    "weak"
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/users/me/password")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+    }
+
+    // ==================== 회원 탈퇴 테스트 ====================
+
+    @Nested
+    @DisplayName("DELETE /api/users/me - 회원 탈퇴")
+    class Withdraw {
+
+        @Test
+        @DisplayName("성공 - 회원 탈퇴")
+        void withdraw_success() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken();
+            WithdrawRequest request = new WithdrawRequest(
+                    "Password123!",
+                    "더 이상 서비스를 이용하지 않습니다."
+            );
+
+            // when & then
+            mockMvc.perform(delete("/api/users/me")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+
+            // 탈퇴 후 로그인 시도 - 실패해야 함 (WITHDRAWN 상태)
+            LoginRequest loginRequest = new LoginRequest("test@example.com", "Password123!");
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(loginRequest)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("실패 - 비밀번호 불일치")
+        void withdraw_fail_wrongPassword() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken();
+            WithdrawRequest request = new WithdrawRequest(
+                    "WrongPassword123!",
+                    "탈퇴 사유"
+            );
+
+            // when & then
+            mockMvc.perform(delete("/api/users/me")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("U004"));
+        }
+
+        @Test
+        @DisplayName("실패 - 인증 없이 접근")
+        void withdraw_fail_unauthorized() throws Exception {
+            // given
+            WithdrawRequest request = new WithdrawRequest("Password123!", null);
+
+            // when & then
+            mockMvc.perform(delete("/api/users/me")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 사용자 본인 정보 관련 API 4개 구현
- 비밀번호 변경, 회원 탈퇴 기능 포함
- 탈퇴/정지 사용자 로그인 차단 로직 추가

## 구현 내용
| Method | Endpoint | 기능 |
|--------|----------|------|
| GET | `/api/users/me` | 내 정보 조회 |
| PUT | `/api/users/me` | 내 정보 수정 |
| PUT | `/api/users/me/password` | 비밀번호 변경 |
| DELETE | `/api/users/me` | 회원 탈퇴 |

## 변경 사항

### 신규 파일 (9개)
- `UserController.java` - /me API 엔드포인트
- `UserService.java`, `UserServiceImpl.java` - 서비스 레이어
- `UpdateProfileRequest.java` - 프로필 수정 DTO
- `ChangePasswordRequest.java` - 비밀번호 변경 DTO
- `WithdrawRequest.java` - 회원 탈퇴 DTO
- `UserDetailResponse.java` - 사용자 상세 응답 DTO
- `PasswordMismatchException.java` - 비밀번호 불일치 예외
- `UserControllerTest.java` - 테스트 (11개)

### 수정 파일 (2개)
- `ErrorCode.java` - PASSWORD_MISMATCH, USER_ALREADY_WITHDRAWN 추가
- `AuthService.java` - 로그인 시 WITHDRAWN/SUSPENDED 상태 체크

## Test plan
- [x] 전체 테스트 통과 (기존 + 신규 11개)
- [x] 빌드 성공
- [x] 컨벤션 준수 확인

Closes #11