### PR TITLE
[Feat] TS 정원 관리 및 Public API 구현(#28)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew test:*)"
+    ]
+  }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeController.java
+++ b/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeController.java
@@ -5,8 +5,10 @@ import com.mzc.lp.common.security.UserPrincipal;
 import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
 import com.mzc.lp.domain.ts.dto.request.CreateCourseTimeRequest;
 import com.mzc.lp.domain.ts.dto.request.UpdateCourseTimeRequest;
+import com.mzc.lp.domain.ts.dto.response.CapacityResponse;
 import com.mzc.lp.domain.ts.dto.response.CourseTimeDetailResponse;
 import com.mzc.lp.domain.ts.dto.response.CourseTimeResponse;
+import com.mzc.lp.domain.ts.dto.response.PriceResponse;
 import com.mzc.lp.domain.ts.service.CourseTimeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -110,6 +112,24 @@ public class CourseTimeController {
             @PathVariable Long id
     ) {
         CourseTimeDetailResponse response = courseTimeService.archiveCourseTime(id);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // ========== Public API (permitAll) ==========
+
+    @GetMapping("/{id}/capacity")
+    public ResponseEntity<ApiResponse<CapacityResponse>> getCapacity(
+            @PathVariable Long id
+    ) {
+        CapacityResponse response = courseTimeService.getCapacity(id);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{id}/price")
+    public ResponseEntity<ApiResponse<PriceResponse>> getPrice(
+            @PathVariable Long id
+    ) {
+        PriceResponse response = courseTimeService.getPrice(id);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/ts/dto/response/CapacityResponse.java
+++ b/src/main/java/com/mzc/lp/domain/ts/dto/response/CapacityResponse.java
@@ -1,0 +1,21 @@
+package com.mzc.lp.domain.ts.dto.response;
+
+import com.mzc.lp.domain.ts.entity.CourseTime;
+
+public record CapacityResponse(
+        Long courseTimeId,
+        Integer capacity,
+        Integer currentEnrollment,
+        Integer availableSeats,
+        boolean unlimited
+) {
+    public static CapacityResponse from(CourseTime courseTime) {
+        return new CapacityResponse(
+                courseTime.getId(),
+                courseTime.getCapacity(),
+                courseTime.getCurrentEnrollment(),
+                courseTime.hasUnlimitedCapacity() ? null : courseTime.getAvailableSeats(),
+                courseTime.hasUnlimitedCapacity()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/dto/response/PriceResponse.java
+++ b/src/main/java/com/mzc/lp/domain/ts/dto/response/PriceResponse.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.domain.ts.dto.response;
+
+import com.mzc.lp.domain.ts.entity.CourseTime;
+
+import java.math.BigDecimal;
+
+public record PriceResponse(
+        Long courseTimeId,
+        BigDecimal price,
+        boolean free
+) {
+    public static PriceResponse from(CourseTime courseTime) {
+        return new PriceResponse(
+                courseTime.getId(),
+                courseTime.getPrice(),
+                courseTime.isFree()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeService.java
+++ b/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeService.java
@@ -3,8 +3,10 @@ package com.mzc.lp.domain.ts.service;
 import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
 import com.mzc.lp.domain.ts.dto.request.CreateCourseTimeRequest;
 import com.mzc.lp.domain.ts.dto.request.UpdateCourseTimeRequest;
+import com.mzc.lp.domain.ts.dto.response.CapacityResponse;
 import com.mzc.lp.domain.ts.dto.response.CourseTimeDetailResponse;
 import com.mzc.lp.domain.ts.dto.response.CourseTimeResponse;
+import com.mzc.lp.domain.ts.dto.response.PriceResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -29,4 +31,14 @@ public interface CourseTimeService {
     CourseTimeDetailResponse closeCourseTime(Long id);
 
     CourseTimeDetailResponse archiveCourseTime(Long id);
+
+    // 정원 관리 (SIS에서 호출)
+    void occupySeat(Long courseTimeId);
+
+    void releaseSeat(Long courseTimeId);
+
+    // Public API
+    CapacityResponse getCapacity(Long id);
+
+    PriceResponse getPrice(Long id);
 }

--- a/src/test/java/com/mzc/lp/domain/ts/service/CourseTimeServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/ts/service/CourseTimeServiceTest.java
@@ -1,0 +1,259 @@
+package com.mzc.lp.domain.ts.service;
+
+import com.mzc.lp.domain.ts.constant.DeliveryType;
+import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
+import com.mzc.lp.domain.ts.dto.response.CapacityResponse;
+import com.mzc.lp.domain.ts.dto.response.PriceResponse;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.ts.exception.CapacityExceededException;
+import com.mzc.lp.domain.ts.exception.CourseTimeNotFoundException;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CourseTimeServiceTest {
+
+    @InjectMocks
+    private CourseTimeServiceImpl courseTimeService;
+
+    @Mock
+    private CourseTimeRepository courseTimeRepository;
+
+    private CourseTime createTestCourseTime(Integer capacity, int currentEnrollment) {
+        CourseTime courseTime = CourseTime.create(
+                "테스트 차수",
+                DeliveryType.ONLINE,
+                LocalDate.now(),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(30),
+                capacity,
+                5,
+                EnrollmentMethod.FIRST_COME,
+                80,
+                new BigDecimal("100000"),
+                false,
+                null,
+                true,
+                1L
+        );
+        // 현재 등록 인원 설정
+        for (int i = 0; i < currentEnrollment; i++) {
+            courseTime.incrementEnrollment();
+        }
+        return courseTime;
+    }
+
+    // ==================== 좌석 점유 테스트 ====================
+
+    @Nested
+    @DisplayName("occupySeat - 좌석 점유")
+    class OccupySeat {
+
+        @Test
+        @DisplayName("성공 - 좌석 점유")
+        void occupySeat_success() {
+            // given
+            CourseTime courseTime = createTestCourseTime(30, 10);
+            given(courseTimeRepository.findByIdWithLock(1L)).willReturn(Optional.of(courseTime));
+
+            // when
+            courseTimeService.occupySeat(1L);
+
+            // then
+            assertThat(courseTime.getCurrentEnrollment()).isEqualTo(11);
+            verify(courseTimeRepository).findByIdWithLock(1L);
+        }
+
+        @Test
+        @DisplayName("성공 - 무제한 정원에서 좌석 점유")
+        void occupySeat_success_unlimited() {
+            // given
+            CourseTime courseTime = createTestCourseTime(null, 100);  // capacity = null
+            given(courseTimeRepository.findByIdWithLock(1L)).willReturn(Optional.of(courseTime));
+
+            // when
+            courseTimeService.occupySeat(1L);
+
+            // then
+            assertThat(courseTime.getCurrentEnrollment()).isEqualTo(101);
+        }
+
+        @Test
+        @DisplayName("실패 - 정원 초과")
+        void occupySeat_fail_capacityExceeded() {
+            // given
+            CourseTime courseTime = createTestCourseTime(30, 30);  // 만석
+            given(courseTimeRepository.findByIdWithLock(1L)).willReturn(Optional.of(courseTime));
+
+            // when & then
+            assertThatThrownBy(() -> courseTimeService.occupySeat(1L))
+                    .isInstanceOf(CapacityExceededException.class);
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 차수")
+        void occupySeat_fail_notFound() {
+            // given
+            given(courseTimeRepository.findByIdWithLock(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> courseTimeService.occupySeat(999L))
+                    .isInstanceOf(CourseTimeNotFoundException.class);
+        }
+    }
+
+    // ==================== 좌석 해제 테스트 ====================
+
+    @Nested
+    @DisplayName("releaseSeat - 좌석 해제")
+    class ReleaseSeat {
+
+        @Test
+        @DisplayName("성공 - 좌석 해제")
+        void releaseSeat_success() {
+            // given
+            CourseTime courseTime = createTestCourseTime(30, 10);
+            given(courseTimeRepository.findByIdWithLock(1L)).willReturn(Optional.of(courseTime));
+
+            // when
+            courseTimeService.releaseSeat(1L);
+
+            // then
+            assertThat(courseTime.getCurrentEnrollment()).isEqualTo(9);
+            verify(courseTimeRepository).findByIdWithLock(1L);
+        }
+
+        @Test
+        @DisplayName("성공 - 등록 인원 0일 때 해제 (0 이하로 내려가지 않음)")
+        void releaseSeat_success_zeroEnrollment() {
+            // given
+            CourseTime courseTime = createTestCourseTime(30, 0);
+            given(courseTimeRepository.findByIdWithLock(1L)).willReturn(Optional.of(courseTime));
+
+            // when
+            courseTimeService.releaseSeat(1L);
+
+            // then
+            assertThat(courseTime.getCurrentEnrollment()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 차수")
+        void releaseSeat_fail_notFound() {
+            // given
+            given(courseTimeRepository.findByIdWithLock(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> courseTimeService.releaseSeat(999L))
+                    .isInstanceOf(CourseTimeNotFoundException.class);
+        }
+    }
+
+    // ==================== Public API 테스트 ====================
+
+    @Nested
+    @DisplayName("getCapacity - 정원 조회")
+    class GetCapacity {
+
+        @Test
+        @DisplayName("성공 - 정원 조회 (제한 있음)")
+        void getCapacity_success_limited() {
+            // given
+            CourseTime courseTime = createTestCourseTime(30, 10);
+            given(courseTimeRepository.findById(1L)).willReturn(Optional.of(courseTime));
+
+            // when
+            CapacityResponse response = courseTimeService.getCapacity(1L);
+
+            // then
+            assertThat(response.capacity()).isEqualTo(30);
+            assertThat(response.currentEnrollment()).isEqualTo(10);
+            assertThat(response.availableSeats()).isEqualTo(20);
+            assertThat(response.unlimited()).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공 - 정원 조회 (무제한)")
+        void getCapacity_success_unlimited() {
+            // given
+            CourseTime courseTime = createTestCourseTime(null, 100);
+            given(courseTimeRepository.findById(1L)).willReturn(Optional.of(courseTime));
+
+            // when
+            CapacityResponse response = courseTimeService.getCapacity(1L);
+
+            // then
+            assertThat(response.capacity()).isNull();
+            assertThat(response.currentEnrollment()).isEqualTo(100);
+            assertThat(response.availableSeats()).isNull();
+            assertThat(response.unlimited()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("getPrice - 가격 조회")
+    class GetPrice {
+
+        @Test
+        @DisplayName("성공 - 가격 조회 (유료)")
+        void getPrice_success_paid() {
+            // given
+            CourseTime courseTime = createTestCourseTime(30, 0);
+            given(courseTimeRepository.findById(1L)).willReturn(Optional.of(courseTime));
+
+            // when
+            PriceResponse response = courseTimeService.getPrice(1L);
+
+            // then
+            assertThat(response.price()).isEqualByComparingTo(new BigDecimal("100000"));
+            assertThat(response.free()).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공 - 가격 조회 (무료)")
+        void getPrice_success_free() {
+            // given
+            CourseTime courseTime = CourseTime.create(
+                    "무료 차수",
+                    DeliveryType.ONLINE,
+                    LocalDate.now(),
+                    LocalDate.now().plusDays(7),
+                    LocalDate.now().plusDays(7),
+                    LocalDate.now().plusDays(30),
+                    30,
+                    null,
+                    EnrollmentMethod.FIRST_COME,
+                    80,
+                    BigDecimal.ZERO,
+                    true,
+                    null,
+                    true,
+                    1L
+            );
+            given(courseTimeRepository.findById(1L)).willReturn(Optional.of(courseTime));
+
+            // when
+            PriceResponse response = courseTimeService.getPrice(1L);
+
+            // then
+            assertThat(response.price()).isEqualByComparingTo(BigDecimal.ZERO);
+            assertThat(response.free()).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

TS 모듈의 정원 관리 기능 및 Public API를 구현합니다.

## Related Issue

- Closes #28

## Changes

- 좌석 점유/해제 내부 메서드 구현 (`occupySeat`, `releaseSeat`)
- 비관적 락(SELECT FOR UPDATE) 적용으로 동시성 제어
- Public API 추가 (`GET /api/ts/course-times/{id}/capacity`, `GET /api/ts/course-times/{id}/price`)
- Response DTO 추가 (`CapacityResponse`, `PriceResponse`)
- Service 단위 테스트 및 Controller 통합 테스트 작성

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- `occupySeat()`, `releaseSeat()`는 SIS 모듈에서 호출할 내부 메서드입니다
- Public API는 인증 없이 접근 가능합니다 (permitAll)
- 비즈니스 규칙: capacity=null이면 무제한 정원