### PR TITLE
[Feat] CM 기반 구조 구현 (Entity, Repository, DTO, Exception) (#41)

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -25,8 +25,13 @@ public enum ErrorCode {
     IMAGE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "U009", "Image size exceeds 5MB limit"),
     FILE_STORAGE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "U010", "Failed to store file"),
 
-    // Course
-    COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "CR001", "Course not found"),
+    // Course (CM - Course Matrix)
+    CM_COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "CM001", "Course not found"),
+    CM_COURSE_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "CM002", "CourseItem not found"),
+    CM_MAX_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "CM003", "Max depth exceeded (10)"),
+    CM_CIRCULAR_REFERENCE(HttpStatus.BAD_REQUEST, "CM004", "Circular reference detected"),
+    CM_INVALID_PARENT(HttpStatus.BAD_REQUEST, "CM005", "Invalid parent"),
+    CM_LEARNING_OBJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "CM008", "LearningObject not found"),
 
     // CourseTime (TS)
     COURSE_TIME_NOT_FOUND(HttpStatus.NOT_FOUND, "TS001", "CourseTime not found"),

--- a/src/main/java/com/mzc/lp/domain/course/constant/CourseLevel.java
+++ b/src/main/java/com/mzc/lp/domain/course/constant/CourseLevel.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.course.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CourseLevel {
+
+    BEGINNER("초급"),
+    INTERMEDIATE("중급"),
+    ADVANCED("고급");
+
+    private final String description;
+}

--- a/src/main/java/com/mzc/lp/domain/course/constant/CourseType.java
+++ b/src/main/java/com/mzc/lp/domain/course/constant/CourseType.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.course.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CourseType {
+
+    ONLINE("온라인"),
+    OFFLINE("오프라인"),
+    BLENDED("블렌디드");
+
+    private final String description;
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/request/CreateCourseRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/CreateCourseRequest.java
@@ -1,0 +1,33 @@
+package com.mzc.lp.domain.course.dto.request;
+
+import com.mzc.lp.domain.course.constant.CourseLevel;
+import com.mzc.lp.domain.course.constant.CourseType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public record CreateCourseRequest(
+        @NotBlank(message = "강의 제목은 필수입니다")
+        @Size(max = 255, message = "강의 제목은 255자 이하여야 합니다")
+        String title,
+
+        @Size(max = 5000, message = "설명은 5000자 이하여야 합니다")
+        String description,
+
+        CourseLevel level,
+
+        CourseType type,
+
+        @Positive(message = "예상 학습 시간은 양수여야 합니다")
+        Integer estimatedHours,
+
+        Long categoryId,
+
+        Long instructorId
+) {
+    public CreateCourseRequest {
+        if (title != null) {
+            title = title.trim();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/request/CreateFolderRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/CreateFolderRequest.java
@@ -1,0 +1,18 @@
+package com.mzc.lp.domain.course.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateFolderRequest(
+        @NotBlank(message = "폴더 이름은 필수입니다")
+        @Size(max = 255, message = "폴더 이름은 255자 이하여야 합니다")
+        String folderName,
+
+        Long parentId
+) {
+    public CreateFolderRequest {
+        if (folderName != null) {
+            folderName = folderName.trim();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/request/CreateItemRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/CreateItemRequest.java
@@ -1,0 +1,22 @@
+package com.mzc.lp.domain.course.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateItemRequest(
+        @NotBlank(message = "항목 이름은 필수입니다")
+        @Size(max = 255, message = "항목 이름은 255자 이하여야 합니다")
+        String itemName,
+
+        Long parentId,
+
+        @NotNull(message = "학습 객체 ID는 필수입니다")
+        Long learningObjectId
+) {
+    public CreateItemRequest {
+        if (itemName != null) {
+            itemName = itemName.trim();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/request/CreateRelationRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/CreateRelationRequest.java
@@ -1,0 +1,21 @@
+package com.mzc.lp.domain.course.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record CreateRelationRequest(
+        @NotEmpty(message = "학습 순서 목록은 비어있을 수 없습니다")
+        @Valid
+        List<RelationItem> relations
+) {
+    public record RelationItem(
+            Long fromItemId,
+
+            @NotNull(message = "대상 항목 ID는 필수입니다")
+            Long toItemId
+    ) {
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/request/MoveItemRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/MoveItemRequest.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.course.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record MoveItemRequest(
+        @NotNull(message = "이동할 항목 ID는 필수입니다")
+        Long itemId,
+
+        Long targetParentId,
+
+        @PositiveOrZero(message = "순서는 0 이상이어야 합니다")
+        Integer targetIndex
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateCourseRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateCourseRequest.java
@@ -1,0 +1,31 @@
+package com.mzc.lp.domain.course.dto.request;
+
+import com.mzc.lp.domain.course.constant.CourseLevel;
+import com.mzc.lp.domain.course.constant.CourseType;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public record UpdateCourseRequest(
+        @Size(max = 255, message = "강의 제목은 255자 이하여야 합니다")
+        String title,
+
+        @Size(max = 5000, message = "설명은 5000자 이하여야 합니다")
+        String description,
+
+        CourseLevel level,
+
+        CourseType type,
+
+        @Positive(message = "예상 학습 시간은 양수여야 합니다")
+        Integer estimatedHours,
+
+        Long categoryId,
+
+        Long instructorId
+) {
+    public UpdateCourseRequest {
+        if (title != null) {
+            title = title.trim();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseDetailResponse.java
@@ -1,0 +1,42 @@
+package com.mzc.lp.domain.course.dto.response;
+
+import com.mzc.lp.domain.course.constant.CourseLevel;
+import com.mzc.lp.domain.course.constant.CourseType;
+import com.mzc.lp.domain.course.entity.Course;
+
+import java.time.Instant;
+import java.util.List;
+
+public record CourseDetailResponse(
+        Long courseId,
+        String title,
+        String description,
+        String thumbnailUrl,
+        CourseLevel level,
+        CourseType type,
+        Integer estimatedHours,
+        Long categoryId,
+        Long instructorId,
+        List<CourseItemResponse> items,
+        long itemCount,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static CourseDetailResponse from(Course course, List<CourseItemResponse> items) {
+        return new CourseDetailResponse(
+                course.getId(),
+                course.getTitle(),
+                course.getDescription(),
+                course.getThumbnailUrl(),
+                course.getLevel(),
+                course.getType(),
+                course.getEstimatedHours(),
+                course.getCategoryId(),
+                course.getInstructorId(),
+                items,
+                items != null ? items.size() : 0,
+                course.getCreatedAt(),
+                course.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseItemHierarchyResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseItemHierarchyResponse.java
@@ -1,0 +1,36 @@
+package com.mzc.lp.domain.course.dto.response;
+
+import com.mzc.lp.domain.course.entity.CourseItem;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record CourseItemHierarchyResponse(
+        Long itemId,
+        String itemName,
+        Integer depth,
+        Long learningObjectId,
+        boolean isFolder,
+        Integer sortOrder,
+        List<CourseItemHierarchyResponse> children
+) {
+    public static CourseItemHierarchyResponse from(CourseItem item) {
+        return new CourseItemHierarchyResponse(
+                item.getId(),
+                item.getItemName(),
+                item.getDepth(),
+                item.getLearningObjectId(),
+                item.isFolder(),
+                item.getSortOrder(),
+                item.getChildren().stream()
+                        .map(CourseItemHierarchyResponse::from)
+                        .collect(Collectors.toList())
+        );
+    }
+
+    public static List<CourseItemHierarchyResponse> fromList(List<CourseItem> rootItems) {
+        return rootItems.stream()
+                .map(CourseItemHierarchyResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseItemResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseItemResponse.java
@@ -1,0 +1,31 @@
+package com.mzc.lp.domain.course.dto.response;
+
+import com.mzc.lp.domain.course.entity.CourseItem;
+
+import java.time.Instant;
+
+public record CourseItemResponse(
+        Long itemId,
+        String itemName,
+        Integer depth,
+        Long parentId,
+        Long learningObjectId,
+        boolean isFolder,
+        Integer sortOrder,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static CourseItemResponse from(CourseItem item) {
+        return new CourseItemResponse(
+                item.getId(),
+                item.getItemName(),
+                item.getDepth(),
+                item.getParent() != null ? item.getParent().getId() : null,
+                item.getLearningObjectId(),
+                item.isFolder(),
+                item.getSortOrder(),
+                item.getCreatedAt(),
+                item.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseRelationResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseRelationResponse.java
@@ -1,0 +1,42 @@
+package com.mzc.lp.domain.course.dto.response;
+
+import com.mzc.lp.domain.course.entity.CourseRelation;
+
+import java.util.List;
+
+public record CourseRelationResponse(
+        Long courseId,
+        List<OrderedItem> orderedItems,
+        List<RelationItem> relations
+) {
+    public record OrderedItem(
+            Long itemId,
+            String itemName,
+            int order
+    ) {
+    }
+
+    public record RelationItem(
+            Long relationId,
+            Long fromItemId,
+            Long toItemId
+    ) {
+        public static RelationItem from(CourseRelation relation) {
+            return new RelationItem(
+                    relation.getId(),
+                    relation.getFromItem() != null ? relation.getFromItem().getId() : null,
+                    relation.getToItem().getId()
+            );
+        }
+    }
+
+    public static CourseRelationResponse from(Long courseId, List<OrderedItem> orderedItems, List<CourseRelation> relations) {
+        return new CourseRelationResponse(
+                courseId,
+                orderedItems,
+                relations.stream()
+                        .map(RelationItem::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseResponse.java
@@ -1,0 +1,37 @@
+package com.mzc.lp.domain.course.dto.response;
+
+import com.mzc.lp.domain.course.constant.CourseLevel;
+import com.mzc.lp.domain.course.constant.CourseType;
+import com.mzc.lp.domain.course.entity.Course;
+
+import java.time.Instant;
+
+public record CourseResponse(
+        Long courseId,
+        String title,
+        String description,
+        String thumbnailUrl,
+        CourseLevel level,
+        CourseType type,
+        Integer estimatedHours,
+        Long categoryId,
+        Long instructorId,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static CourseResponse from(Course course) {
+        return new CourseResponse(
+                course.getId(),
+                course.getTitle(),
+                course.getDescription(),
+                course.getThumbnailUrl(),
+                course.getLevel(),
+                course.getType(),
+                course.getEstimatedHours(),
+                course.getCategoryId(),
+                course.getInstructorId(),
+                course.getCreatedAt(),
+                course.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/entity/Course.java
+++ b/src/main/java/com/mzc/lp/domain/course/entity/Course.java
@@ -1,0 +1,134 @@
+package com.mzc.lp.domain.course.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import com.mzc.lp.domain.course.constant.CourseLevel;
+import com.mzc.lp.domain.course.constant.CourseType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "cm_courses")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Course extends TenantEntity {
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(length = 500)
+    private String thumbnailUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private CourseLevel level;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private CourseType type;
+
+    @Column
+    private Integer estimatedHours;
+
+    @Column
+    private Long categoryId;
+
+    @Column
+    private Long instructorId;
+
+    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CourseItem> items = new ArrayList<>();
+
+    // ===== 정적 팩토리 메서드 =====
+    public static Course create(String title, Long instructorId) {
+        Course course = new Course();
+        course.title = title;
+        course.instructorId = instructorId;
+        return course;
+    }
+
+    public static Course create(String title, String description, CourseLevel level,
+                                CourseType type, Integer estimatedHours,
+                                Long categoryId, Long instructorId) {
+        Course course = new Course();
+        course.title = title;
+        course.description = description;
+        course.level = level;
+        course.type = type;
+        course.estimatedHours = estimatedHours;
+        course.categoryId = categoryId;
+        course.instructorId = instructorId;
+        return course;
+    }
+
+    // ===== 비즈니스 메서드 =====
+    public void updateTitle(String title) {
+        validateTitle(title);
+        this.title = title;
+    }
+
+    public void updateDescription(String description) {
+        this.description = description;
+    }
+
+    public void updateThumbnailUrl(String thumbnailUrl) {
+        this.thumbnailUrl = thumbnailUrl;
+    }
+
+    public void updateLevel(CourseLevel level) {
+        this.level = level;
+    }
+
+    public void updateType(CourseType type) {
+        this.type = type;
+    }
+
+    public void updateEstimatedHours(Integer estimatedHours) {
+        this.estimatedHours = estimatedHours;
+    }
+
+    public void updateCategoryId(Long categoryId) {
+        this.categoryId = categoryId;
+    }
+
+    public void updateInstructorId(Long instructorId) {
+        this.instructorId = instructorId;
+    }
+
+    public void update(String title, String description, CourseLevel level,
+                       CourseType type, Integer estimatedHours,
+                       Long categoryId, Long instructorId) {
+        if (title != null) {
+            updateTitle(title);
+        }
+        this.description = description;
+        this.level = level;
+        this.type = type;
+        this.estimatedHours = estimatedHours;
+        this.categoryId = categoryId;
+        this.instructorId = instructorId;
+    }
+
+    // ===== 연관관계 편의 메서드 =====
+    public void addItem(CourseItem item) {
+        this.items.add(item);
+        item.assignCourse(this);
+    }
+
+    // ===== Private 검증 메서드 =====
+    private void validateTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("강의 제목은 필수입니다");
+        }
+        if (title.length() > 255) {
+            throw new IllegalArgumentException("강의 제목은 255자 이하여야 합니다");
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/entity/CourseItem.java
+++ b/src/main/java/com/mzc/lp/domain/course/entity/CourseItem.java
@@ -1,0 +1,173 @@
+package com.mzc.lp.domain.course.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "cm_course_items", indexes = {
+        @Index(name = "idx_course_item_course", columnList = "course_id"),
+        @Index(name = "idx_course_item_parent", columnList = "parent_id"),
+        @Index(name = "idx_course_item_lo", columnList = "learning_object_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CourseItem extends TenantEntity {
+
+    private static final int MAX_DEPTH = 9;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private CourseItem parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CourseItem> children = new ArrayList<>();
+
+    @Column(name = "learning_object_id")
+    private Long learningObjectId;
+
+    @Column(name = "item_name", nullable = false, length = 255)
+    private String itemName;
+
+    @Column(nullable = false)
+    private Integer depth;
+
+    @Column
+    private Integer sortOrder;
+
+    // ===== 정적 팩토리 메서드 =====
+    public static CourseItem createFolder(Course course, String itemName, CourseItem parent) {
+        CourseItem item = new CourseItem();
+        item.course = course;
+        item.itemName = itemName;
+        item.parent = parent;
+        item.depth = parent != null ? parent.getDepth() + 1 : 0;
+        item.learningObjectId = null;
+        item.validateDepth();
+        return item;
+    }
+
+    public static CourseItem createItem(Course course, String itemName,
+                                        CourseItem parent, Long learningObjectId) {
+        CourseItem item = new CourseItem();
+        item.course = course;
+        item.itemName = itemName;
+        item.parent = parent;
+        item.depth = parent != null ? parent.getDepth() + 1 : 0;
+        item.learningObjectId = learningObjectId;
+        item.validateDepth();
+        return item;
+    }
+
+    // ===== 비즈니스 메서드 =====
+    public boolean isFolder() {
+        return this.learningObjectId == null;
+    }
+
+    public void updateItemName(String itemName) {
+        validateItemName(itemName);
+        this.itemName = itemName;
+    }
+
+    public void updateLearningObjectId(Long learningObjectId) {
+        if (isFolder()) {
+            throw new IllegalStateException("폴더에는 학습 객체를 연결할 수 없습니다");
+        }
+        this.learningObjectId = learningObjectId;
+    }
+
+    public void moveTo(CourseItem newParent) {
+        int newDepth = newParent != null ? newParent.getDepth() + 1 : 0;
+
+        // 하위 항목들의 최대 깊이 계산
+        int maxChildDepth = calculateMaxChildDepth();
+        int depthDiff = newDepth - this.depth;
+
+        if (maxChildDepth + depthDiff > MAX_DEPTH) {
+            throw new IllegalArgumentException("최대 깊이(10단계)를 초과할 수 없습니다");
+        }
+
+        // 순환 참조 검증
+        if (newParent != null && isAncestorOf(newParent)) {
+            throw new IllegalArgumentException("하위 항목으로 이동할 수 없습니다");
+        }
+
+        if (this.parent != null) {
+            this.parent.getChildren().remove(this);
+        }
+
+        this.parent = newParent;
+        updateDepthRecursively(newDepth);
+
+        if (newParent != null) {
+            newParent.getChildren().add(this);
+        }
+    }
+
+    public void updateSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    // ===== 연관관계 편의 메서드 =====
+    void assignCourse(Course course) {
+        this.course = course;
+    }
+
+    public void addChild(CourseItem child) {
+        this.children.add(child);
+        child.parent = this;
+    }
+
+    // ===== Private 검증/헬퍼 메서드 =====
+    private void validateDepth() {
+        if (this.depth > MAX_DEPTH) {
+            throw new IllegalArgumentException("최대 깊이(10단계)를 초과할 수 없습니다");
+        }
+    }
+
+    private void validateItemName(String itemName) {
+        if (itemName == null || itemName.isBlank()) {
+            throw new IllegalArgumentException("항목 이름은 필수입니다");
+        }
+        if (itemName.length() > 255) {
+            throw new IllegalArgumentException("항목 이름은 255자 이하여야 합니다");
+        }
+    }
+
+    private int calculateMaxChildDepth() {
+        if (children.isEmpty()) {
+            return this.depth;
+        }
+        return children.stream()
+                .mapToInt(CourseItem::calculateMaxChildDepth)
+                .max()
+                .orElse(this.depth);
+    }
+
+    private boolean isAncestorOf(CourseItem item) {
+        CourseItem current = item;
+        while (current != null) {
+            if (current.getId() != null && current.getId().equals(this.getId())) {
+                return true;
+            }
+            current = current.getParent();
+        }
+        return false;
+    }
+
+    private void updateDepthRecursively(int newDepth) {
+        this.depth = newDepth;
+        for (CourseItem child : children) {
+            child.updateDepthRecursively(newDepth + 1);
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/entity/CourseRelation.java
+++ b/src/main/java/com/mzc/lp/domain/course/entity/CourseRelation.java
@@ -1,0 +1,84 @@
+package com.mzc.lp.domain.course.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "cr_course_relations",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"from_item_id", "to_item_id"}),
+       indexes = {
+           @Index(name = "idx_relation_from", columnList = "from_item_id"),
+           @Index(name = "idx_relation_to", columnList = "to_item_id")
+       })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CourseRelation extends TenantEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_item_id")
+    private CourseItem fromItem;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_item_id", nullable = false)
+    private CourseItem toItem;
+
+    // ===== 정적 팩토리 메서드 =====
+    public static CourseRelation create(CourseItem fromItem, CourseItem toItem) {
+        validateRelation(fromItem, toItem);
+
+        CourseRelation relation = new CourseRelation();
+        relation.fromItem = fromItem;
+        relation.toItem = toItem;
+        return relation;
+    }
+
+    public static CourseRelation createStartPoint(CourseItem toItem) {
+        if (toItem == null) {
+            throw new IllegalArgumentException("시작점 항목은 필수입니다");
+        }
+        if (toItem.isFolder()) {
+            throw new IllegalArgumentException("폴더는 학습 순서에 포함할 수 없습니다");
+        }
+
+        CourseRelation relation = new CourseRelation();
+        relation.fromItem = null;
+        relation.toItem = toItem;
+        return relation;
+    }
+
+    // ===== 비즈니스 메서드 =====
+    public boolean isStartPoint() {
+        return this.fromItem == null;
+    }
+
+    public void updateFromItem(CourseItem fromItem) {
+        validateRelation(fromItem, this.toItem);
+        this.fromItem = fromItem;
+    }
+
+    public void updateToItem(CourseItem toItem) {
+        validateRelation(this.fromItem, toItem);
+        this.toItem = toItem;
+    }
+
+    // ===== Private 검증 메서드 =====
+    private static void validateRelation(CourseItem fromItem, CourseItem toItem) {
+        if (toItem == null) {
+            throw new IllegalArgumentException("대상 항목은 필수입니다");
+        }
+        if (toItem.isFolder()) {
+            throw new IllegalArgumentException("폴더는 학습 순서에 포함할 수 없습니다");
+        }
+        if (fromItem != null) {
+            if (fromItem.isFolder()) {
+                throw new IllegalArgumentException("폴더는 학습 순서에 포함할 수 없습니다");
+            }
+            if (fromItem.getId() != null && fromItem.getId().equals(toItem.getId())) {
+                throw new IllegalArgumentException("자기 자신을 참조할 수 없습니다");
+            }
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/exception/CircularReferenceException.java
+++ b/src/main/java/com/mzc/lp/domain/course/exception/CircularReferenceException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.course.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class CircularReferenceException extends BusinessException {
+
+    public CircularReferenceException() {
+        super(ErrorCode.CM_CIRCULAR_REFERENCE);
+    }
+
+    public CircularReferenceException(String message) {
+        super(ErrorCode.CM_CIRCULAR_REFERENCE, message);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/exception/CourseItemNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/course/exception/CourseItemNotFoundException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.course.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class CourseItemNotFoundException extends BusinessException {
+
+    public CourseItemNotFoundException() {
+        super(ErrorCode.CM_COURSE_ITEM_NOT_FOUND);
+    }
+
+    public CourseItemNotFoundException(Long itemId) {
+        super(ErrorCode.CM_COURSE_ITEM_NOT_FOUND, "차시/폴더를 찾을 수 없습니다. ID: " + itemId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/exception/CourseNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/course/exception/CourseNotFoundException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.course.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class CourseNotFoundException extends BusinessException {
+
+    public CourseNotFoundException() {
+        super(ErrorCode.CM_COURSE_NOT_FOUND);
+    }
+
+    public CourseNotFoundException(Long courseId) {
+        super(ErrorCode.CM_COURSE_NOT_FOUND, "강의를 찾을 수 없습니다. ID: " + courseId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/exception/InvalidParentException.java
+++ b/src/main/java/com/mzc/lp/domain/course/exception/InvalidParentException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.course.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class InvalidParentException extends BusinessException {
+
+    public InvalidParentException() {
+        super(ErrorCode.CM_INVALID_PARENT);
+    }
+
+    public InvalidParentException(String message) {
+        super(ErrorCode.CM_INVALID_PARENT, message);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/exception/MaxDepthExceededException.java
+++ b/src/main/java/com/mzc/lp/domain/course/exception/MaxDepthExceededException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.course.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class MaxDepthExceededException extends BusinessException {
+
+    public MaxDepthExceededException() {
+        super(ErrorCode.CM_MAX_DEPTH_EXCEEDED);
+    }
+
+    public MaxDepthExceededException(int currentDepth) {
+        super(ErrorCode.CM_MAX_DEPTH_EXCEEDED, "최대 깊이(10단계)를 초과했습니다. 현재 깊이: " + currentDepth);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/repository/CourseItemRepository.java
+++ b/src/main/java/com/mzc/lp/domain/course/repository/CourseItemRepository.java
@@ -1,0 +1,43 @@
+package com.mzc.lp.domain.course.repository;
+
+import com.mzc.lp.domain.course.entity.CourseItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CourseItemRepository extends JpaRepository<CourseItem, Long> {
+
+    Optional<CourseItem> findByIdAndTenantId(Long id, Long tenantId);
+
+    List<CourseItem> findByCourseIdAndTenantId(Long courseId, Long tenantId);
+
+    List<CourseItem> findByCourseIdAndTenantIdAndParentIsNull(Long courseId, Long tenantId);
+
+    List<CourseItem> findByCourseIdAndTenantIdAndParentId(Long courseId, Long tenantId, Long parentId);
+
+    @Query("SELECT ci FROM CourseItem ci WHERE ci.course.id = :courseId AND ci.tenantId = :tenantId ORDER BY ci.depth, ci.sortOrder")
+    List<CourseItem> findByCourseIdOrderByDepthAndSortOrder(@Param("courseId") Long courseId, @Param("tenantId") Long tenantId);
+
+    @Query("SELECT ci FROM CourseItem ci WHERE ci.course.id = :courseId AND ci.tenantId = :tenantId AND ci.learningObjectId IS NOT NULL ORDER BY ci.sortOrder")
+    List<CourseItem> findItemsOnlyByCourseId(@Param("courseId") Long courseId, @Param("tenantId") Long tenantId);
+
+    @Query("SELECT ci FROM CourseItem ci WHERE ci.course.id = :courseId AND ci.tenantId = :tenantId AND ci.learningObjectId IS NULL ORDER BY ci.depth, ci.sortOrder")
+    List<CourseItem> findFoldersOnlyByCourseId(@Param("courseId") Long courseId, @Param("tenantId") Long tenantId);
+
+    @Query("SELECT ci FROM CourseItem ci LEFT JOIN FETCH ci.children WHERE ci.id = :id AND ci.tenantId = :tenantId")
+    Optional<CourseItem> findByIdWithChildren(@Param("id") Long id, @Param("tenantId") Long tenantId);
+
+    @Query("SELECT DISTINCT ci FROM CourseItem ci LEFT JOIN FETCH ci.children WHERE ci.course.id = :courseId AND ci.tenantId = :tenantId AND ci.parent IS NULL ORDER BY ci.sortOrder")
+    List<CourseItem> findRootItemsWithChildren(@Param("courseId") Long courseId, @Param("tenantId") Long tenantId);
+
+    boolean existsByIdAndTenantId(Long id, Long tenantId);
+
+    boolean existsByCourseIdAndTenantIdAndLearningObjectId(Long courseId, Long tenantId, Long learningObjectId);
+
+    long countByCourseIdAndTenantId(Long courseId, Long tenantId);
+
+    long countByCourseIdAndTenantIdAndLearningObjectIdIsNotNull(Long courseId, Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/course/repository/CourseRelationRepository.java
+++ b/src/main/java/com/mzc/lp/domain/course/repository/CourseRelationRepository.java
@@ -1,0 +1,42 @@
+package com.mzc.lp.domain.course.repository;
+
+import com.mzc.lp.domain.course.entity.CourseRelation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CourseRelationRepository extends JpaRepository<CourseRelation, Long> {
+
+    Optional<CourseRelation> findByIdAndTenantId(Long id, Long tenantId);
+
+    @Query("SELECT cr FROM CourseRelation cr WHERE cr.toItem.course.id = :courseId AND cr.tenantId = :tenantId")
+    List<CourseRelation> findByCourseId(@Param("courseId") Long courseId, @Param("tenantId") Long tenantId);
+
+    @Query("SELECT cr FROM CourseRelation cr WHERE cr.fromItem IS NULL AND cr.toItem.course.id = :courseId AND cr.tenantId = :tenantId")
+    Optional<CourseRelation> findStartPointByCourseId(@Param("courseId") Long courseId, @Param("tenantId") Long tenantId);
+
+    @Query("SELECT cr FROM CourseRelation cr WHERE cr.fromItem.id = :fromItemId AND cr.tenantId = :tenantId")
+    Optional<CourseRelation> findByFromItemId(@Param("fromItemId") Long fromItemId, @Param("tenantId") Long tenantId);
+
+    @Query("SELECT cr FROM CourseRelation cr WHERE cr.toItem.id = :toItemId AND cr.tenantId = :tenantId")
+    Optional<CourseRelation> findByToItemId(@Param("toItemId") Long toItemId, @Param("tenantId") Long tenantId);
+
+    @Query("SELECT cr FROM CourseRelation cr LEFT JOIN FETCH cr.fromItem LEFT JOIN FETCH cr.toItem WHERE cr.toItem.course.id = :courseId AND cr.tenantId = :tenantId")
+    List<CourseRelation> findByCourseIdWithItems(@Param("courseId") Long courseId, @Param("tenantId") Long tenantId);
+
+    boolean existsByFromItemIdAndToItemIdAndTenantId(Long fromItemId, Long toItemId, Long tenantId);
+
+    @Modifying
+    @Query("DELETE FROM CourseRelation cr WHERE cr.toItem.course.id = :courseId AND cr.tenantId = :tenantId")
+    int deleteByCourseId(@Param("courseId") Long courseId, @Param("tenantId") Long tenantId);
+
+    @Modifying
+    @Query("DELETE FROM CourseRelation cr WHERE cr.fromItem.id = :itemId OR cr.toItem.id = :itemId")
+    int deleteByItemId(@Param("itemId") Long itemId);
+
+    long countByToItemCourseIdAndTenantId(Long courseId, Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/mzc/lp/domain/course/repository/CourseRepository.java
@@ -1,0 +1,33 @@
+package com.mzc.lp.domain.course.repository;
+
+import com.mzc.lp.domain.course.entity.Course;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CourseRepository extends JpaRepository<Course, Long> {
+
+    Optional<Course> findByIdAndTenantId(Long id, Long tenantId);
+
+    Page<Course> findByTenantId(Long tenantId, Pageable pageable);
+
+    Page<Course> findByTenantIdAndTitleContaining(Long tenantId, String keyword, Pageable pageable);
+
+    Page<Course> findByTenantIdAndInstructorId(Long tenantId, Long instructorId, Pageable pageable);
+
+    Page<Course> findByTenantIdAndCategoryId(Long tenantId, Long categoryId, Pageable pageable);
+
+    List<Course> findByTenantIdAndInstructorId(Long tenantId, Long instructorId);
+
+    @Query("SELECT c FROM Course c LEFT JOIN FETCH c.items WHERE c.id = :id AND c.tenantId = :tenantId")
+    Optional<Course> findByIdWithItems(@Param("id") Long id, @Param("tenantId") Long tenantId);
+
+    boolean existsByIdAndTenantId(Long id, Long tenantId);
+
+    long countByTenantIdAndInstructorId(Long tenantId, Long instructorId);
+}


### PR DESCRIPTION
## Summary
- CM (Course Matrix) 모듈의 기반 구조 구현
- 강의 템플릿 관리를 위한 Entity, Repository, DTO, Exception 추가

## Changes

### Constant (2개)
- `CourseLevel`: 난이도 (BEGINNER, INTERMEDIATE, ADVANCED)
- `CourseType`: 유형 (ONLINE, OFFLINE, BLENDED)

### Entity (3개)
- `Course`: 강의 메타데이터 (TenantEntity 상속)
- `CourseItem`: 차시/폴더 (self-reference, depth 0~9)
- `CourseRelation`: 학습 순서 (Linked List 패턴)

### Repository (3개)
- `CourseRepository`: 강의 CRUD + 페이징/필터 쿼리
- `CourseItemRepository`: 차시/폴더 계층 구조 쿼리
- `CourseRelationRepository`: 학습 순서 조회/삭제 쿼리

### DTO Request (6개)
- `CreateCourseRequest`, `UpdateCourseRequest`
- `CreateItemRequest`, `CreateFolderRequest`, `MoveItemRequest`
- `CreateRelationRequest`

### DTO Response (5개)
- `CourseResponse`, `CourseDetailResponse`
- `CourseItemResponse`, `CourseItemHierarchyResponse`
- `CourseRelationResponse`

### Exception (5개) + ErrorCode
- `CourseNotFoundException` (CM001)
- `CourseItemNotFoundException` (CM002)
- `MaxDepthExceededException` (CM003)
- `CircularReferenceException` (CM004)
- `InvalidParentException` (CM005)
- `ErrorCode.java`: CM001~CM008 추가

## Test plan
- [x] gradlew compileJava 빌드 성공
- [ ] Entity 연관관계 검증 (Phase 2에서 통합 테스트)
- [ ] Repository 쿼리 메서드 검증 (Phase 2에서 통합 테스트)

## Related
- Closes #41
- ROADMAP-CM.md Phase 1

