### PR TITLE
[Feat] CourseRole API (DESIGNER 역할 요청/조회) 구현 - #13

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "U003", "Invalid password format"),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "U004", "Current password is incorrect"),
     USER_ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "U005", "User already withdrawn"),
+    ROLE_ALREADY_EXISTS(HttpStatus.CONFLICT, "U006", "Role already exists for this user"),
 
     // Course
     COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "CR001", "Course not found"),

--- a/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
+++ b/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
@@ -9,11 +9,14 @@ import com.mzc.lp.domain.user.dto.request.ChangeRoleRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeStatusRequest;
 import com.mzc.lp.domain.user.dto.request.UpdateProfileRequest;
 import com.mzc.lp.domain.user.dto.request.WithdrawRequest;
+import com.mzc.lp.domain.user.dto.response.CourseRoleResponse;
 import com.mzc.lp.domain.user.dto.response.UserDetailResponse;
 import com.mzc.lp.domain.user.dto.response.UserListResponse;
 import com.mzc.lp.domain.user.dto.response.UserRoleResponse;
 import com.mzc.lp.domain.user.dto.response.UserStatusResponse;
 import com.mzc.lp.domain.user.service.UserService;
+
+import java.util.List;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -66,6 +69,24 @@ public class UserController {
     ) {
         userService.withdraw(principal.id(), request);
         return ResponseEntity.noContent().build();
+    }
+
+    // ========== CourseRole API ==========
+
+    @PostMapping("/me/course-roles/designer")
+    public ResponseEntity<ApiResponse<CourseRoleResponse>> requestDesignerRole(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseRoleResponse response = userService.requestDesignerRole(principal.id());
+        return ResponseEntity.status(201).body(ApiResponse.success(response));
+    }
+
+    @GetMapping("/me/course-roles")
+    public ResponseEntity<ApiResponse<List<CourseRoleResponse>>> getMyCourseRoles(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<CourseRoleResponse> response = userService.getMyCourseRoles(principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // ========== 관리 API (OPERATOR 이상 권한) ==========

--- a/src/main/java/com/mzc/lp/domain/user/dto/response/CourseRoleResponse.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/response/CourseRoleResponse.java
@@ -1,0 +1,36 @@
+package com.mzc.lp.domain.user.dto.response;
+
+import com.mzc.lp.domain.user.entity.UserCourseRole;
+
+import java.time.Instant;
+
+public record CourseRoleResponse(
+        Long courseRoleId,
+        Long courseId,
+        String courseName,
+        String role,
+        Integer revenueSharePercent,
+        Instant createdAt
+) {
+    public static CourseRoleResponse from(UserCourseRole userCourseRole) {
+        return new CourseRoleResponse(
+                userCourseRole.getId(),
+                userCourseRole.getCourseId(),
+                null,  // courseName은 Course 모듈 구현 후 조인해서 가져올 예정
+                userCourseRole.getRole().name(),
+                userCourseRole.getRevenueSharePercent(),
+                userCourseRole.getCreatedAt()
+        );
+    }
+
+    public static CourseRoleResponse from(UserCourseRole userCourseRole, String courseName) {
+        return new CourseRoleResponse(
+                userCourseRole.getId(),
+                userCourseRole.getCourseId(),
+                courseName,
+                userCourseRole.getRole().name(),
+                userCourseRole.getRevenueSharePercent(),
+                userCourseRole.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/entity/UserCourseRole.java
+++ b/src/main/java/com/mzc/lp/domain/user/entity/UserCourseRole.java
@@ -1,0 +1,58 @@
+package com.mzc.lp.domain.user.entity;
+
+import com.mzc.lp.common.entity.BaseTimeEntity;
+import com.mzc.lp.domain.user.constant.CourseRole;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_course_roles", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "course_id", "role"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserCourseRole extends BaseTimeEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "course_id")
+    private Long courseId;  // null이면 테넌트 레벨 역할 (DESIGNER)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private CourseRole role;
+
+    private Integer revenueSharePercent;  // 수익 분배 비율 (B2C OWNER: 70%)
+
+    // B2C: 강의 개설 버튼 클릭 시 DESIGNER 부여
+    public static UserCourseRole createDesigner(User user) {
+        UserCourseRole ucr = new UserCourseRole();
+        ucr.user = user;
+        ucr.courseId = null;  // 아직 강의 없음
+        ucr.role = CourseRole.DESIGNER;
+        return ucr;
+    }
+
+    // 강의 승인 후 OWNER로 전환
+    public static UserCourseRole createOwner(User user, Long courseId) {
+        UserCourseRole ucr = new UserCourseRole();
+        ucr.user = user;
+        ucr.courseId = courseId;
+        ucr.role = CourseRole.OWNER;
+        ucr.revenueSharePercent = 70;  // B2C 기본 70% (플랫폼 30%)
+        return ucr;
+    }
+
+    // B2B: OPERATOR가 강사 부여
+    public static UserCourseRole createInstructor(User user, Long courseId) {
+        UserCourseRole ucr = new UserCourseRole();
+        ucr.user = user;
+        ucr.courseId = courseId;
+        ucr.role = CourseRole.INSTRUCTOR;
+        return ucr;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/exception/RoleAlreadyExistsException.java
+++ b/src/main/java/com/mzc/lp/domain/user/exception/RoleAlreadyExistsException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.user.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class RoleAlreadyExistsException extends BusinessException {
+
+    public RoleAlreadyExistsException() {
+        super(ErrorCode.ROLE_ALREADY_EXISTS);
+    }
+
+    public RoleAlreadyExistsException(String role) {
+        super(ErrorCode.ROLE_ALREADY_EXISTS, "Role already exists: " + role);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/repository/UserCourseRoleRepository.java
+++ b/src/main/java/com/mzc/lp/domain/user/repository/UserCourseRoleRepository.java
@@ -1,0 +1,23 @@
+package com.mzc.lp.domain.user.repository;
+
+import com.mzc.lp.domain.user.constant.CourseRole;
+import com.mzc.lp.domain.user.entity.UserCourseRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserCourseRoleRepository extends JpaRepository<UserCourseRole, Long> {
+
+    List<UserCourseRole> findByUserId(Long userId);
+
+    Optional<UserCourseRole> findByUserIdAndCourseIdIsNullAndRole(Long userId, CourseRole role);
+
+    boolean existsByUserIdAndCourseIdIsNullAndRole(Long userId, CourseRole role);
+
+    boolean existsByUserIdAndCourseIdAndRole(Long userId, Long courseId, CourseRole role);
+
+    List<UserCourseRole> findByUserIdAndCourseId(Long userId, Long courseId);
+
+    List<UserCourseRole> findByCourseIdAndRole(Long courseId, CourseRole role);
+}

--- a/src/main/java/com/mzc/lp/domain/user/service/UserService.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserService.java
@@ -7,12 +7,15 @@ import com.mzc.lp.domain.user.dto.request.ChangeRoleRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeStatusRequest;
 import com.mzc.lp.domain.user.dto.request.UpdateProfileRequest;
 import com.mzc.lp.domain.user.dto.request.WithdrawRequest;
+import com.mzc.lp.domain.user.dto.response.CourseRoleResponse;
 import com.mzc.lp.domain.user.dto.response.UserDetailResponse;
 import com.mzc.lp.domain.user.dto.response.UserListResponse;
 import com.mzc.lp.domain.user.dto.response.UserRoleResponse;
 import com.mzc.lp.domain.user.dto.response.UserStatusResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface UserService {
 
@@ -33,4 +36,9 @@ public interface UserService {
     UserRoleResponse changeUserRole(Long userId, ChangeRoleRequest request);
 
     UserStatusResponse changeUserStatus(Long userId, ChangeStatusRequest request);
+
+    // CourseRole API
+    CourseRoleResponse requestDesignerRole(Long userId);
+
+    List<CourseRoleResponse> getMyCourseRoles(Long userId);
 }


### PR DESCRIPTION
## Summary
- B2C 사용자가 DESIGNER 역할을 요청할 수 있는 API 구현
- 본인의 CourseRole 목록 조회 API 구현
- 중복 역할 요청 시 409 Conflict 반환

## Changes

### 신규 파일 (7개)
| 파일 | 설명 |
|-----|------|
| `UserCourseRole.java` | CourseRole Entity (user_id, course_id, role, revenue_share_percent) |
| `UserCourseRoleRepository.java` | JPA Repository |
| `CourseRoleResponse.java` | 응답 DTO (Record) |
| `RoleAlreadyExistsException.java` | 중복 역할 예외 |

### 수정 파일 (4개)
| 파일 | 변경 내용 |
|-----|----------|
| `ErrorCode.java` | `ROLE_ALREADY_EXISTS` 추가 |
| `UserController.java` | 2개 엔드포인트 추가 |
| `UserService.java` | 2개 메서드 시그니처 추가 |
| `UserServiceImpl.java` | CourseRole 비즈니스 로직 구현 |

### 테스트
| 파일 | 추가 테스트 |
|-----|------------|
| `UserControllerTest.java` | 6개 테스트 케이스 추가 (총 31개 통과) |

## API Endpoints

| Method | Endpoint | 설명 |
|--------|----------|------|
| `GET` | `/api/users/me/course-roles` | 내 CourseRole 목록 조회 |
| `POST` | `/api/users/me/course-roles/designer` | DESIGNER 역할 요청 |

## Test Plan
- [x] DESIGNER 역할 요청 성공 (201 Created)
- [x] 중복 역할 요청 시 409 Conflict
- [x] CourseRole 목록 조회 (빈 배열 / 데이터 있음)
- [x] 미인증 사용자 401 Unauthorized
- [x] MySQL 실제 데이터 저장 테스트 완료

Closes #13