### PR TITLE
회원 탈퇴 API RefreshToken 삭제 로직 추가

### DIFF
--- a/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
@@ -20,6 +20,7 @@ import com.mzc.lp.domain.user.exception.CourseRoleNotFoundException;
 import com.mzc.lp.domain.user.exception.PasswordMismatchException;
 import com.mzc.lp.domain.user.exception.RoleAlreadyExistsException;
 import com.mzc.lp.domain.user.exception.UserNotFoundException;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
 import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
 import com.mzc.lp.domain.user.repository.UserRepository;
 
@@ -41,6 +42,7 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final UserCourseRoleRepository userCourseRoleRepository;
     private final PasswordEncoder passwordEncoder;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Override
     public UserDetailResponse getMe(Long userId) {
@@ -87,7 +89,8 @@ public class UserServiceImpl implements UserService {
         }
 
         user.withdraw();
-        log.info("User withdrawn: userId={}", userId);
+        refreshTokenRepository.deleteByUserId(userId);
+        log.info("User withdrawn: userId={}, reason={}", userId, request.reason());
     }
 
     // ========== 관리 API (OPERATOR 권한) ==========


### PR DESCRIPTION
## 관련 이슈
Closes #24

## 변경 사항
### 추가된 기능
- 회원 탈퇴 시 모든 RefreshToken 자동 삭제 기능 추가

### 수정된 파일
- `UserServiceImpl.java`
  - RefreshTokenRepository 의존성 주입 추가
  - `withdraw()` 메서드에 `refreshTokenRepository.deleteByUserId(userId)` 로직 추가
  - 탈퇴 사유(reason) 로그 출력 추가

## API 스펙
DELETE /api/users/me Authorization: Bearer {accessToken} Request Body: { "password": "Test1234!", "reason": "더 이상 사용하지 않습니다" } Response: 204 No Content

## 비즈니스 로직
- ✅ 현재 비밀번호 검증 필수
- ✅ 상태를 WITHDRAWN으로 변경 (soft delete)
- ✅ 모든 RefreshToken 무효화
- ✅ 탈퇴 후 재가입 가능

## 테스트
- ✅ 전체 테스트 통과 (BUILD SUCCESSFUL)
- ✅ 기존 UserControllerTest의 Withdraw 테스트 클래스 검증
  - 성공 케이스: 비밀번호 검증 후 탈퇴
  - 실패 케이스: 잘못된 비밀번호, 인증 없이 접근

## 체크리스트
- [x] WithdrawRequest DTO 확인
- [x] UserService.withdraw() 메서드 구현
- [x] UserController DELETE /api/users/me 엔드포인트 확인
- [x] 비밀번호 검증 로직
- [x] 상태 변경 (ACTIVE → WITHDRAWN) 로직
- [x] RefreshToken 전체 삭제 로직
- [x] 테스트 코드 작성 및 통과
- [x] 컨벤션 체크