### PR TITLE
[Feat] User 관리 API (OPERATOR 권한) 구현 - #12

### DIFF
--- a/src/main/java/com/mzc/lp/common/config/SecurityConfig.java
+++ b/src/main/java/com/mzc/lp/common/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.mzc.lp.common.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -15,6 +16,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/mzc/lp/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mzc/lp/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.mzc.lp.common.constant.ErrorCode;
 import com.mzc.lp.common.dto.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -31,6 +32,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
                 .body(ApiResponse.error(ErrorCode.INVALID_INPUT_VALUE, message));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("AccessDeniedException: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.ACCESS_DENIED.getStatus())
+                .body(ApiResponse.error(ErrorCode.ACCESS_DENIED));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
+++ b/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
@@ -2,14 +2,25 @@ package com.mzc.lp.domain.user.controller;
 
 import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.constant.UserStatus;
 import com.mzc.lp.domain.user.dto.request.ChangePasswordRequest;
+import com.mzc.lp.domain.user.dto.request.ChangeRoleRequest;
+import com.mzc.lp.domain.user.dto.request.ChangeStatusRequest;
 import com.mzc.lp.domain.user.dto.request.UpdateProfileRequest;
 import com.mzc.lp.domain.user.dto.request.WithdrawRequest;
 import com.mzc.lp.domain.user.dto.response.UserDetailResponse;
+import com.mzc.lp.domain.user.dto.response.UserListResponse;
+import com.mzc.lp.domain.user.dto.response.UserRoleResponse;
+import com.mzc.lp.domain.user.dto.response.UserStatusResponse;
 import com.mzc.lp.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -55,5 +66,48 @@ public class UserController {
     ) {
         userService.withdraw(principal.id(), request);
         return ResponseEntity.noContent().build();
+    }
+
+    // ========== 관리 API (OPERATOR 이상 권한) ==========
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<Page<UserListResponse>>> getUsers(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) TenantRole role,
+            @RequestParam(required = false) UserStatus status,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<UserListResponse> response = userService.getUsers(keyword, role, status, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{userId}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<UserDetailResponse>> getUser(
+            @PathVariable Long userId
+    ) {
+        UserDetailResponse response = userService.getUser(userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PutMapping("/{userId}/role")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<UserRoleResponse>> changeUserRole(
+            @PathVariable Long userId,
+            @Valid @RequestBody ChangeRoleRequest request
+    ) {
+        UserRoleResponse response = userService.changeUserRole(userId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PutMapping("/{userId}/status")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<UserStatusResponse>> changeUserStatus(
+            @PathVariable Long userId,
+            @Valid @RequestBody ChangeStatusRequest request
+    ) {
+        UserStatusResponse response = userService.changeUserStatus(userId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/ChangeRoleRequest.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/ChangeRoleRequest.java
@@ -1,0 +1,9 @@
+package com.mzc.lp.domain.user.dto.request;
+
+import com.mzc.lp.domain.user.constant.TenantRole;
+import jakarta.validation.constraints.NotNull;
+
+public record ChangeRoleRequest(
+        @NotNull(message = "역할은 필수입니다")
+        TenantRole role
+) {}

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/ChangeStatusRequest.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/ChangeStatusRequest.java
@@ -1,0 +1,13 @@
+package com.mzc.lp.domain.user.dto.request;
+
+import com.mzc.lp.domain.user.constant.UserStatus;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ChangeStatusRequest(
+        @NotNull(message = "상태는 필수입니다")
+        UserStatus status,
+
+        @Size(max = 500, message = "사유는 500자 이하여야 합니다")
+        String reason
+) {}

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/UserSearchRequest.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/UserSearchRequest.java
@@ -1,0 +1,10 @@
+package com.mzc.lp.domain.user.dto.request;
+
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.constant.UserStatus;
+
+public record UserSearchRequest(
+        String keyword,
+        TenantRole role,
+        UserStatus status
+) {}

--- a/src/main/java/com/mzc/lp/domain/user/dto/response/UserListResponse.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/response/UserListResponse.java
@@ -1,0 +1,25 @@
+package com.mzc.lp.domain.user.dto.response;
+
+import com.mzc.lp.domain.user.entity.User;
+
+import java.time.Instant;
+
+public record UserListResponse(
+        Long userId,
+        String email,
+        String name,
+        String role,
+        String status,
+        Instant createdAt
+) {
+    public static UserListResponse from(User user) {
+        return new UserListResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getRole().name(),
+                user.getStatus().name(),
+                user.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/dto/response/UserRoleResponse.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/response/UserRoleResponse.java
@@ -1,0 +1,23 @@
+package com.mzc.lp.domain.user.dto.response;
+
+import com.mzc.lp.domain.user.entity.User;
+
+import java.time.Instant;
+
+public record UserRoleResponse(
+        Long userId,
+        String email,
+        String name,
+        String role,
+        Instant updatedAt
+) {
+    public static UserRoleResponse from(User user) {
+        return new UserRoleResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getRole().name(),
+                user.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/dto/response/UserStatusResponse.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/response/UserStatusResponse.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.domain.user.dto.response;
+
+import com.mzc.lp.domain.user.entity.User;
+
+import java.time.Instant;
+
+public record UserStatusResponse(
+        Long userId,
+        String status,
+        Instant updatedAt
+) {
+    public static UserStatusResponse from(User user) {
+        return new UserStatusResponse(
+                user.getId(),
+                user.getStatus().name(),
+                user.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/mzc/lp/domain/user/repository/UserRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
 
     Optional<User> findByEmail(String email);
 

--- a/src/main/java/com/mzc/lp/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/mzc/lp/domain/user/repository/UserRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.mzc.lp.domain.user.repository;
+
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.constant.UserStatus;
+import com.mzc.lp.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserRepositoryCustom {
+
+    Page<User> searchUsers(String keyword, TenantRole role, UserStatus status, Pageable pageable);
+}

--- a/src/main/java/com/mzc/lp/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/mzc/lp/domain/user/repository/UserRepositoryImpl.java
@@ -1,0 +1,76 @@
+package com.mzc.lp.domain.user.repository;
+
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.constant.UserStatus;
+import com.mzc.lp.domain.user.entity.User;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+public class UserRepositoryImpl implements UserRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public Page<User> searchUsers(String keyword, TenantRole role, UserStatus status, Pageable pageable) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+
+        // Main query
+        CriteriaQuery<User> query = cb.createQuery(User.class);
+        Root<User> user = query.from(User.class);
+
+        List<Predicate> predicates = buildPredicates(cb, user, keyword, role, status);
+        query.where(predicates.toArray(new Predicate[0]));
+        query.orderBy(cb.desc(user.get("createdAt")));
+
+        TypedQuery<User> typedQuery = entityManager.createQuery(query);
+        typedQuery.setFirstResult((int) pageable.getOffset());
+        typedQuery.setMaxResults(pageable.getPageSize());
+
+        List<User> users = typedQuery.getResultList();
+
+        // Count query
+        CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
+        Root<User> countRoot = countQuery.from(User.class);
+
+        List<Predicate> countPredicates = buildPredicates(cb, countRoot, keyword, role, status);
+        countQuery.select(cb.count(countRoot));
+        countQuery.where(countPredicates.toArray(new Predicate[0]));
+
+        Long total = entityManager.createQuery(countQuery).getSingleResult();
+
+        return new PageImpl<>(users, pageable, total);
+    }
+
+    private List<Predicate> buildPredicates(CriteriaBuilder cb, Root<User> user,
+                                            String keyword, TenantRole role, UserStatus status) {
+        List<Predicate> predicates = new ArrayList<>();
+
+        if (keyword != null && !keyword.isBlank()) {
+            String pattern = "%" + keyword.toLowerCase() + "%";
+            Predicate emailLike = cb.like(cb.lower(user.get("email")), pattern);
+            Predicate nameLike = cb.like(cb.lower(user.get("name")), pattern);
+            predicates.add(cb.or(emailLike, nameLike));
+        }
+
+        if (role != null) {
+            predicates.add(cb.equal(user.get("role"), role));
+        }
+
+        if (status != null) {
+            predicates.add(cb.equal(user.get("status"), status));
+        }
+
+        return predicates;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/service/UserService.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserService.java
@@ -1,12 +1,22 @@
 package com.mzc.lp.domain.user.service;
 
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.constant.UserStatus;
 import com.mzc.lp.domain.user.dto.request.ChangePasswordRequest;
+import com.mzc.lp.domain.user.dto.request.ChangeRoleRequest;
+import com.mzc.lp.domain.user.dto.request.ChangeStatusRequest;
 import com.mzc.lp.domain.user.dto.request.UpdateProfileRequest;
 import com.mzc.lp.domain.user.dto.request.WithdrawRequest;
 import com.mzc.lp.domain.user.dto.response.UserDetailResponse;
+import com.mzc.lp.domain.user.dto.response.UserListResponse;
+import com.mzc.lp.domain.user.dto.response.UserRoleResponse;
+import com.mzc.lp.domain.user.dto.response.UserStatusResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface UserService {
 
+    // /me API
     UserDetailResponse getMe(Long userId);
 
     UserDetailResponse updateMe(Long userId, UpdateProfileRequest request);
@@ -14,4 +24,13 @@ public interface UserService {
     void changePassword(Long userId, ChangePasswordRequest request);
 
     void withdraw(Long userId, WithdrawRequest request);
+
+    // 관리 API (OPERATOR 권한)
+    Page<UserListResponse> getUsers(String keyword, TenantRole role, UserStatus status, Pageable pageable);
+
+    UserDetailResponse getUser(Long userId);
+
+    UserRoleResponse changeUserRole(Long userId, ChangeRoleRequest request);
+
+    UserStatusResponse changeUserStatus(Long userId, ChangeStatusRequest request);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   datasource:
     url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:mza_newlp}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME:root}
-    password: ${DB_PASSWORD:}
+    password: ${DB_PASSWORD:mzanewlp123}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:


### PR DESCRIPTION
- GET /api/users: 사용자 목록 조회 (페이징/필터링/검색)
- GET /api/users/{userId}: 사용자 상세 조회
- PUT /api/users/{userId}/role: 역할 변경 (TENANT_ADMIN 전용)
- PUT /api/users/{userId}/status: 상태 변경

신규 파일:
- ChangeRoleRequest, ChangeStatusRequest, UserSearchRequest DTO
- UserListResponse, UserRoleResponse, UserStatusResponse DTO
- UserRepositoryCustom, UserRepositoryImpl (JPA Criteria 검색)

변경 사항:
- SecurityConfig: @EnableMethodSecurity 추가
- GlobalExceptionHandler: AccessDeniedException 핸들러 추가
- UserController: Admin API 엔드포인트 추가
- UserService/UserServiceImpl: 관리 메서드 확장
- UserControllerTest: Admin API 테스트 14개 추가
- 
## 관련 이슈
closes #12