### PR TITLE
[Feat] TS 차수 CRUD API 구현 (#27)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeController.java
+++ b/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeController.java
@@ -1,0 +1,115 @@
+package com.mzc.lp.domain.ts.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+import com.mzc.lp.domain.ts.dto.request.CreateCourseTimeRequest;
+import com.mzc.lp.domain.ts.dto.request.UpdateCourseTimeRequest;
+import com.mzc.lp.domain.ts.dto.response.CourseTimeDetailResponse;
+import com.mzc.lp.domain.ts.dto.response.CourseTimeResponse;
+import com.mzc.lp.domain.ts.service.CourseTimeService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/ts/course-times")
+@RequiredArgsConstructor
+@Validated
+public class CourseTimeController {
+
+    private final CourseTimeService courseTimeService;
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseTimeDetailResponse>> createCourseTime(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody CreateCourseTimeRequest request
+    ) {
+        CourseTimeDetailResponse response = courseTimeService.createCourseTime(request, principal.id());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<CourseTimeResponse>>> getCourseTimes(
+            @RequestParam(required = false) CourseTimeStatus status,
+            @RequestParam(required = false) Long cmCourseId,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<CourseTimeResponse> response = courseTimeService.getCourseTimes(status, cmCourseId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<CourseTimeDetailResponse>> getCourseTime(
+            @PathVariable Long id
+    ) {
+        CourseTimeDetailResponse response = courseTimeService.getCourseTime(id);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseTimeDetailResponse>> updateCourseTime(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateCourseTimeRequest request
+    ) {
+        CourseTimeDetailResponse response = courseTimeService.updateCourseTime(id, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> deleteCourseTime(
+            @PathVariable Long id
+    ) {
+        courseTimeService.deleteCourseTime(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ========== 상태 전이 API ==========
+
+    @PostMapping("/{id}/open")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseTimeDetailResponse>> openCourseTime(
+            @PathVariable Long id
+    ) {
+        CourseTimeDetailResponse response = courseTimeService.openCourseTime(id);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/{id}/start")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseTimeDetailResponse>> startCourseTime(
+            @PathVariable Long id
+    ) {
+        CourseTimeDetailResponse response = courseTimeService.startCourseTime(id);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/{id}/close")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseTimeDetailResponse>> closeCourseTime(
+            @PathVariable Long id
+    ) {
+        CourseTimeDetailResponse response = courseTimeService.closeCourseTime(id);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/{id}/archive")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseTimeDetailResponse>> archiveCourseTime(
+            @PathVariable Long id
+    ) {
+        CourseTimeDetailResponse response = courseTimeService.archiveCourseTime(id);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeService.java
+++ b/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeService.java
@@ -1,0 +1,32 @@
+package com.mzc.lp.domain.ts.service;
+
+import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+import com.mzc.lp.domain.ts.dto.request.CreateCourseTimeRequest;
+import com.mzc.lp.domain.ts.dto.request.UpdateCourseTimeRequest;
+import com.mzc.lp.domain.ts.dto.response.CourseTimeDetailResponse;
+import com.mzc.lp.domain.ts.dto.response.CourseTimeResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CourseTimeService {
+
+    // CRUD
+    CourseTimeDetailResponse createCourseTime(CreateCourseTimeRequest request, Long createdBy);
+
+    Page<CourseTimeResponse> getCourseTimes(CourseTimeStatus status, Long cmCourseId, Pageable pageable);
+
+    CourseTimeDetailResponse getCourseTime(Long id);
+
+    CourseTimeDetailResponse updateCourseTime(Long id, UpdateCourseTimeRequest request);
+
+    void deleteCourseTime(Long id);
+
+    // 상태 전이
+    CourseTimeDetailResponse openCourseTime(Long id);
+
+    CourseTimeDetailResponse startCourseTime(Long id);
+
+    CourseTimeDetailResponse closeCourseTime(Long id);
+
+    CourseTimeDetailResponse archiveCourseTime(Long id);
+}

--- a/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeServiceImpl.java
@@ -1,0 +1,314 @@
+package com.mzc.lp.domain.ts.service;
+
+import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
+import com.mzc.lp.domain.ts.dto.request.CreateCourseTimeRequest;
+import com.mzc.lp.domain.ts.dto.request.UpdateCourseTimeRequest;
+import com.mzc.lp.domain.ts.dto.response.CourseTimeDetailResponse;
+import com.mzc.lp.domain.ts.dto.response.CourseTimeResponse;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.ts.exception.CourseTimeNotFoundException;
+import com.mzc.lp.domain.ts.exception.InvalidDateRangeException;
+import com.mzc.lp.domain.ts.exception.InvalidStatusTransitionException;
+import com.mzc.lp.domain.ts.exception.LocationRequiredException;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CourseTimeServiceImpl implements CourseTimeService {
+
+    private final CourseTimeRepository courseTimeRepository;
+
+    @Override
+    @Transactional
+    public CourseTimeDetailResponse createCourseTime(CreateCourseTimeRequest request, Long createdBy) {
+        log.info("Creating course time: title={}", request.title());
+
+        // 비즈니스 규칙 검증
+        validateDateRange(request);
+        validateLocationInfo(request);
+        validateEnrollmentMethod(request);
+
+        CourseTime courseTime = CourseTime.create(
+                request.title(),
+                request.deliveryType(),
+                request.enrollStartDate(),
+                request.enrollEndDate(),
+                request.classStartDate(),
+                request.classEndDate(),
+                request.capacity(),
+                request.maxWaitingCount(),
+                request.enrollmentMethod(),
+                request.minProgressForCompletion(),
+                request.price(),
+                request.isFree(),
+                request.locationInfo(),
+                request.allowLateEnrollment() != null ? request.allowLateEnrollment() : false,
+                createdBy
+        );
+
+        // CM 연결 (있는 경우)
+        if (request.cmCourseId() != null) {
+            courseTime.linkCourse(request.cmCourseId(), request.cmCourseVersionId());
+        }
+
+        CourseTime savedCourseTime = courseTimeRepository.save(courseTime);
+        log.info("Course time created: id={}", savedCourseTime.getId());
+
+        return CourseTimeDetailResponse.from(savedCourseTime);
+    }
+
+    @Override
+    public Page<CourseTimeResponse> getCourseTimes(CourseTimeStatus status, Long cmCourseId, Pageable pageable) {
+        log.debug("Getting course times: status={}, cmCourseId={}", status, cmCourseId);
+
+        if (cmCourseId != null) {
+            return courseTimeRepository.findByCmCourseIdAndTenantId(cmCourseId, getCurrentTenantId())
+                    .stream()
+                    .filter(ct -> status == null || ct.getStatus() == status)
+                    .map(CourseTimeResponse::from)
+                    .collect(java.util.stream.Collectors.collectingAndThen(
+                            java.util.stream.Collectors.toList(),
+                            list -> new org.springframework.data.domain.PageImpl<>(list, pageable, list.size())
+                    ));
+        }
+
+        if (status != null) {
+            return courseTimeRepository.findByTenantIdAndStatus(getCurrentTenantId(), status, pageable)
+                    .map(CourseTimeResponse::from);
+        }
+
+        return courseTimeRepository.findByTenantId(getCurrentTenantId(), pageable)
+                .map(CourseTimeResponse::from);
+    }
+
+    @Override
+    public CourseTimeDetailResponse getCourseTime(Long id) {
+        log.debug("Getting course time: id={}", id);
+
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, getCurrentTenantId())
+                .orElseThrow(() -> new CourseTimeNotFoundException(id));
+
+        return CourseTimeDetailResponse.from(courseTime);
+    }
+
+    @Override
+    @Transactional
+    public CourseTimeDetailResponse updateCourseTime(Long id, UpdateCourseTimeRequest request) {
+        log.info("Updating course time: id={}", id);
+
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, getCurrentTenantId())
+                .orElseThrow(() -> new CourseTimeNotFoundException(id));
+
+        // DRAFT 또는 RECRUITING 상태에서만 수정 가능
+        if (!courseTime.isDraft() && !courseTime.isRecruiting()) {
+            throw new InvalidStatusTransitionException();
+        }
+
+        // 부분 업데이트
+        if (request.title() != null) {
+            courseTime.updateTitle(request.title());
+        }
+
+        if (request.enrollStartDate() != null || request.enrollEndDate() != null
+                || request.classStartDate() != null || request.classEndDate() != null) {
+            courseTime.updatePeriod(
+                    request.enrollStartDate() != null ? request.enrollStartDate() : courseTime.getEnrollStartDate(),
+                    request.enrollEndDate() != null ? request.enrollEndDate() : courseTime.getEnrollEndDate(),
+                    request.classStartDate() != null ? request.classStartDate() : courseTime.getClassStartDate(),
+                    request.classEndDate() != null ? request.classEndDate() : courseTime.getClassEndDate()
+            );
+        }
+
+        if (request.capacity() != null || request.maxWaitingCount() != null) {
+            courseTime.updateCapacity(
+                    request.capacity() != null ? request.capacity() : courseTime.getCapacity(),
+                    request.maxWaitingCount() != null ? request.maxWaitingCount() : courseTime.getMaxWaitingCount()
+            );
+        }
+
+        if (request.price() != null || request.isFree() != null) {
+            courseTime.updatePrice(
+                    request.price() != null ? request.price() : courseTime.getPrice(),
+                    request.isFree() != null ? request.isFree() : courseTime.isFree()
+            );
+        }
+
+        if (request.locationInfo() != null) {
+            courseTime.updateLocationInfo(request.locationInfo());
+        }
+
+        if (request.allowLateEnrollment() != null) {
+            courseTime.updateAllowLateEnrollment(request.allowLateEnrollment());
+        }
+
+        if (request.minProgressForCompletion() != null) {
+            courseTime.updateMinProgress(request.minProgressForCompletion());
+        }
+
+        log.info("Course time updated: id={}", id);
+        return CourseTimeDetailResponse.from(courseTime);
+    }
+
+    @Override
+    @Transactional
+    public void deleteCourseTime(Long id) {
+        log.info("Deleting course time: id={}", id);
+
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, getCurrentTenantId())
+                .orElseThrow(() -> new CourseTimeNotFoundException(id));
+
+        // DRAFT 상태에서만 삭제 가능
+        if (!courseTime.isDraft()) {
+            throw new InvalidStatusTransitionException();
+        }
+
+        courseTimeRepository.delete(courseTime);
+        log.info("Course time deleted: id={}", id);
+    }
+
+    // ========== 상태 전이 ==========
+
+    @Override
+    @Transactional
+    public CourseTimeDetailResponse openCourseTime(Long id) {
+        log.info("Opening course time: id={}", id);
+
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, getCurrentTenantId())
+                .orElseThrow(() -> new CourseTimeNotFoundException(id));
+
+        if (!courseTime.isDraft()) {
+            throw new InvalidStatusTransitionException(
+                    courseTime.getStatus(),
+                    CourseTimeStatus.RECRUITING
+            );
+        }
+
+        // 장소 정보 필수 검증 (OFFLINE/BLENDED)
+        if (courseTime.requiresLocationInfo() &&
+                (courseTime.getLocationInfo() == null || courseTime.getLocationInfo().isBlank())) {
+            throw new LocationRequiredException();
+        }
+
+        courseTime.open();
+        log.info("Course time opened: id={}", id);
+
+        return CourseTimeDetailResponse.from(courseTime);
+    }
+
+    @Override
+    @Transactional
+    public CourseTimeDetailResponse startCourseTime(Long id) {
+        log.info("Starting course time: id={}", id);
+
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, getCurrentTenantId())
+                .orElseThrow(() -> new CourseTimeNotFoundException(id));
+
+        if (!courseTime.isRecruiting()) {
+            throw new InvalidStatusTransitionException(
+                    courseTime.getStatus(),
+                    CourseTimeStatus.ONGOING
+            );
+        }
+
+        courseTime.startClass();
+        log.info("Course time started: id={}", id);
+
+        return CourseTimeDetailResponse.from(courseTime);
+    }
+
+    @Override
+    @Transactional
+    public CourseTimeDetailResponse closeCourseTime(Long id) {
+        log.info("Closing course time: id={}", id);
+
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, getCurrentTenantId())
+                .orElseThrow(() -> new CourseTimeNotFoundException(id));
+
+        if (!courseTime.isOngoing()) {
+            throw new InvalidStatusTransitionException(
+                    courseTime.getStatus(),
+                    CourseTimeStatus.CLOSED
+            );
+        }
+
+        courseTime.close();
+        log.info("Course time closed: id={}", id);
+
+        return CourseTimeDetailResponse.from(courseTime);
+    }
+
+    @Override
+    @Transactional
+    public CourseTimeDetailResponse archiveCourseTime(Long id) {
+        log.info("Archiving course time: id={}", id);
+
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, getCurrentTenantId())
+                .orElseThrow(() -> new CourseTimeNotFoundException(id));
+
+        if (!courseTime.isClosed()) {
+            throw new InvalidStatusTransitionException(
+                    courseTime.getStatus(),
+                    CourseTimeStatus.ARCHIVED
+            );
+        }
+
+        courseTime.archive();
+        log.info("Course time archived: id={}", id);
+
+        return CourseTimeDetailResponse.from(courseTime);
+    }
+
+    // ========== Private Methods ==========
+
+    private void validateDateRange(CreateCourseTimeRequest request) {
+        // [R09] enroll_end_date <= class_end_date
+        if (request.enrollEndDate().isAfter(request.classEndDate())) {
+            throw new InvalidDateRangeException("모집 종료일은 학습 종료일 이전이어야 합니다");
+        }
+
+        // 모집 시작일 <= 모집 종료일
+        if (request.enrollStartDate().isAfter(request.enrollEndDate())) {
+            throw new InvalidDateRangeException("모집 시작일은 모집 종료일 이전이어야 합니다");
+        }
+
+        // 학습 시작일 <= 학습 종료일
+        if (request.classStartDate().isAfter(request.classEndDate())) {
+            throw new InvalidDateRangeException("학습 시작일은 학습 종료일 이전이어야 합니다");
+        }
+    }
+
+    private void validateLocationInfo(CreateCourseTimeRequest request) {
+        // [R10] OFFLINE/BLENDED일 때 location_info 필수
+        if ((request.deliveryType() == com.mzc.lp.domain.ts.constant.DeliveryType.OFFLINE
+                || request.deliveryType() == com.mzc.lp.domain.ts.constant.DeliveryType.BLENDED)
+                && (request.locationInfo() == null || request.locationInfo().isBlank())) {
+            throw new LocationRequiredException();
+        }
+    }
+
+    private void validateEnrollmentMethod(CreateCourseTimeRequest request) {
+        // [R53] APPROVAL + maxWaitingCount > 0 조합 불가
+        if (request.enrollmentMethod() == EnrollmentMethod.APPROVAL
+                && request.maxWaitingCount() != null
+                && request.maxWaitingCount() > 0) {
+            throw new IllegalArgumentException("승인제 모집에서는 대기자 기능을 사용할 수 없습니다");
+        }
+    }
+
+    private Long getCurrentTenantId() {
+        // TODO: SecurityContext에서 tenantId 추출
+        // 현재는 임시로 1L 반환
+        return 1L;
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/ts/controller/CourseTimeControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/ts/controller/CourseTimeControllerTest.java
@@ -1,0 +1,627 @@
+package com.mzc.lp.domain.ts.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+import com.mzc.lp.domain.ts.constant.DeliveryType;
+import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
+import com.mzc.lp.domain.ts.dto.request.CreateCourseTimeRequest;
+import com.mzc.lp.domain.ts.dto.request.UpdateCourseTimeRequest;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CourseTimeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CourseTimeRepository courseTimeRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private UserCourseRoleRepository userCourseRoleRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        courseTimeRepository.deleteAll();
+        userCourseRoleRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ========== Helper Methods ==========
+
+    private User createOperatorUser() {
+        User user = User.create("operator@example.com", "운영자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.OPERATOR);
+        return userRepository.save(user);
+    }
+
+    private User createNormalUser() {
+        User user = User.create("user@example.com", "일반사용자", passwordEncoder.encode("Password123!"));
+        return userRepository.save(user);
+    }
+
+    private String loginAndGetAccessToken(String email, String password) throws Exception {
+        LoginRequest request = new LoginRequest(email, password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("data").get("accessToken").asText();
+    }
+
+    private CreateCourseTimeRequest createValidRequest() {
+        return new CreateCourseTimeRequest(
+                null,
+                null,
+                "스프링 부트 마스터 1차",
+                DeliveryType.ONLINE,
+                LocalDate.now(),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(30),
+                30,
+                5,
+                EnrollmentMethod.FIRST_COME,
+                80,
+                new BigDecimal("100000"),
+                false,
+                null,
+                true
+        );
+    }
+
+    private CreateCourseTimeRequest createOfflineRequest() {
+        return new CreateCourseTimeRequest(
+                null,
+                null,
+                "오프라인 교육 1차",
+                DeliveryType.OFFLINE,
+                LocalDate.now(),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(30),
+                20,
+                null,
+                EnrollmentMethod.APPROVAL,
+                70,
+                new BigDecimal("200000"),
+                false,
+                "{\"address\": \"서울시 강남구\", \"room\": \"A동 101호\"}",
+                false
+        );
+    }
+
+    private CourseTime createTestCourseTime() {
+        CourseTime courseTime = CourseTime.create(
+                "테스트 차수",
+                DeliveryType.ONLINE,
+                LocalDate.now(),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(30),
+                30,
+                5,
+                EnrollmentMethod.FIRST_COME,
+                80,
+                new BigDecimal("100000"),
+                false,
+                null,
+                true,
+                1L
+        );
+        return courseTimeRepository.save(courseTime);
+    }
+
+    // ==================== 차수 생성 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/ts/course-times - 차수 생성")
+    class CreateCourseTime {
+
+        @Test
+        @DisplayName("성공 - OPERATOR가 온라인 차수 생성")
+        void createCourseTime_success_online() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CreateCourseTimeRequest request = createValidRequest();
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.title").value("스프링 부트 마스터 1차"))
+                    .andExpect(jsonPath("$.data.deliveryType").value("ONLINE"))
+                    .andExpect(jsonPath("$.data.status").value("DRAFT"))
+                    .andExpect(jsonPath("$.data.capacity").value(30))
+                    .andExpect(jsonPath("$.data.currentEnrollment").value(0));
+        }
+
+        @Test
+        @DisplayName("성공 - OPERATOR가 오프라인 차수 생성")
+        void createCourseTime_success_offline() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CreateCourseTimeRequest request = createOfflineRequest();
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.deliveryType").value("OFFLINE"))
+                    .andExpect(jsonPath("$.data.locationInfo").isNotEmpty());
+        }
+
+        @Test
+        @DisplayName("실패 - 오프라인인데 장소 정보 없음")
+        void createCourseTime_fail_offlineWithoutLocation() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CreateCourseTimeRequest request = new CreateCourseTimeRequest(
+                    null, null, "오프라인 교육",
+                    DeliveryType.OFFLINE,
+                    LocalDate.now(), LocalDate.now().plusDays(7),
+                    LocalDate.now().plusDays(7), LocalDate.now().plusDays(30),
+                    20, null, EnrollmentMethod.FIRST_COME, 70,
+                    new BigDecimal("100000"), false,
+                    null,  // 장소 정보 없음
+                    false
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("TS005"));
+        }
+
+        @Test
+        @DisplayName("실패 - 모집 종료일이 학습 종료일 이후")
+        void createCourseTime_fail_invalidDateRange() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CreateCourseTimeRequest request = new CreateCourseTimeRequest(
+                    null, null, "날짜 오류 테스트",
+                    DeliveryType.ONLINE,
+                    LocalDate.now(), LocalDate.now().plusDays(60),  // 모집 종료일이 학습 종료일 이후
+                    LocalDate.now().plusDays(7), LocalDate.now().plusDays(30),
+                    20, null, EnrollmentMethod.FIRST_COME, 70,
+                    new BigDecimal("100000"), false, null, false
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("TS004"));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 생성 시도")
+        void createCourseTime_fail_userRole() throws Exception {
+            // given
+            createNormalUser();
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+            CreateCourseTimeRequest request = createValidRequest();
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("실패 - 인증 없이 접근")
+        void createCourseTime_fail_unauthorized() throws Exception {
+            // given
+            CreateCourseTimeRequest request = createValidRequest();
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 차수 목록 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/ts/course-times - 차수 목록 조회")
+    class GetCourseTimes {
+
+        @Test
+        @DisplayName("성공 - 인증된 사용자가 목록 조회")
+        void getCourseTimes_success() throws Exception {
+            // given
+            createNormalUser();
+            createTestCourseTime();
+            createTestCourseTime();
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/ts/course-times")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.totalElements").value(2));
+        }
+
+        @Test
+        @DisplayName("성공 - 상태별 필터링")
+        void getCourseTimes_success_filterByStatus() throws Exception {
+            // given
+            createNormalUser();
+            CourseTime draft = createTestCourseTime();
+            CourseTime recruiting = createTestCourseTime();
+            recruiting.open();
+            courseTimeRepository.save(recruiting);
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/ts/course-times")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("status", "RECRUITING"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.totalElements").value(1));
+        }
+    }
+
+    // ==================== 차수 상세 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/ts/course-times/{id} - 차수 상세 조회")
+    class GetCourseTime {
+
+        @Test
+        @DisplayName("성공 - 인증된 사용자가 상세 조회")
+        void getCourseTime_success() throws Exception {
+            // given
+            createNormalUser();
+            CourseTime courseTime = createTestCourseTime();
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/ts/course-times/{id}", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.id").value(courseTime.getId()))
+                    .andExpect(jsonPath("$.data.title").value("테스트 차수"));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 차수")
+        void getCourseTime_fail_notFound() throws Exception {
+            // given
+            createNormalUser();
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/ts/course-times/{id}", 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("TS001"));
+        }
+    }
+
+    // ==================== 차수 수정 테스트 ====================
+
+    @Nested
+    @DisplayName("PATCH /api/ts/course-times/{id} - 차수 수정")
+    class UpdateCourseTime {
+
+        @Test
+        @DisplayName("성공 - DRAFT 상태 차수 수정")
+        void updateCourseTime_success_draft() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createTestCourseTime();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            UpdateCourseTimeRequest request = new UpdateCourseTimeRequest(
+                    "수정된 제목",
+                    null,  // deliveryType
+                    null, null, null, null,  // dates
+                    50, null,  // capacity, maxWaitingCount
+                    null,  // enrollmentMethod
+                    null,  // minProgressForCompletion
+                    new BigDecimal("150000"), null,  // price, isFree
+                    null, null  // locationInfo, allowLateEnrollment
+            );
+
+            // when & then
+            mockMvc.perform(patch("/api/ts/course-times/{id}", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.title").value("수정된 제목"))
+                    .andExpect(jsonPath("$.data.capacity").value(50))
+                    .andExpect(jsonPath("$.data.price").value(150000));
+        }
+
+        @Test
+        @DisplayName("실패 - ONGOING 상태 차수 수정")
+        void updateCourseTime_fail_ongoing() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createTestCourseTime();
+            courseTime.open();
+            courseTime.startClass();
+            courseTimeRepository.save(courseTime);
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            UpdateCourseTimeRequest request = new UpdateCourseTimeRequest(
+                    "수정 시도", null, null, null, null, null,
+                    null, null, null, null, null, null, null, null
+            );
+
+            // when & then
+            mockMvc.perform(patch("/api/ts/course-times/{id}", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("TS002"));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 수정 시도")
+        void updateCourseTime_fail_userRole() throws Exception {
+            // given
+            createNormalUser();
+            CourseTime courseTime = createTestCourseTime();
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+            UpdateCourseTimeRequest request = new UpdateCourseTimeRequest(
+                    "수정 시도", null, null, null, null, null,
+                    null, null, null, null, null, null, null, null
+            );
+
+            // when & then
+            mockMvc.perform(patch("/api/ts/course-times/{id}", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 차수 삭제 테스트 ====================
+
+    @Nested
+    @DisplayName("DELETE /api/ts/course-times/{id} - 차수 삭제")
+    class DeleteCourseTime {
+
+        @Test
+        @DisplayName("성공 - DRAFT 상태 차수 삭제")
+        void deleteCourseTime_success() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createTestCourseTime();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(delete("/api/ts/course-times/{id}", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+
+            // 삭제 확인
+            mockMvc.perform(get("/api/ts/course-times/{id}", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("실패 - RECRUITING 상태 차수 삭제")
+        void deleteCourseTime_fail_recruiting() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createTestCourseTime();
+            courseTime.open();
+            courseTimeRepository.save(courseTime);
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(delete("/api/ts/course-times/{id}", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("TS002"));
+        }
+    }
+
+    // ==================== 상태 전이 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/ts/course-times/{id}/open - 모집 시작")
+    class OpenCourseTime {
+
+        @Test
+        @DisplayName("성공 - DRAFT → RECRUITING")
+        void openCourseTime_success() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createTestCourseTime();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times/{id}/open", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.status").value("RECRUITING"));
+        }
+
+        @Test
+        @DisplayName("실패 - RECRUITING 상태에서 open 시도")
+        void openCourseTime_fail_alreadyRecruiting() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createTestCourseTime();
+            courseTime.open();
+            courseTimeRepository.save(courseTime);
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times/{id}/open", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error.code").value("TS002"));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/ts/course-times/{id}/start - 학습 시작")
+    class StartCourseTime {
+
+        @Test
+        @DisplayName("성공 - RECRUITING → ONGOING")
+        void startCourseTime_success() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createTestCourseTime();
+            courseTime.open();
+            courseTimeRepository.save(courseTime);
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times/{id}/start", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.status").value("ONGOING"));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/ts/course-times/{id}/close - 학습 종료")
+    class CloseCourseTime {
+
+        @Test
+        @DisplayName("성공 - ONGOING → CLOSED")
+        void closeCourseTime_success() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createTestCourseTime();
+            courseTime.open();
+            courseTime.startClass();
+            courseTimeRepository.save(courseTime);
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times/{id}/close", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.status").value("CLOSED"));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/ts/course-times/{id}/archive - 아카이브")
+    class ArchiveCourseTime {
+
+        @Test
+        @DisplayName("성공 - CLOSED → ARCHIVED")
+        void archiveCourseTime_success() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createTestCourseTime();
+            courseTime.open();
+            courseTime.startClass();
+            courseTime.close();
+            courseTimeRepository.save(courseTime);
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times/{id}/archive", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.status").value("ARCHIVED"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

TS 모듈의 차수(CourseTime) CRUD API 및 상태 전이 API 구현

## Related Issue

- Closes #27

## Changes

- CourseTimeService 인터페이스 및 구현체 추가
- CourseTimeController REST API 엔드포인트 구현
  - POST /api/ts/course-times (생성)
  - GET /api/ts/course-times (목록 조회)
  - GET /api/ts/course-times/{id} (상세 조회)
  - PATCH /api/ts/course-times/{id} (수정)
  - DELETE /api/ts/course-times/{id} (삭제)
- 상태 전이 API 구현 (open, start, close, archive)
- CourseTimeControllerTest 통합 테스트 추가

## 비즈니스 로직

- ✅ OPERATOR/TENANT_ADMIN 권한만 생성/수정/삭제 가능
- ✅ 날짜 범위 검증 (수강신청 기간, 수업 기간)
- ✅ DRAFT 상태에서만 삭제 가능
- ✅ DRAFT/RECRUITING 상태에서만 수정 가능
- ✅ OFFLINE/BLENDED 타입 장소 정보 필수 검증
- ✅ 상태 전이 규칙 적용 (DRAFT → RECRUITING → ONGOING → CLOSED → ARCHIVED)
- ✅ 멀티테넌시 지원 (tenantId 기반 데이터 격리)

## 테스트

- ✅ 전체 테스트 통과 (BUILD SUCCESSFUL)
- ✅ CourseTimeControllerTest 통합 테스트 추가
  - 성공: 차수 생성 (OPERATOR 권한)
  - 성공: 차수 목록 조회
  - 성공: 차수 상세 조회
  - 성공: 차수 수정 (DRAFT 상태)
  - 성공: 차수 삭제 (DRAFT 상태)
  - 성공: 상태 전이 (open, start, close, archive)
  - 실패: USER 권한으로 생성 시도
  - 실패: ONGOING 상태에서 수정 시도
  - 실패: 존재하지 않는 차수 조회

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- tenantId는 현재 임시로 1L 반환 (SecurityContext 연동 TODO)
- 실제 DB 연동 API 테스트 완료