### PR TITLE
feat: 콘텐츠 썸네일 자동 생성 기능 (#54)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+bin/
 .gradle/
 .idea/
 *.jar

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // Thumbnail generation
+    implementation 'org.apache.pdfbox:pdfbox:3.0.3'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/mzc/lp/domain/content/dto/response/ContentListResponse.java
+++ b/src/main/java/com/mzc/lp/domain/content/dto/response/ContentListResponse.java
@@ -13,6 +13,7 @@ public record ContentListResponse(
         Long fileSize,
         Integer duration,
         String resolution,
+        String thumbnailPath,
         LocalDateTime createdAt
 ) {
     public static ContentListResponse from(Content content) {
@@ -23,6 +24,7 @@ public record ContentListResponse(
                 content.getFileSize(),
                 content.getDuration(),
                 content.getResolution(),
+                content.getThumbnailPath(),
                 content.getCreatedAt() != null
                         ? LocalDateTime.ofInstant(content.getCreatedAt(), ZoneId.systemDefault())
                         : null

--- a/src/main/java/com/mzc/lp/domain/content/dto/response/ContentResponse.java
+++ b/src/main/java/com/mzc/lp/domain/content/dto/response/ContentResponse.java
@@ -17,6 +17,7 @@ public record ContentResponse(
         Integer pageCount,
         String externalUrl,
         String filePath,
+        String thumbnailPath,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -32,6 +33,7 @@ public record ContentResponse(
                 content.getPageCount(),
                 content.getExternalUrl(),
                 content.getFilePath(),
+                content.getThumbnailPath(),
                 content.getCreatedAt() != null
                         ? LocalDateTime.ofInstant(content.getCreatedAt(), ZoneId.systemDefault())
                         : null,

--- a/src/main/java/com/mzc/lp/domain/content/entity/Content.java
+++ b/src/main/java/com/mzc/lp/domain/content/entity/Content.java
@@ -45,6 +45,9 @@ public class Content extends TenantEntity {
     @Column(name = "file_path", length = 1000)
     private String filePath;
 
+    @Column(name = "thumbnail_path", length = 1000)
+    private String thumbnailPath;
+
     // 정적 팩토리 메서드 - 파일 업로드용
     public static Content createFile(String originalFileName, String storedFileName,
                                      ContentType contentType, Long fileSize, String filePath) {
@@ -112,5 +115,10 @@ public class Content extends TenantEntity {
         this.storedFileName = storedFileName;
         this.fileSize = fileSize;
         this.filePath = filePath;
+    }
+
+    // 비즈니스 메서드 - 썸네일 설정
+    public void setThumbnailPath(String thumbnailPath) {
+        this.thumbnailPath = thumbnailPath;
     }
 }

--- a/src/main/java/com/mzc/lp/domain/content/service/ThumbnailService.java
+++ b/src/main/java/com/mzc/lp/domain/content/service/ThumbnailService.java
@@ -1,0 +1,44 @@
+package com.mzc.lp.domain.content.service;
+
+import com.mzc.lp.domain.content.constant.ContentType;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+public interface ThumbnailService {
+
+    /**
+     * 콘텐츠 타입에 따라 썸네일 생성
+     * @param sourcePath 원본 파일 경로
+     * @param contentType 콘텐츠 타입
+     * @return 생성된 썸네일 경로 (생성 실패 시 empty)
+     */
+    Optional<String> generateThumbnail(Path sourcePath, ContentType contentType);
+
+    /**
+     * 동영상 썸네일 생성 (ffmpeg 사용)
+     * @param videoPath 동영상 파일 경로
+     * @return 썸네일 경로
+     */
+    Optional<String> generateVideoThumbnail(Path videoPath);
+
+    /**
+     * 이미지 썸네일 생성 (리사이즈)
+     * @param imagePath 이미지 파일 경로
+     * @return 썸네일 경로
+     */
+    Optional<String> generateImageThumbnail(Path imagePath);
+
+    /**
+     * PDF 문서 첫 페이지 썸네일 생성
+     * @param pdfPath PDF 파일 경로
+     * @return 썸네일 경로
+     */
+    Optional<String> generatePdfThumbnail(Path pdfPath);
+
+    /**
+     * 썸네일 삭제
+     * @param thumbnailPath 썸네일 경로
+     */
+    void deleteThumbnail(String thumbnailPath);
+}

--- a/src/main/java/com/mzc/lp/domain/content/service/ThumbnailServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/content/service/ThumbnailServiceImpl.java
@@ -1,0 +1,223 @@
+package com.mzc.lp.domain.content.service;
+
+import com.mzc.lp.domain.content.constant.ContentType;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+public class ThumbnailServiceImpl implements ThumbnailService {
+
+    private static final int THUMBNAIL_WIDTH = 320;
+    private static final int THUMBNAIL_HEIGHT = 180;
+    private static final String THUMBNAIL_FORMAT = "jpg";
+
+    private final Path thumbnailPath;
+    private final String ffmpegPath;
+
+    public ThumbnailServiceImpl(
+            @Value("${file.upload-dir:./uploads}") String uploadDir,
+            @Value("${thumbnail.ffmpeg-path:ffmpeg}") String ffmpegPath) {
+        this.thumbnailPath = Paths.get(uploadDir).resolve("thumbnails").toAbsolutePath().normalize();
+        this.ffmpegPath = ffmpegPath;
+    }
+
+    @PostConstruct
+    public void init() {
+        try {
+            Files.createDirectories(this.thumbnailPath);
+            log.info("Thumbnail storage initialized at: {}", this.thumbnailPath);
+        } catch (IOException e) {
+            log.error("Could not create thumbnail directory", e);
+        }
+    }
+
+    @Override
+    public Optional<String> generateThumbnail(Path sourcePath, ContentType contentType) {
+        return switch (contentType) {
+            case VIDEO -> generateVideoThumbnail(sourcePath);
+            case IMAGE -> generateImageThumbnail(sourcePath);
+            case DOCUMENT -> {
+                String extension = getFileExtension(sourcePath.getFileName().toString());
+                if ("pdf".equalsIgnoreCase(extension)) {
+                    yield generatePdfThumbnail(sourcePath);
+                }
+                yield Optional.empty();
+            }
+            default -> Optional.empty();
+        };
+    }
+
+    @Override
+    public Optional<String> generateVideoThumbnail(Path videoPath) {
+        try {
+            String outputFileName = generateThumbnailFileName();
+            Path outputPath = getThumbnailOutputPath(outputFileName);
+
+            // ffmpeg -i input.mp4 -ss 00:00:01 -vframes 1 -vf "scale=320:180" output.jpg
+            ProcessBuilder pb = new ProcessBuilder(
+                    ffmpegPath,
+                    "-i", videoPath.toString(),
+                    "-ss", "00:00:01",
+                    "-vframes", "1",
+                    "-vf", String.format("scale=%d:%d:force_original_aspect_ratio=decrease,pad=%d:%d:(ow-iw)/2:(oh-ih)/2",
+                            THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT),
+                    "-y",
+                    outputPath.toString()
+            );
+            pb.redirectErrorStream(true);
+
+            Process process = pb.start();
+            boolean finished = process.waitFor(30, TimeUnit.SECONDS);
+
+            if (finished && process.exitValue() == 0 && Files.exists(outputPath)) {
+                String relativePath = "/uploads/thumbnails/" + getDatePath() + "/" + outputFileName;
+                log.info("Video thumbnail generated: {}", relativePath);
+                return Optional.of(relativePath);
+            } else {
+                log.warn("Failed to generate video thumbnail for: {}", videoPath);
+                return Optional.empty();
+            }
+        } catch (Exception e) {
+            log.error("Error generating video thumbnail: {}", videoPath, e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<String> generateImageThumbnail(Path imagePath) {
+        try {
+            BufferedImage originalImage = ImageIO.read(imagePath.toFile());
+            if (originalImage == null) {
+                log.warn("Could not read image: {}", imagePath);
+                return Optional.empty();
+            }
+
+            BufferedImage thumbnail = resizeImage(originalImage, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
+
+            String outputFileName = generateThumbnailFileName();
+            Path outputPath = getThumbnailOutputPath(outputFileName);
+
+            ImageIO.write(thumbnail, THUMBNAIL_FORMAT, outputPath.toFile());
+
+            String relativePath = "/uploads/thumbnails/" + getDatePath() + "/" + outputFileName;
+            log.info("Image thumbnail generated: {}", relativePath);
+            return Optional.of(relativePath);
+        } catch (Exception e) {
+            log.error("Error generating image thumbnail: {}", imagePath, e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<String> generatePdfThumbnail(Path pdfPath) {
+        try (PDDocument document = Loader.loadPDF(pdfPath.toFile())) {
+            PDFRenderer renderer = new PDFRenderer(document);
+            BufferedImage pageImage = renderer.renderImageWithDPI(0, 72);
+
+            BufferedImage thumbnail = resizeImage(pageImage, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
+
+            String outputFileName = generateThumbnailFileName();
+            Path outputPath = getThumbnailOutputPath(outputFileName);
+
+            ImageIO.write(thumbnail, THUMBNAIL_FORMAT, outputPath.toFile());
+
+            String relativePath = "/uploads/thumbnails/" + getDatePath() + "/" + outputFileName;
+            log.info("PDF thumbnail generated: {}", relativePath);
+            return Optional.of(relativePath);
+        } catch (Exception e) {
+            log.error("Error generating PDF thumbnail: {}", pdfPath, e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void deleteThumbnail(String thumbnailPathStr) {
+        if (thumbnailPathStr == null || thumbnailPathStr.isBlank()) {
+            return;
+        }
+
+        try {
+            String relativePath = thumbnailPathStr.startsWith("/uploads/thumbnails/")
+                    ? thumbnailPathStr.substring("/uploads/thumbnails/".length())
+                    : thumbnailPathStr;
+
+            Path file = this.thumbnailPath.resolve(relativePath).normalize();
+            Files.deleteIfExists(file);
+            log.info("Thumbnail deleted: {}", thumbnailPathStr);
+        } catch (IOException e) {
+            log.error("Failed to delete thumbnail: {}", thumbnailPathStr, e);
+        }
+    }
+
+    private BufferedImage resizeImage(BufferedImage original, int targetWidth, int targetHeight) {
+        double aspectRatio = (double) original.getWidth() / original.getHeight();
+        double targetRatio = (double) targetWidth / targetHeight;
+
+        int width, height;
+        if (aspectRatio > targetRatio) {
+            width = targetWidth;
+            height = (int) (targetWidth / aspectRatio);
+        } else {
+            height = targetHeight;
+            width = (int) (targetHeight * aspectRatio);
+        }
+
+        BufferedImage resized = new BufferedImage(targetWidth, targetHeight, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g2d = resized.createGraphics();
+
+        g2d.setColor(Color.WHITE);
+        g2d.fillRect(0, 0, targetWidth, targetHeight);
+
+        g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+        int x = (targetWidth - width) / 2;
+        int y = (targetHeight - height) / 2;
+        g2d.drawImage(original, x, y, width, height, null);
+        g2d.dispose();
+
+        return resized;
+    }
+
+    private String generateThumbnailFileName() {
+        return UUID.randomUUID().toString() + "." + THUMBNAIL_FORMAT;
+    }
+
+    private String getDatePath() {
+        LocalDate now = LocalDate.now();
+        return String.format("%d/%02d", now.getYear(), now.getMonthValue());
+    }
+
+    private Path getThumbnailOutputPath(String fileName) throws IOException {
+        Path datePath = this.thumbnailPath.resolve(getDatePath());
+        Files.createDirectories(datePath);
+        return datePath.resolve(fileName);
+    }
+
+    private String getFileExtension(String fileName) {
+        int dotIndex = fileName.lastIndexOf('.');
+        if (dotIndex > 0 && dotIndex < fileName.length() - 1) {
+            return fileName.substring(dotIndex + 1).toLowerCase();
+        }
+        return "";
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/content/service/ThumbnailServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/content/service/ThumbnailServiceTest.java
@@ -1,0 +1,186 @@
+package com.mzc.lp.domain.content.service;
+
+import com.mzc.lp.domain.content.constant.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ThumbnailServiceTest {
+
+    private ThumbnailService thumbnailService;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        thumbnailService = new ThumbnailServiceImpl(tempDir.toString(), "ffmpeg");
+    }
+
+    @Nested
+    @DisplayName("이미지 썸네일 생성")
+    class GenerateImageThumbnail {
+
+        @Test
+        @DisplayName("성공 - JPG 이미지 썸네일 생성")
+        void generateImageThumbnail_success_jpg() throws Exception {
+            // given
+            Path imagePath = createTestImage("test.jpg", "jpg", 800, 600);
+
+            // when
+            Optional<String> result = thumbnailService.generateImageThumbnail(imagePath);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get()).contains("/uploads/thumbnails/");
+            assertThat(result.get()).endsWith(".jpg");
+        }
+
+        @Test
+        @DisplayName("성공 - PNG 이미지 썸네일 생성")
+        void generateImageThumbnail_success_png() throws Exception {
+            // given
+            Path imagePath = createTestImage("test.png", "png", 1920, 1080);
+
+            // when
+            Optional<String> result = thumbnailService.generateImageThumbnail(imagePath);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get()).contains("/uploads/thumbnails/");
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 파일")
+        void generateImageThumbnail_fail_fileNotFound() {
+            // given
+            Path nonExistentPath = tempDir.resolve("non-existent.jpg");
+
+            // when
+            Optional<String> result = thumbnailService.generateImageThumbnail(nonExistentPath);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("콘텐츠 타입별 썸네일 생성")
+    class GenerateThumbnail {
+
+        @Test
+        @DisplayName("IMAGE 타입 - 썸네일 생성")
+        void generateThumbnail_image() throws Exception {
+            // given
+            Path imagePath = createTestImage("test.jpg", "jpg", 640, 480);
+
+            // when
+            Optional<String> result = thumbnailService.generateThumbnail(imagePath, ContentType.IMAGE);
+
+            // then
+            assertThat(result).isPresent();
+        }
+
+        @Test
+        @DisplayName("EXTERNAL_LINK 타입 - 썸네일 미생성")
+        void generateThumbnail_externalLink() throws Exception {
+            // given
+            Path dummyPath = tempDir.resolve("dummy.txt");
+            Files.writeString(dummyPath, "dummy content");
+
+            // when
+            Optional<String> result = thumbnailService.generateThumbnail(dummyPath, ContentType.EXTERNAL_LINK);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("AUDIO 타입 - 썸네일 미생성")
+        void generateThumbnail_audio() throws Exception {
+            // given
+            Path dummyPath = tempDir.resolve("audio.mp3");
+            Files.writeString(dummyPath, "dummy audio content");
+
+            // when
+            Optional<String> result = thumbnailService.generateThumbnail(dummyPath, ContentType.AUDIO);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("DOCUMENT (non-PDF) - 썸네일 미생성")
+        void generateThumbnail_document_nonPdf() throws Exception {
+            // given
+            Path docPath = tempDir.resolve("document.docx");
+            Files.writeString(docPath, "dummy document content");
+
+            // when
+            Optional<String> result = thumbnailService.generateThumbnail(docPath, ContentType.DOCUMENT);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("썸네일 삭제")
+    class DeleteThumbnail {
+
+        @Test
+        @DisplayName("성공 - 썸네일 삭제")
+        void deleteThumbnail_success() throws Exception {
+            // given
+            Path imagePath = createTestImage("test.jpg", "jpg", 320, 180);
+            Optional<String> thumbnailPath = thumbnailService.generateImageThumbnail(imagePath);
+            assertThat(thumbnailPath).isPresent();
+
+            // when
+            thumbnailService.deleteThumbnail(thumbnailPath.get());
+
+            // then - 삭제 후 에러 없이 완료되면 성공
+        }
+
+        @Test
+        @DisplayName("null 경로 - 에러 없이 무시")
+        void deleteThumbnail_nullPath() {
+            // when & then - 에러 없이 완료
+            thumbnailService.deleteThumbnail(null);
+        }
+
+        @Test
+        @DisplayName("빈 경로 - 에러 없이 무시")
+        void deleteThumbnail_emptyPath() {
+            // when & then - 에러 없이 완료
+            thumbnailService.deleteThumbnail("");
+        }
+    }
+
+    // 테스트용 이미지 파일 생성 헬퍼
+    private Path createTestImage(String fileName, String format, int width, int height) throws Exception {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g2d = image.createGraphics();
+        g2d.setColor(Color.BLUE);
+        g2d.fillRect(0, 0, width, height);
+        g2d.setColor(Color.WHITE);
+        g2d.drawString("Test Image", 10, 30);
+        g2d.dispose();
+
+        Path imagePath = tempDir.resolve(fileName);
+        ImageIO.write(image, format, imagePath.toFile());
+        return imagePath;
+    }
+}


### PR DESCRIPTION
## Summary
- VIDEO, IMAGE, PDF 콘텐츠 업로드 시 썸네일 자동 생성
- FFmpeg(동영상), ImageIO(이미지), PDFBox(PDF) 라이브러리 활용
- 썸네일 크기: 320x180 (16:9 비율)

## Changes
- `ThumbnailService` 인터페이스 및 구현체 추가
- `Content` 엔티티에 `thumbnailPath` 필드 추가
- `ContentResponse`, `ContentListResponse`에 `thumbnailPath` 추가
- `ContentServiceImpl`에 썸네일 생성/삭제 로직 연동
- `build.gradle`에 PDFBox 의존성 추가

## Test
- [x] ThumbnailServiceTest 단위 테스트 통과
- [x] 빌드 성공

## Related
- Closes #54