### PR TITLE
feat: 프로필 이미지 업로드 API 구현

### DIFF
--- a/src/main/java/com/mzc/lp/common/config/WebConfig.java
+++ b/src/main/java/com/mzc/lp/common/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}

--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -21,6 +21,9 @@ public enum ErrorCode {
     USER_ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "U005", "User already withdrawn"),
     ROLE_ALREADY_EXISTS(HttpStatus.CONFLICT, "U006", "Role already exists for this user"),
     COURSE_ROLE_NOT_FOUND(HttpStatus.NOT_FOUND, "U007", "Course role not found"),
+    INVALID_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "U008", "Invalid image format. Only JPG, JPEG, PNG allowed"),
+    IMAGE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "U009", "Image size exceeds 5MB limit"),
+    FILE_STORAGE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "U010", "Failed to store file"),
 
     // Course
     COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "CR001", "Course not found"),

--- a/src/main/java/com/mzc/lp/common/service/FileStorageService.java
+++ b/src/main/java/com/mzc/lp/common/service/FileStorageService.java
@@ -1,0 +1,75 @@
+package com.mzc.lp.common.service;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+public class FileStorageService {
+
+    private static final List<String> ALLOWED_IMAGE_TYPES = Arrays.asList("image/jpeg", "image/jpg", "image/png");
+    private static final long MAX_FILE_SIZE = 5L * 1024 * 1024; // 5MB
+
+    @Value("${file.upload-dir:uploads/profile-images}")
+    private String uploadDir;
+
+    public String storeProfileImage(MultipartFile file) {
+        validateFile(file);
+
+        try {
+            // 업로드 디렉토리 생성
+            Path uploadPath = Paths.get(uploadDir);
+            if (!Files.exists(uploadPath)) {
+                Files.createDirectories(uploadPath);
+            }
+
+            // 고유한 파일명 생성
+            String originalFilename = file.getOriginalFilename();
+            String extension = originalFilename != null && originalFilename.contains(".")
+                    ? originalFilename.substring(originalFilename.lastIndexOf("."))
+                    : ".jpg";
+            String filename = UUID.randomUUID().toString() + extension;
+
+            // 파일 저장
+            Path targetPath = uploadPath.resolve(filename);
+            Files.copy(file.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+
+            log.info("Profile image stored: {}", filename);
+            return "/uploads/profile-images/" + filename;
+
+        } catch (IOException e) {
+            log.error("Failed to store profile image", e);
+            throw new BusinessException(ErrorCode.FILE_STORAGE_ERROR);
+        }
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_IMAGE_FORMAT);
+        }
+
+        // 파일 타입 검증
+        String contentType = file.getContentType();
+        if (contentType == null || !ALLOWED_IMAGE_TYPES.contains(contentType)) {
+            throw new BusinessException(ErrorCode.INVALID_IMAGE_FORMAT);
+        }
+
+        // 파일 크기 검증
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new BusinessException(ErrorCode.IMAGE_SIZE_EXCEEDED);
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
+++ b/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
@@ -15,6 +15,7 @@ import com.mzc.lp.domain.user.dto.response.UserDetailResponse;
 import com.mzc.lp.domain.user.dto.response.UserListResponse;
 import com.mzc.lp.domain.user.dto.response.UserRoleResponse;
 import com.mzc.lp.domain.user.dto.response.UserStatusResponse;
+import com.mzc.lp.domain.user.dto.response.ProfileImageResponse;
 import com.mzc.lp.domain.user.service.UserService;
 
 import java.util.List;
@@ -28,6 +29,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/users")
@@ -70,6 +72,15 @@ public class UserController {
     ) {
         userService.withdraw(principal.id(), request);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/me/profile-image")
+    public ResponseEntity<ApiResponse<ProfileImageResponse>> uploadProfileImage(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam MultipartFile file
+    ) {
+        ProfileImageResponse response = userService.uploadProfileImage(principal.id(), file);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // ========== CourseRole API ==========

--- a/src/main/java/com/mzc/lp/domain/user/dto/response/ProfileImageResponse.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/response/ProfileImageResponse.java
@@ -1,0 +1,9 @@
+package com.mzc.lp.domain.user.dto.response;
+
+public record ProfileImageResponse(
+        String profileImageUrl
+) {
+    public static ProfileImageResponse from(String profileImageUrl) {
+        return new ProfileImageResponse(profileImageUrl);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/service/UserService.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserService.java
@@ -13,8 +13,10 @@ import com.mzc.lp.domain.user.dto.response.UserDetailResponse;
 import com.mzc.lp.domain.user.dto.response.UserListResponse;
 import com.mzc.lp.domain.user.dto.response.UserRoleResponse;
 import com.mzc.lp.domain.user.dto.response.UserStatusResponse;
+import com.mzc.lp.domain.user.dto.response.ProfileImageResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -28,6 +30,8 @@ public interface UserService {
     void changePassword(Long userId, ChangePasswordRequest request);
 
     void withdraw(Long userId, WithdrawRequest request);
+
+    ProfileImageResponse uploadProfileImage(Long userId, MultipartFile file);
 
     // 관리 API (OPERATOR 권한)
     Page<UserListResponse> getUsers(String keyword, TenantRole role, UserStatus status, Pageable pageable);


### PR DESCRIPTION
## 관련 이슈
Closes #33

## 변경 사항
### 추가된 기능
- 프로필 이미지 업로드 API 구현
- CORS 설정 추가 (localhost:3000 허용)

### 추가된 파일
- `WebConfig.java`
  - CORS 설정 추가 (localhost:3000)
  - GET, POST, PUT, DELETE, PATCH, OPTIONS 메서드 허용
  
- `ProfileImageResponse.java`
  - 프로필 이미지 URL 응답 DTO
  
- `FileStorageService.java`
  - 프로필 이미지 파일 저장 서비스
  - 파일 타입 검증 (JPG, JPEG, PNG만 허용)
  - 파일 크기 검증 (최대 5MB)
  - UUID 기반 고유 파일명 생성
  - 로컬 파일시스템 저장

### 수정된 파일
- `ErrorCode.java`
  - INVALID_IMAGE_FORMAT (U008): 잘못된 이미지 형식
  - IMAGE_SIZE_EXCEEDED (U009): 이미지 크기 초과
  - FILE_STORAGE_ERROR (U010): 파일 저장 실패

- `UserService.java` / `UserServiceImpl.java`
  - `uploadProfileImage()` 메서드 추가
  - FileStorageService를 통한 파일 저장
  - User 엔티티 profileImageUrl 업데이트

- `UserController.java`
  - `POST /api/users/me/profile-image` 엔드포인트 추가
  - MultipartFile로 이미지 파일 수신

- `UserControllerTest.java`
  - 프로필 이미지 업로드 테스트 추가 (6개 테스트 케이스)

## API 스펙
POST /api/users/me/profile-image Authorization: Bearer {accessToken} Content-Type: multipart/form-data Request:
file: MultipartFile (JPG/JPEG/PNG, 최대 5MB)
Response: 200 OK { "success": true, "data": { "profileImageUrl": "/uploads/profile-images/{uuid}.jpg" } }

## 비즈니스 로직
- ✅ 인증된 사용자만 업로드 가능
- ✅ 파일 형식 검증 (JPG, JPEG, PNG만 허용)
- ✅ 파일 크기 검증 (최대 5MB)
- ✅ UUID 기반 고유 파일명 생성으로 충돌 방지
- ✅ User 엔티티의 profileImageUrl 자동 업데이트
- ✅ 로컬 파일시스템 저장 (uploads/profile-images/)

## 테스트
- ✅ 전체 테스트 통과 (BUILD SUCCESSFUL)
- ✅ 프로필 이미지 업로드 테스트 6개 추가
  - 성공: JPG 업로드
  - 성공: PNG 업로드
  - 실패: 잘못된 파일 형식 (txt)
  - 실패: 파일 크기 초과 (6MB)
  - 실패: 빈 파일
  - 실패: 인증 없이 접근

## 체크리스트
- [x] ProfileImageResponse DTO 생성
- [x] FileStorageService 생성
- [x] UserService.uploadProfileImage() 메서드 구현
- [x] UserController POST /api/users/me/profile-image 엔드포인트 추가
- [x] 파일 검증 로직 구현
- [x] 에러 코드 추가 (U008, U009, U010)
- [x] CORS 설정 추가 (localhost:3000)
- [x] 테스트 코드 작성 및 통과
- [x] 컨벤션 체크