### PR TITLE
[Feat] CourseRole 관리 API (OPERATOR 역할 부여/회수) 구현 - #13

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "U004", "Current password is incorrect"),
     USER_ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "U005", "User already withdrawn"),
     ROLE_ALREADY_EXISTS(HttpStatus.CONFLICT, "U006", "Role already exists for this user"),
+    COURSE_ROLE_NOT_FOUND(HttpStatus.NOT_FOUND, "U007", "Course role not found"),
 
     // Course
     COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "CR001", "Course not found"),

--- a/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
+++ b/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.common.security.UserPrincipal;
 import com.mzc.lp.domain.user.constant.TenantRole;
 import com.mzc.lp.domain.user.constant.UserStatus;
+import com.mzc.lp.domain.user.dto.request.AssignCourseRoleRequest;
 import com.mzc.lp.domain.user.dto.request.ChangePasswordRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeRoleRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeStatusRequest;
@@ -130,5 +131,27 @@ public class UserController {
     ) {
         UserStatusResponse response = userService.changeUserStatus(userId, request);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // ========== CourseRole 관리 API (OPERATOR 이상 권한) ==========
+
+    @PostMapping("/{userId}/course-roles")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseRoleResponse>> assignCourseRole(
+            @PathVariable Long userId,
+            @Valid @RequestBody AssignCourseRoleRequest request
+    ) {
+        CourseRoleResponse response = userService.assignCourseRole(userId, request);
+        return ResponseEntity.status(201).body(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/{userId}/course-roles/{courseRoleId}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> revokeCourseRole(
+            @PathVariable Long userId,
+            @PathVariable Long courseRoleId
+    ) {
+        userService.revokeCourseRole(userId, courseRoleId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/AssignCourseRoleRequest.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/AssignCourseRoleRequest.java
@@ -1,0 +1,14 @@
+package com.mzc.lp.domain.user.dto.request;
+
+import com.mzc.lp.domain.user.constant.CourseRole;
+import jakarta.validation.constraints.NotNull;
+
+public record AssignCourseRoleRequest(
+        Long courseId,  // null 가능 (DESIGNER 역할의 경우)
+
+        @NotNull(message = "Role is required")
+        CourseRole role,
+
+        Integer revenueSharePercent  // OWNER인 경우 수익 분배 비율
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/user/entity/UserCourseRole.java
+++ b/src/main/java/com/mzc/lp/domain/user/entity/UserCourseRole.java
@@ -55,4 +55,14 @@ public class UserCourseRole extends BaseTimeEntity {
         ucr.role = CourseRole.INSTRUCTOR;
         return ucr;
     }
+
+    // OPERATOR가 역할 부여
+    public static UserCourseRole create(User user, Long courseId, CourseRole role, Integer revenueSharePercent) {
+        UserCourseRole ucr = new UserCourseRole();
+        ucr.user = user;
+        ucr.courseId = courseId;
+        ucr.role = role;
+        ucr.revenueSharePercent = revenueSharePercent;
+        return ucr;
+    }
 }

--- a/src/main/java/com/mzc/lp/domain/user/exception/CourseRoleNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/user/exception/CourseRoleNotFoundException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.user.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class CourseRoleNotFoundException extends BusinessException {
+
+    public CourseRoleNotFoundException() {
+        super(ErrorCode.COURSE_ROLE_NOT_FOUND);
+    }
+
+    public CourseRoleNotFoundException(Long courseRoleId) {
+        super(ErrorCode.COURSE_ROLE_NOT_FOUND, "Course role not found: " + courseRoleId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/service/UserService.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.mzc.lp.domain.user.service;
 
 import com.mzc.lp.domain.user.constant.TenantRole;
 import com.mzc.lp.domain.user.constant.UserStatus;
+import com.mzc.lp.domain.user.dto.request.AssignCourseRoleRequest;
 import com.mzc.lp.domain.user.dto.request.ChangePasswordRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeRoleRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeStatusRequest;
@@ -41,4 +42,9 @@ public interface UserService {
     CourseRoleResponse requestDesignerRole(Long userId);
 
     List<CourseRoleResponse> getMyCourseRoles(Long userId);
+
+    // CourseRole 관리 API (OPERATOR 권한)
+    CourseRoleResponse assignCourseRole(Long userId, AssignCourseRoleRequest request);
+
+    void revokeCourseRole(Long userId, Long courseRoleId);
 }


### PR DESCRIPTION
## Summary

OPERATOR/TENANT_ADMIN이 사용자에게 강의 역할(DESIGNER, INSTRUCTOR, OWNER)을 부여하고 회수할 수 있는 관리 API 구현

## Related Issue

- Closes #13

## Changes

- `POST /api/users/{userId}/course-roles` - 역할 부여 API 추가
- `DELETE /api/users/{userId}/course-roles/{courseRoleId}` - 역할 회수 API 추가
- `AssignCourseRoleRequest.java` DTO 신규 생성
- `CourseRoleNotFoundException.java` 예외 신규 생성
- `ErrorCode.java` - U007 (COURSE_ROLE_NOT_FOUND) 추가
- `UserCourseRole.java` - 범용 create() 팩토리 메서드 추가
- `UserService.java` / `UserServiceImpl.java` - 역할 부여/회수 로직 추가
- `UserController.java` - 2개 엔드포인트 추가 (@PreAuthorize 권한 체크)
- `UserControllerTest.java` - 테스트 케이스 9개 추가

## Type of Change

- [x] Feat: 새로운 기능
- [x] Test: 테스트 추가/수정

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### API 스펙

**역할 부여**
POST /api/users/{userId}/course-roles Authorization: Bearer {accessToken} Request: { "courseId": null, "role": "DESIGNER", "revenueSharePercent": null } Response: 201 Created

**역할 회수**
DELETE /api/users/{userId}/course-roles/{courseRoleId} Authorization: Bearer {accessToken} Response: 204 No Content

### 테스트 결과
- 빌드 성공
- 전체 테스트 통과 (51개)
- MySQL 실제 연동 테스트 완료