### PR TITLE
[Feat] Course CRUD API 구현 (#53)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/course/controller/CourseController.java
+++ b/src/main/java/com/mzc/lp/domain/course/controller/CourseController.java
@@ -1,0 +1,115 @@
+package com.mzc.lp.domain.course.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.course.dto.request.CreateCourseRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateCourseRequest;
+import com.mzc.lp.domain.course.dto.response.CourseDetailResponse;
+import com.mzc.lp.domain.course.dto.response.CourseResponse;
+import com.mzc.lp.domain.course.service.CourseService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/courses")
+@RequiredArgsConstructor
+@Validated
+public class CourseController {
+
+    private final CourseService courseService;
+
+    /**
+     * 강의 생성
+     * POST /api/courses
+     */
+    @PostMapping
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseResponse>> createCourse(
+            @Valid @RequestBody CreateCourseRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseResponse response = courseService.createCourse(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 강의 목록 조회 (페이징, 키워드 검색, 카테고리 필터)
+     * GET /api/courses
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<CourseResponse>>> getCourses(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) Long categoryId,
+            @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Page<CourseResponse> response = courseService.getCourses(keyword, categoryId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 강의 상세 조회
+     * GET /api/courses/{courseId}
+     */
+    @GetMapping("/{courseId}")
+    public ResponseEntity<ApiResponse<CourseDetailResponse>> getCourseDetail(
+            @PathVariable @Positive Long courseId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseDetailResponse response = courseService.getCourseDetail(courseId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 강사별 강의 목록 조회
+     * GET /api/courses/instructor/{instructorId}
+     */
+    @GetMapping("/instructor/{instructorId}")
+    public ResponseEntity<ApiResponse<Page<CourseResponse>>> getCoursesByInstructor(
+            @PathVariable @Positive Long instructorId,
+            @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Page<CourseResponse> response = courseService.getCoursesByInstructor(instructorId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 강의 수정
+     * PUT /api/courses/{courseId}
+     */
+    @PutMapping("/{courseId}")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseResponse>> updateCourse(
+            @PathVariable @Positive Long courseId,
+            @Valid @RequestBody UpdateCourseRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseResponse response = courseService.updateCourse(courseId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 강의 삭제
+     * DELETE /api/courses/{courseId}
+     */
+    @DeleteMapping("/{courseId}")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> deleteCourse(
+            @PathVariable @Positive Long courseId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        courseService.deleteCourse(courseId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/mzc/lp/domain/course/repository/CourseRepository.java
@@ -22,6 +22,8 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 
     Page<Course> findByTenantIdAndCategoryId(Long tenantId, Long categoryId, Pageable pageable);
 
+    Page<Course> findByTenantIdAndTitleContainingAndCategoryId(Long tenantId, String keyword, Long categoryId, Pageable pageable);
+
     List<Course> findByTenantIdAndInstructorId(Long tenantId, Long instructorId);
 
     @Query("SELECT c FROM Course c LEFT JOIN FETCH c.items WHERE c.id = :id AND c.tenantId = :tenantId")

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseService.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseService.java
@@ -1,0 +1,56 @@
+package com.mzc.lp.domain.course.service;
+
+import com.mzc.lp.domain.course.dto.request.CreateCourseRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateCourseRequest;
+import com.mzc.lp.domain.course.dto.response.CourseDetailResponse;
+import com.mzc.lp.domain.course.dto.response.CourseResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CourseService {
+
+    /**
+     * 강의 생성
+     * @param request 생성 요청 DTO
+     * @return 생성된 강의 정보
+     */
+    CourseResponse createCourse(CreateCourseRequest request);
+
+    /**
+     * 강의 목록 조회 (페이징, 키워드 검색, 카테고리 필터)
+     * @param keyword 검색 키워드 (제목)
+     * @param categoryId 카테고리 ID (필터)
+     * @param pageable 페이징 정보
+     * @return 강의 목록 페이지
+     */
+    Page<CourseResponse> getCourses(String keyword, Long categoryId, Pageable pageable);
+
+    /**
+     * 강의 상세 조회 (아이템 포함)
+     * @param courseId 강의 ID
+     * @return 강의 상세 정보
+     */
+    CourseDetailResponse getCourseDetail(Long courseId);
+
+    /**
+     * 강사별 강의 목록 조회
+     * @param instructorId 강사 ID
+     * @param pageable 페이징 정보
+     * @return 강의 목록 페이지
+     */
+    Page<CourseResponse> getCoursesByInstructor(Long instructorId, Pageable pageable);
+
+    /**
+     * 강의 수정
+     * @param courseId 강의 ID
+     * @param request 수정 요청 DTO
+     * @return 수정된 강의 정보
+     */
+    CourseResponse updateCourse(Long courseId, UpdateCourseRequest request);
+
+    /**
+     * 강의 삭제
+     * @param courseId 강의 ID
+     */
+    void deleteCourse(Long courseId);
+}

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
@@ -1,0 +1,128 @@
+package com.mzc.lp.domain.course.service;
+
+import com.mzc.lp.domain.course.dto.request.CreateCourseRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateCourseRequest;
+import com.mzc.lp.domain.course.dto.response.CourseDetailResponse;
+import com.mzc.lp.domain.course.dto.response.CourseItemResponse;
+import com.mzc.lp.domain.course.dto.response.CourseResponse;
+import com.mzc.lp.domain.course.entity.Course;
+import com.mzc.lp.domain.course.exception.CourseNotFoundException;
+import com.mzc.lp.domain.course.repository.CourseRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CourseServiceImpl implements CourseService {
+
+    private final CourseRepository courseRepository;
+
+    private static final Long DEFAULT_TENANT_ID = 1L;
+
+    @Override
+    @Transactional
+    public CourseResponse createCourse(CreateCourseRequest request) {
+        log.info("Creating course: title={}", request.title());
+
+        Course course = Course.create(
+                request.title(),
+                request.description(),
+                request.level(),
+                request.type(),
+                request.estimatedHours(),
+                request.categoryId(),
+                request.instructorId()
+        );
+
+        Course savedCourse = courseRepository.save(course);
+        log.info("Course created: id={}, title={}", savedCourse.getId(), savedCourse.getTitle());
+
+        return CourseResponse.from(savedCourse);
+    }
+
+    @Override
+    public Page<CourseResponse> getCourses(String keyword, Long categoryId, Pageable pageable) {
+        log.debug("Getting courses: keyword={}, categoryId={}", keyword, categoryId);
+
+        Page<Course> courses;
+
+        if (keyword != null && !keyword.isBlank() && categoryId != null) {
+            courses = courseRepository.findByTenantIdAndTitleContainingAndCategoryId(
+                    DEFAULT_TENANT_ID, keyword, categoryId, pageable);
+        } else if (keyword != null && !keyword.isBlank()) {
+            courses = courseRepository.findByTenantIdAndTitleContaining(
+                    DEFAULT_TENANT_ID, keyword, pageable);
+        } else if (categoryId != null) {
+            courses = courseRepository.findByTenantIdAndCategoryId(
+                    DEFAULT_TENANT_ID, categoryId, pageable);
+        } else {
+            courses = courseRepository.findByTenantId(DEFAULT_TENANT_ID, pageable);
+        }
+
+        return courses.map(CourseResponse::from);
+    }
+
+    @Override
+    public CourseDetailResponse getCourseDetail(Long courseId) {
+        log.debug("Getting course detail: courseId={}", courseId);
+
+        Course course = courseRepository.findByIdWithItems(courseId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new CourseNotFoundException(courseId));
+
+        List<CourseItemResponse> items = course.getItems().stream()
+                .map(CourseItemResponse::from)
+                .toList();
+
+        return CourseDetailResponse.from(course, items);
+    }
+
+    @Override
+    public Page<CourseResponse> getCoursesByInstructor(Long instructorId, Pageable pageable) {
+        log.debug("Getting courses by instructor: instructorId={}", instructorId);
+
+        return courseRepository.findByTenantIdAndInstructorId(DEFAULT_TENANT_ID, instructorId, pageable)
+                .map(CourseResponse::from);
+    }
+
+    @Override
+    @Transactional
+    public CourseResponse updateCourse(Long courseId, UpdateCourseRequest request) {
+        log.info("Updating course: courseId={}", courseId);
+
+        Course course = courseRepository.findByIdAndTenantId(courseId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new CourseNotFoundException(courseId));
+
+        course.update(
+                request.title(),
+                request.description(),
+                request.level(),
+                request.type(),
+                request.estimatedHours(),
+                request.categoryId(),
+                request.instructorId()
+        );
+
+        log.info("Course updated: id={}", courseId);
+        return CourseResponse.from(course);
+    }
+
+    @Override
+    @Transactional
+    public void deleteCourse(Long courseId) {
+        log.info("Deleting course: courseId={}", courseId);
+
+        Course course = courseRepository.findByIdAndTenantId(courseId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new CourseNotFoundException(courseId));
+
+        courseRepository.delete(course);
+        log.info("Course deleted: id={}", courseId);
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseControllerTest.java
@@ -1,0 +1,750 @@
+package com.mzc.lp.domain.course.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.domain.course.constant.CourseLevel;
+import com.mzc.lp.domain.course.constant.CourseType;
+import com.mzc.lp.domain.course.dto.request.CreateCourseRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateCourseRequest;
+import com.mzc.lp.domain.course.entity.Course;
+import com.mzc.lp.domain.course.repository.CourseRepository;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.dto.request.RegisterRequest;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CourseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private UserCourseRoleRepository userCourseRoleRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        courseRepository.deleteAll();
+        userCourseRoleRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ===== 헬퍼 메서드 =====
+
+    private User createOperatorUser() {
+        User user = User.create("operator@example.com", "운영자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.OPERATOR);
+        return userRepository.save(user);
+    }
+
+    private User createAdminUser() {
+        User user = User.create("admin@example.com", "관리자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.TENANT_ADMIN);
+        return userRepository.save(user);
+    }
+
+    private void createTestUser() throws Exception {
+        RegisterRequest request = new RegisterRequest(
+                "test@example.com",
+                "Password123!",
+                "홍길동",
+                "010-1234-5678"
+        );
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+    }
+
+    private String loginAndGetAccessToken(String email, String password) throws Exception {
+        LoginRequest request = new LoginRequest(email, password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("data").get("accessToken").asText();
+    }
+
+    private Course createTestCourse(String title) {
+        Course course = Course.create(
+                title,
+                "테스트 강의 설명",
+                CourseLevel.BEGINNER,
+                CourseType.ONLINE,
+                10,
+                1L,
+                1L
+        );
+        return courseRepository.save(course);
+    }
+
+    private Course createTestCourse(String title, Long instructorId) {
+        Course course = Course.create(
+                title,
+                "테스트 강의 설명",
+                CourseLevel.BEGINNER,
+                CourseType.ONLINE,
+                10,
+                1L,
+                instructorId
+        );
+        return courseRepository.save(course);
+    }
+
+    // ==================== 강의 생성 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/courses - 강의 생성")
+    class CreateCourse {
+
+        @Test
+        @DisplayName("성공 - OPERATOR가 강의 생성")
+        void createCourse_success_operator() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CreateCourseRequest request = new CreateCourseRequest(
+                    "Spring Boot 기초",
+                    "Spring Boot 입문 강의입니다.",
+                    CourseLevel.BEGINNER,
+                    CourseType.ONLINE,
+                    20,
+                    1L,
+                    1L
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/courses")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.title").value("Spring Boot 기초"))
+                    .andExpect(jsonPath("$.data.description").value("Spring Boot 입문 강의입니다."))
+                    .andExpect(jsonPath("$.data.level").value("BEGINNER"))
+                    .andExpect(jsonPath("$.data.type").value("ONLINE"))
+                    .andExpect(jsonPath("$.data.estimatedHours").value(20));
+        }
+
+        @Test
+        @DisplayName("성공 - TENANT_ADMIN이 강의 생성")
+        void createCourse_success_admin() throws Exception {
+            // given
+            createAdminUser();
+            String accessToken = loginAndGetAccessToken("admin@example.com", "Password123!");
+            CreateCourseRequest request = new CreateCourseRequest(
+                    "React 심화",
+                    null,
+                    CourseLevel.ADVANCED,
+                    CourseType.BLENDED,
+                    30,
+                    2L,
+                    2L
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/courses")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.title").value("React 심화"));
+        }
+
+        @Test
+        @DisplayName("성공 - 최소 필드로 강의 생성 (title만)")
+        void createCourse_success_minimalFields() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CreateCourseRequest request = new CreateCourseRequest(
+                    "최소 강의",
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/courses")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.title").value("최소 강의"));
+        }
+
+        @Test
+        @DisplayName("실패 - 제목 누락")
+        void createCourse_fail_missingTitle() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CreateCourseRequest request = new CreateCourseRequest(
+                    null,
+                    "설명만 있는 요청",
+                    CourseLevel.BEGINNER,
+                    CourseType.ONLINE,
+                    10,
+                    1L,
+                    1L
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/courses")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("실패 - 제목 빈 문자열")
+        void createCourse_fail_emptyTitle() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CreateCourseRequest request = new CreateCourseRequest(
+                    "   ",
+                    "설명",
+                    CourseLevel.BEGINNER,
+                    CourseType.ONLINE,
+                    10,
+                    1L,
+                    1L
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/courses")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("실패 - 제목 255자 초과")
+        void createCourse_fail_titleTooLong() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            String longTitle = "a".repeat(256);
+            CreateCourseRequest request = new CreateCourseRequest(
+                    longTitle,
+                    "설명",
+                    CourseLevel.BEGINNER,
+                    CourseType.ONLINE,
+                    10,
+                    1L,
+                    1L
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/courses")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 생성 시도")
+        void createCourse_fail_userRole() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken("test@example.com", "Password123!");
+            CreateCourseRequest request = new CreateCourseRequest(
+                    "테스트 강의",
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/courses")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("실패 - 인증 없이 접근")
+        void createCourse_fail_unauthorized() throws Exception {
+            // given
+            CreateCourseRequest request = new CreateCourseRequest(
+                    "테스트 강의",
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/courses")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 강의 목록 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/courses - 강의 목록 조회")
+    class GetCourses {
+
+        @Test
+        @DisplayName("성공 - 전체 강의 목록 조회")
+        void getCourses_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            createTestCourse("Spring Boot 기초");
+            createTestCourse("React 입문");
+            createTestCourse("Docker 활용");
+
+            // when & then
+            mockMvc.perform(get("/api/courses")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.totalElements").value(3));
+        }
+
+        @Test
+        @DisplayName("성공 - 키워드 검색")
+        void getCourses_success_withKeyword() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            createTestCourse("Spring Boot 기초");
+            createTestCourse("Spring Security 심화");
+            createTestCourse("React 입문");
+
+            // when & then
+            mockMvc.perform(get("/api/courses")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("keyword", "Spring"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.totalElements").value(2));
+        }
+
+        @Test
+        @DisplayName("성공 - 카테고리 필터")
+        void getCourses_success_withCategoryFilter() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            Course course1 = Course.create("Spring Boot", "설명", CourseLevel.BEGINNER, CourseType.ONLINE, 10, 1L, 1L);
+            Course course2 = Course.create("React", "설명", CourseLevel.BEGINNER, CourseType.ONLINE, 10, 2L, 1L);
+            Course course3 = Course.create("Docker", "설명", CourseLevel.BEGINNER, CourseType.ONLINE, 10, 1L, 1L);
+            courseRepository.save(course1);
+            courseRepository.save(course2);
+            courseRepository.save(course3);
+
+            // when & then
+            mockMvc.perform(get("/api/courses")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("categoryId", "1"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.totalElements").value(2));
+        }
+
+        @Test
+        @DisplayName("성공 - 페이징 처리")
+        void getCourses_success_pagination() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            for (int i = 1; i <= 25; i++) {
+                createTestCourse("강의 " + i);
+            }
+
+            // when & then
+            mockMvc.perform(get("/api/courses")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("page", "0")
+                            .param("size", "10"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.content.length()").value(10))
+                    .andExpect(jsonPath("$.data.totalElements").value(25))
+                    .andExpect(jsonPath("$.data.totalPages").value(3));
+        }
+
+        @Test
+        @DisplayName("성공 - 빈 결과")
+        void getCourses_success_empty() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/courses")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.totalElements").value(0));
+        }
+    }
+
+    // ==================== 강의 상세 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/courses/{courseId} - 강의 상세 조회")
+    class GetCourseDetail {
+
+        @Test
+        @DisplayName("성공 - 강의 상세 조회")
+        void getCourseDetail_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("Spring Boot 기초");
+
+            // when & then
+            mockMvc.perform(get("/api/courses/{courseId}", course.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.courseId").value(course.getId()))
+                    .andExpect(jsonPath("$.data.title").value("Spring Boot 기초"))
+                    .andExpect(jsonPath("$.data.items").isArray())
+                    .andExpect(jsonPath("$.data.itemCount").value(0));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 강의")
+        void getCourseDetail_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/courses/{courseId}", 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM_COURSE_NOT_FOUND"));
+        }
+    }
+
+    // ==================== 강사별 강의 목록 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/courses/instructor/{instructorId} - 강사별 강의 목록")
+    class GetCoursesByInstructor {
+
+        @Test
+        @DisplayName("성공 - 강사별 강의 목록 조회")
+        void getCoursesByInstructor_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            createTestCourse("Spring Boot 기초", 100L);
+            createTestCourse("Spring Security", 100L);
+            createTestCourse("React 입문", 200L);
+
+            // when & then
+            mockMvc.perform(get("/api/courses/instructor/{instructorId}", 100L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.totalElements").value(2));
+        }
+
+        @Test
+        @DisplayName("성공 - 강의가 없는 강사")
+        void getCoursesByInstructor_success_empty() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            createTestCourse("Spring Boot 기초", 100L);
+
+            // when & then
+            mockMvc.perform(get("/api/courses/instructor/{instructorId}", 999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.totalElements").value(0));
+        }
+    }
+
+    // ==================== 강의 수정 테스트 ====================
+
+    @Nested
+    @DisplayName("PUT /api/courses/{courseId} - 강의 수정")
+    class UpdateCourse {
+
+        @Test
+        @DisplayName("성공 - OPERATOR가 강의 수정")
+        void updateCourse_success_operator() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("원래 제목");
+            UpdateCourseRequest request = new UpdateCourseRequest(
+                    "수정된 제목",
+                    "수정된 설명",
+                    CourseLevel.ADVANCED,
+                    CourseType.BLENDED,
+                    50,
+                    2L,
+                    2L
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/courses/{courseId}", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.title").value("수정된 제목"))
+                    .andExpect(jsonPath("$.data.description").value("수정된 설명"))
+                    .andExpect(jsonPath("$.data.level").value("ADVANCED"))
+                    .andExpect(jsonPath("$.data.type").value("BLENDED"))
+                    .andExpect(jsonPath("$.data.estimatedHours").value(50));
+        }
+
+        @Test
+        @DisplayName("성공 - 부분 수정")
+        void updateCourse_success_partial() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("원래 제목");
+            UpdateCourseRequest request = new UpdateCourseRequest(
+                    "수정된 제목만",
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/courses/{courseId}", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.title").value("수정된 제목만"));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 강의")
+        void updateCourse_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            UpdateCourseRequest request = new UpdateCourseRequest(
+                    "수정 시도",
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/courses/{courseId}", 99999L)
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM_COURSE_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 수정 시도")
+        void updateCourse_fail_userRole() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken("test@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            UpdateCourseRequest request = new UpdateCourseRequest(
+                    "수정 시도",
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/courses/{courseId}", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 강의 삭제 테스트 ====================
+
+    @Nested
+    @DisplayName("DELETE /api/courses/{courseId} - 강의 삭제")
+    class DeleteCourse {
+
+        @Test
+        @DisplayName("성공 - OPERATOR가 강의 삭제")
+        void deleteCourse_success_operator() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("삭제할 강의");
+
+            // when & then
+            mockMvc.perform(delete("/api/courses/{courseId}", course.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+
+            // 삭제 확인
+            mockMvc.perform(get("/api/courses/{courseId}", course.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("성공 - TENANT_ADMIN이 강의 삭제")
+        void deleteCourse_success_admin() throws Exception {
+            // given
+            createAdminUser();
+            String accessToken = loginAndGetAccessToken("admin@example.com", "Password123!");
+            Course course = createTestCourse("삭제할 강의");
+
+            // when & then
+            mockMvc.perform(delete("/api/courses/{courseId}", course.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 강의")
+        void deleteCourse_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(delete("/api/courses/{courseId}", 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM_COURSE_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 삭제 시도")
+        void deleteCourse_fail_userRole() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken("test@example.com", "Password123!");
+            Course course = createTestCourse("삭제할 강의");
+
+            // when & then
+            mockMvc.perform(delete("/api/courses/{courseId}", course.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("실패 - 인증 없이 접근")
+        void deleteCourse_fail_unauthorized() throws Exception {
+            // given
+            Course course = createTestCourse("삭제할 강의");
+
+            // when & then
+            mockMvc.perform(delete("/api/courses/{courseId}", course.getId()))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Course CRUD API 6개 구현 (생성, 목록, 상세, 강사별 목록, 수정, 삭제)
- CourseService 인터페이스 및 구현체 추가
- CourseController 추가
- CourseControllerTest 통합 테스트 추가

## Changes
| 파일 | 변경 |
|------|------|
| `CourseRepository.java` | 복합 필터 메서드 추가 |
| `CourseService.java` | 신규 (인터페이스) |
| `CourseServiceImpl.java` | 신규 (구현체) |
| `CourseController.java` | 신규 (REST API) |
| `CourseControllerTest.java` | 신규 (통합 테스트) |

## API
| Method | Endpoint | 기능 | Status |
|--------|----------|------|--------|
| POST | `/api/courses` | 강의 생성 | 201 |
| GET | `/api/courses` | 강의 목록 | 200 |
| GET | `/api/courses/{courseId}` | 강의 상세 | 200 |
| GET | `/api/courses/instructor/{instructorId}` | 강사별 목록 | 200 |
| PUT | `/api/courses/{courseId}` | 강의 수정 | 200 |
| DELETE | `/api/courses/{courseId}` | 강의 삭제 | 204 |

## Test plan
- [x] 빌드 성공 확인
- [ ] CourseControllerTest 전체 테스트 실행
- [ ] 수동 API 테스트

## Notes
- TenantId: `DEFAULT_TENANT_ID = 1L` 하드코딩 (추후 UserPrincipal 수정 시 변경 필요)
- 권한: OPERATOR, TENANT_ADMIN (DESIGNER는 CourseRole이므로 추후 확인)

Closes #53