### PR TITLE
feat(sis): 수강신청 CRUD API 구현

### DIFF
--- a/src/main/java/com/mzc/lp/domain/student/controller/EnrollmentController.java
+++ b/src/main/java/com/mzc/lp/domain/student/controller/EnrollmentController.java
@@ -1,0 +1,172 @@
+package com.mzc.lp.domain.student.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.student.constant.EnrollmentStatus;
+import com.mzc.lp.domain.student.dto.request.CompleteEnrollmentRequest;
+import com.mzc.lp.domain.student.dto.request.ForceEnrollRequest;
+import com.mzc.lp.domain.student.dto.request.UpdateEnrollmentStatusRequest;
+import com.mzc.lp.domain.student.dto.request.UpdateProgressRequest;
+import com.mzc.lp.domain.student.dto.response.EnrollmentDetailResponse;
+import com.mzc.lp.domain.student.dto.response.EnrollmentResponse;
+import com.mzc.lp.domain.student.dto.response.ForceEnrollResultResponse;
+import com.mzc.lp.domain.student.service.EnrollmentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class EnrollmentController {
+
+    private final EnrollmentService enrollmentService;
+
+    // ========== 수강 신청 API (TS 기반) ==========
+
+    /**
+     * 수강 신청
+     */
+    @PostMapping("/api/ts/course-times/{courseTimeId}/enrollments")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<EnrollmentDetailResponse>> enroll(
+            @PathVariable Long courseTimeId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        EnrollmentDetailResponse response = enrollmentService.enroll(courseTimeId, principal.id());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 강제 배정 (필수 교육)
+     */
+    @PostMapping("/api/ts/course-times/{courseTimeId}/enrollments/force")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<ForceEnrollResultResponse>> forceEnroll(
+            @PathVariable Long courseTimeId,
+            @Valid @RequestBody ForceEnrollRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        ForceEnrollResultResponse response = enrollmentService.forceEnroll(courseTimeId, request, principal.id());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 차수별 수강생 목록 조회
+     */
+    @GetMapping("/api/ts/course-times/{courseTimeId}/enrollments")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<Page<EnrollmentResponse>>> getEnrollmentsByCourseTime(
+            @PathVariable Long courseTimeId,
+            @RequestParam(required = false) EnrollmentStatus status,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<EnrollmentResponse> response = enrollmentService.getEnrollmentsByCourseTime(courseTimeId, status, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // ========== 수강 관리 API ==========
+
+    /**
+     * 수강 상세 조회
+     */
+    @GetMapping("/api/enrollments/{enrollmentId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<EnrollmentDetailResponse>> getEnrollment(
+            @PathVariable Long enrollmentId
+    ) {
+        EnrollmentDetailResponse response = enrollmentService.getEnrollment(enrollmentId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 진도율 업데이트
+     */
+    @PatchMapping("/api/enrollments/{enrollmentId}/progress")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<EnrollmentResponse>> updateProgress(
+            @PathVariable Long enrollmentId,
+            @Valid @RequestBody UpdateProgressRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        EnrollmentResponse response = enrollmentService.updateProgress(enrollmentId, request, principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 수료 처리
+     */
+    @PatchMapping("/api/enrollments/{enrollmentId}/complete")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<EnrollmentDetailResponse>> completeEnrollment(
+            @PathVariable Long enrollmentId,
+            @Valid @RequestBody CompleteEnrollmentRequest request
+    ) {
+        EnrollmentDetailResponse response = enrollmentService.completeEnrollment(enrollmentId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 상태 변경 (관리자)
+     */
+    @PatchMapping("/api/enrollments/{enrollmentId}/status")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<EnrollmentDetailResponse>> updateStatus(
+            @PathVariable Long enrollmentId,
+            @Valid @RequestBody UpdateEnrollmentStatusRequest request
+    ) {
+        EnrollmentDetailResponse response = enrollmentService.updateStatus(enrollmentId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 수강 취소
+     */
+    @DeleteMapping("/api/enrollments/{enrollmentId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> cancelEnrollment(
+            @PathVariable Long enrollmentId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        enrollmentService.cancelEnrollment(enrollmentId, principal.id());
+        return ResponseEntity.noContent().build();
+    }
+
+    // ========== 사용자별 수강 조회 API ==========
+
+    /**
+     * 내 수강 목록 조회
+     */
+    @GetMapping("/api/users/me/enrollments")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<Page<EnrollmentResponse>>> getMyEnrollments(
+            @RequestParam(required = false) EnrollmentStatus status,
+            @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Page<EnrollmentResponse> response = enrollmentService.getMyEnrollments(principal.id(), status, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 사용자별 수강 이력 조회 (관리자)
+     */
+    @GetMapping("/api/users/{userId}/enrollments")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<Page<EnrollmentResponse>>> getEnrollmentsByUser(
+            @PathVariable Long userId,
+            @RequestParam(required = false) EnrollmentStatus status,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<EnrollmentResponse> response = enrollmentService.getEnrollmentsByUser(userId, status, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/student/dto/request/CompleteEnrollmentRequest.java
+++ b/src/main/java/com/mzc/lp/domain/student/dto/request/CompleteEnrollmentRequest.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.student.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record CompleteEnrollmentRequest(
+        @Min(value = 0, message = "점수는 0 이상이어야 합니다")
+        @Max(value = 100, message = "점수는 100 이하여야 합니다")
+        Integer score
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/student/dto/request/ForceEnrollRequest.java
+++ b/src/main/java/com/mzc/lp/domain/student/dto/request/ForceEnrollRequest.java
@@ -1,0 +1,16 @@
+package com.mzc.lp.domain.student.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record ForceEnrollRequest(
+        @NotEmpty(message = "사용자 ID 목록은 필수입니다")
+        @Size(max = 100, message = "한 번에 최대 100명까지 배정 가능합니다")
+        List<Long> userIds,
+
+        @Size(max = 500, message = "사유는 500자 이내로 입력해주세요")
+        String reason
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/student/dto/request/UpdateEnrollmentStatusRequest.java
+++ b/src/main/java/com/mzc/lp/domain/student/dto/request/UpdateEnrollmentStatusRequest.java
@@ -1,0 +1,14 @@
+package com.mzc.lp.domain.student.dto.request;
+
+import com.mzc.lp.domain.student.constant.EnrollmentStatus;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UpdateEnrollmentStatusRequest(
+        @NotNull(message = "상태는 필수입니다")
+        EnrollmentStatus status,
+
+        @Size(max = 500, message = "사유는 500자 이내로 입력해주세요")
+        String reason
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/student/dto/request/UpdateProgressRequest.java
+++ b/src/main/java/com/mzc/lp/domain/student/dto/request/UpdateProgressRequest.java
@@ -1,0 +1,13 @@
+package com.mzc.lp.domain.student.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateProgressRequest(
+        @NotNull(message = "진도율은 필수입니다")
+        @Min(value = 0, message = "진도율은 0 이상이어야 합니다")
+        @Max(value = 100, message = "진도율은 100 이하여야 합니다")
+        Integer progressPercent
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/student/dto/response/EnrollmentDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/student/dto/response/EnrollmentDetailResponse.java
@@ -1,0 +1,39 @@
+package com.mzc.lp.domain.student.dto.response;
+
+import com.mzc.lp.domain.student.constant.EnrollmentStatus;
+import com.mzc.lp.domain.student.constant.EnrollmentType;
+import com.mzc.lp.domain.student.entity.Enrollment;
+
+import java.time.Instant;
+
+public record EnrollmentDetailResponse(
+        Long id,
+        Long userId,
+        Long courseTimeId,
+        Instant enrolledAt,
+        Long enrolledBy,
+        EnrollmentType type,
+        EnrollmentStatus status,
+        Integer progressPercent,
+        Integer score,
+        Instant completedAt,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static EnrollmentDetailResponse from(Enrollment enrollment) {
+        return new EnrollmentDetailResponse(
+                enrollment.getId(),
+                enrollment.getUserId(),
+                enrollment.getCourseTimeId(),
+                enrollment.getEnrolledAt(),
+                enrollment.getEnrolledBy(),
+                enrollment.getType(),
+                enrollment.getStatus(),
+                enrollment.getProgressPercent(),
+                enrollment.getScore(),
+                enrollment.getCompletedAt(),
+                enrollment.getCreatedAt(),
+                enrollment.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/student/dto/response/EnrollmentResponse.java
+++ b/src/main/java/com/mzc/lp/domain/student/dto/response/EnrollmentResponse.java
@@ -1,0 +1,33 @@
+package com.mzc.lp.domain.student.dto.response;
+
+import com.mzc.lp.domain.student.constant.EnrollmentStatus;
+import com.mzc.lp.domain.student.constant.EnrollmentType;
+import com.mzc.lp.domain.student.entity.Enrollment;
+
+import java.time.Instant;
+
+public record EnrollmentResponse(
+        Long id,
+        Long userId,
+        Long courseTimeId,
+        Instant enrolledAt,
+        EnrollmentType type,
+        EnrollmentStatus status,
+        Integer progressPercent,
+        Integer score,
+        Instant completedAt
+) {
+    public static EnrollmentResponse from(Enrollment enrollment) {
+        return new EnrollmentResponse(
+                enrollment.getId(),
+                enrollment.getUserId(),
+                enrollment.getCourseTimeId(),
+                enrollment.getEnrolledAt(),
+                enrollment.getType(),
+                enrollment.getStatus(),
+                enrollment.getProgressPercent(),
+                enrollment.getScore(),
+                enrollment.getCompletedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/student/dto/response/ForceEnrollResultResponse.java
+++ b/src/main/java/com/mzc/lp/domain/student/dto/response/ForceEnrollResultResponse.java
@@ -1,0 +1,28 @@
+package com.mzc.lp.domain.student.dto.response;
+
+import java.util.List;
+
+public record ForceEnrollResultResponse(
+        int successCount,
+        int failCount,
+        List<EnrollmentResponse> enrollments,
+        List<FailureDetail> failures
+) {
+    public record FailureDetail(
+            Long userId,
+            String reason
+    ) {
+    }
+
+    public static ForceEnrollResultResponse of(
+            List<EnrollmentResponse> enrollments,
+            List<FailureDetail> failures
+    ) {
+        return new ForceEnrollResultResponse(
+                enrollments.size(),
+                failures.size(),
+                enrollments,
+                failures
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/student/entity/Enrollment.java
+++ b/src/main/java/com/mzc/lp/domain/student/entity/Enrollment.java
@@ -8,7 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(name = "sis_enrollments",
@@ -37,7 +37,7 @@ public class Enrollment extends TenantEntity {
     private Long courseTimeId;
 
     @Column(name = "enrolled_at", nullable = false)
-    private LocalDateTime enrolledAt;
+    private Instant enrolledAt;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
@@ -53,7 +53,7 @@ public class Enrollment extends TenantEntity {
     private Integer score;
 
     @Column(name = "completed_at")
-    private LocalDateTime completedAt;
+    private Instant completedAt;
 
     @Column(name = "enrolled_by")
     private Long enrolledBy;
@@ -63,7 +63,7 @@ public class Enrollment extends TenantEntity {
         Enrollment enrollment = new Enrollment();
         enrollment.userId = userId;
         enrollment.courseTimeId = courseTimeId;
-        enrollment.enrolledAt = LocalDateTime.now();
+        enrollment.enrolledAt = Instant.now();
         enrollment.type = EnrollmentType.VOLUNTARY;
         enrollment.status = EnrollmentStatus.ENROLLED;
         enrollment.progressPercent = 0;
@@ -76,7 +76,7 @@ public class Enrollment extends TenantEntity {
         Enrollment enrollment = new Enrollment();
         enrollment.userId = userId;
         enrollment.courseTimeId = courseTimeId;
-        enrollment.enrolledAt = LocalDateTime.now();
+        enrollment.enrolledAt = Instant.now();
         enrollment.type = EnrollmentType.MANDATORY;
         enrollment.status = EnrollmentStatus.ENROLLED;
         enrollment.progressPercent = 0;
@@ -96,7 +96,7 @@ public class Enrollment extends TenantEntity {
     public void complete(Integer score) {
         this.status = EnrollmentStatus.COMPLETED;
         this.score = score;
-        this.completedAt = LocalDateTime.now();
+        this.completedAt = Instant.now();
         this.progressPercent = 100;
     }
 
@@ -111,7 +111,7 @@ public class Enrollment extends TenantEntity {
     public void updateStatus(EnrollmentStatus status) {
         this.status = status;
         if (status == EnrollmentStatus.COMPLETED) {
-            this.completedAt = LocalDateTime.now();
+            this.completedAt = Instant.now();
         }
     }
 

--- a/src/main/java/com/mzc/lp/domain/student/service/EnrollmentService.java
+++ b/src/main/java/com/mzc/lp/domain/student/service/EnrollmentService.java
@@ -1,0 +1,45 @@
+package com.mzc.lp.domain.student.service;
+
+import com.mzc.lp.domain.student.constant.EnrollmentStatus;
+import com.mzc.lp.domain.student.dto.request.CompleteEnrollmentRequest;
+import com.mzc.lp.domain.student.dto.request.ForceEnrollRequest;
+import com.mzc.lp.domain.student.dto.request.UpdateEnrollmentStatusRequest;
+import com.mzc.lp.domain.student.dto.request.UpdateProgressRequest;
+import com.mzc.lp.domain.student.dto.response.EnrollmentDetailResponse;
+import com.mzc.lp.domain.student.dto.response.EnrollmentResponse;
+import com.mzc.lp.domain.student.dto.response.ForceEnrollResultResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface EnrollmentService {
+
+    // 수강 신청
+    EnrollmentDetailResponse enroll(Long courseTimeId, Long userId);
+
+    // 강제 배정 (필수 교육)
+    ForceEnrollResultResponse forceEnroll(Long courseTimeId, ForceEnrollRequest request, Long operatorId);
+
+    // 수강 상세 조회
+    EnrollmentDetailResponse getEnrollment(Long enrollmentId);
+
+    // 차수별 수강생 목록 조회
+    Page<EnrollmentResponse> getEnrollmentsByCourseTime(Long courseTimeId, EnrollmentStatus status, Pageable pageable);
+
+    // 내 수강 목록 조회
+    Page<EnrollmentResponse> getMyEnrollments(Long userId, EnrollmentStatus status, Pageable pageable);
+
+    // 사용자별 수강 이력 조회 (관리자)
+    Page<EnrollmentResponse> getEnrollmentsByUser(Long userId, EnrollmentStatus status, Pageable pageable);
+
+    // 진도율 업데이트
+    EnrollmentResponse updateProgress(Long enrollmentId, UpdateProgressRequest request, Long userId);
+
+    // 수료 처리
+    EnrollmentDetailResponse completeEnrollment(Long enrollmentId, CompleteEnrollmentRequest request);
+
+    // 상태 변경 (관리자)
+    EnrollmentDetailResponse updateStatus(Long enrollmentId, UpdateEnrollmentStatusRequest request);
+
+    // 수강 취소
+    void cancelEnrollment(Long enrollmentId, Long userId);
+}

--- a/src/main/java/com/mzc/lp/domain/student/service/EnrollmentServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/student/service/EnrollmentServiceImpl.java
@@ -1,0 +1,244 @@
+package com.mzc.lp.domain.student.service;
+
+import com.mzc.lp.domain.student.constant.EnrollmentStatus;
+import com.mzc.lp.domain.student.dto.request.CompleteEnrollmentRequest;
+import com.mzc.lp.domain.student.dto.request.ForceEnrollRequest;
+import com.mzc.lp.domain.student.dto.request.UpdateEnrollmentStatusRequest;
+import com.mzc.lp.domain.student.dto.request.UpdateProgressRequest;
+import com.mzc.lp.domain.student.dto.response.EnrollmentDetailResponse;
+import com.mzc.lp.domain.student.dto.response.EnrollmentResponse;
+import com.mzc.lp.domain.student.dto.response.ForceEnrollResultResponse;
+import com.mzc.lp.domain.student.entity.Enrollment;
+import com.mzc.lp.domain.student.exception.AlreadyEnrolledException;
+import com.mzc.lp.domain.student.exception.CannotCancelCompletedException;
+import com.mzc.lp.domain.student.exception.EnrollmentNotFoundException;
+import com.mzc.lp.domain.student.exception.EnrollmentPeriodClosedException;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.ts.exception.CourseTimeNotFoundException;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import com.mzc.lp.domain.ts.service.CourseTimeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EnrollmentServiceImpl implements EnrollmentService {
+
+    private final EnrollmentRepository enrollmentRepository;
+    private final CourseTimeRepository courseTimeRepository;
+    private final CourseTimeService courseTimeService;
+
+    @Override
+    @Transactional
+    public EnrollmentDetailResponse enroll(Long courseTimeId, Long userId) {
+        log.info("Enrolling user: userId={}, courseTimeId={}", userId, courseTimeId);
+
+        Long tenantId = getCurrentTenantId();
+
+        // 차수 조회 및 검증
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(courseTimeId, tenantId)
+                .orElseThrow(() -> new CourseTimeNotFoundException(courseTimeId));
+
+        // 수강 신청 가능 여부 체크
+        if (!courseTime.canEnroll()) {
+            throw new EnrollmentPeriodClosedException(courseTimeId);
+        }
+
+        // 중복 수강 체크
+        if (enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, tenantId)) {
+            throw new AlreadyEnrolledException(userId, courseTimeId);
+        }
+
+        // 정원 확보 (TS 서비스 호출 - 비관적 락)
+        courseTimeService.occupySeat(courseTimeId);
+
+        // 수강 생성
+        Enrollment enrollment = Enrollment.createVoluntary(userId, courseTimeId);
+        Enrollment savedEnrollment = enrollmentRepository.save(enrollment);
+
+        log.info("Enrollment created: id={}, userId={}, courseTimeId={}",
+                savedEnrollment.getId(), userId, courseTimeId);
+
+        return EnrollmentDetailResponse.from(savedEnrollment);
+    }
+
+    @Override
+    @Transactional
+    public ForceEnrollResultResponse forceEnroll(Long courseTimeId, ForceEnrollRequest request, Long operatorId) {
+        log.info("Force enrolling users: courseTimeId={}, userCount={}, operatorId={}",
+                courseTimeId, request.userIds().size(), operatorId);
+
+        Long tenantId = getCurrentTenantId();
+
+        // 차수 조회 및 검증
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(courseTimeId, tenantId)
+                .orElseThrow(() -> new CourseTimeNotFoundException(courseTimeId));
+
+        List<EnrollmentResponse> enrollments = new ArrayList<>();
+        List<ForceEnrollResultResponse.FailureDetail> failures = new ArrayList<>();
+
+        for (Long userId : request.userIds()) {
+            try {
+                // 중복 수강 체크
+                if (enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, tenantId)) {
+                    failures.add(new ForceEnrollResultResponse.FailureDetail(userId, "이미 수강 중입니다"));
+                    continue;
+                }
+
+                // 정원 확보 (강제 배정은 정원 초과 무시 가능하도록 직접 증가)
+                courseTime.incrementEnrollment();
+
+                // 수강 생성
+                Enrollment enrollment = Enrollment.createMandatory(userId, courseTimeId, operatorId);
+                Enrollment savedEnrollment = enrollmentRepository.save(enrollment);
+
+                enrollments.add(EnrollmentResponse.from(savedEnrollment));
+            } catch (Exception e) {
+                log.warn("Failed to force enroll user: userId={}, error={}", userId, e.getMessage());
+                failures.add(new ForceEnrollResultResponse.FailureDetail(userId, e.getMessage()));
+            }
+        }
+
+        log.info("Force enrollment completed: successCount={}, failCount={}",
+                enrollments.size(), failures.size());
+
+        return ForceEnrollResultResponse.of(enrollments, failures);
+    }
+
+    @Override
+    public EnrollmentDetailResponse getEnrollment(Long enrollmentId) {
+        log.debug("Getting enrollment: id={}", enrollmentId);
+
+        Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, getCurrentTenantId())
+                .orElseThrow(() -> new EnrollmentNotFoundException(enrollmentId));
+
+        return EnrollmentDetailResponse.from(enrollment);
+    }
+
+    @Override
+    public Page<EnrollmentResponse> getEnrollmentsByCourseTime(Long courseTimeId, EnrollmentStatus status, Pageable pageable) {
+        log.debug("Getting enrollments by course time: courseTimeId={}, status={}", courseTimeId, status);
+
+        Long tenantId = getCurrentTenantId();
+
+        if (status != null) {
+            return enrollmentRepository.findByCourseTimeIdAndStatusAndTenantId(courseTimeId, status, tenantId, pageable)
+                    .map(EnrollmentResponse::from);
+        }
+
+        return enrollmentRepository.findByCourseTimeIdAndTenantId(courseTimeId, tenantId, pageable)
+                .map(EnrollmentResponse::from);
+    }
+
+    @Override
+    public Page<EnrollmentResponse> getMyEnrollments(Long userId, EnrollmentStatus status, Pageable pageable) {
+        log.debug("Getting my enrollments: userId={}, status={}", userId, status);
+
+        Long tenantId = getCurrentTenantId();
+
+        if (status != null) {
+            return enrollmentRepository.findByUserIdAndStatusAndTenantId(userId, status, tenantId, pageable)
+                    .map(EnrollmentResponse::from);
+        }
+
+        return enrollmentRepository.findByUserIdAndTenantId(userId, tenantId, pageable)
+                .map(EnrollmentResponse::from);
+    }
+
+    @Override
+    public Page<EnrollmentResponse> getEnrollmentsByUser(Long userId, EnrollmentStatus status, Pageable pageable) {
+        log.debug("Getting enrollments by user: userId={}, status={}", userId, status);
+
+        // 관리자용 - 동일 로직
+        return getMyEnrollments(userId, status, pageable);
+    }
+
+    @Override
+    @Transactional
+    public EnrollmentResponse updateProgress(Long enrollmentId, UpdateProgressRequest request, Long userId) {
+        log.info("Updating progress: enrollmentId={}, progressPercent={}", enrollmentId, request.progressPercent());
+
+        Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, getCurrentTenantId())
+                .orElseThrow(() -> new EnrollmentNotFoundException(enrollmentId));
+
+        // 본인 확인 (또는 관리자)
+        // TODO: 권한 체크 로직 추가
+
+        enrollment.updateProgress(request.progressPercent());
+
+        log.info("Progress updated: enrollmentId={}, progressPercent={}",
+                enrollmentId, request.progressPercent());
+
+        return EnrollmentResponse.from(enrollment);
+    }
+
+    @Override
+    @Transactional
+    public EnrollmentDetailResponse completeEnrollment(Long enrollmentId, CompleteEnrollmentRequest request) {
+        log.info("Completing enrollment: enrollmentId={}, score={}", enrollmentId, request.score());
+
+        Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, getCurrentTenantId())
+                .orElseThrow(() -> new EnrollmentNotFoundException(enrollmentId));
+
+        enrollment.complete(request.score());
+
+        log.info("Enrollment completed: enrollmentId={}", enrollmentId);
+
+        return EnrollmentDetailResponse.from(enrollment);
+    }
+
+    @Override
+    @Transactional
+    public EnrollmentDetailResponse updateStatus(Long enrollmentId, UpdateEnrollmentStatusRequest request) {
+        log.info("Updating enrollment status: enrollmentId={}, status={}", enrollmentId, request.status());
+
+        Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, getCurrentTenantId())
+                .orElseThrow(() -> new EnrollmentNotFoundException(enrollmentId));
+
+        enrollment.updateStatus(request.status());
+
+        log.info("Enrollment status updated: enrollmentId={}, status={}", enrollmentId, request.status());
+
+        return EnrollmentDetailResponse.from(enrollment);
+    }
+
+    @Override
+    @Transactional
+    public void cancelEnrollment(Long enrollmentId, Long userId) {
+        log.info("Cancelling enrollment: enrollmentId={}, userId={}", enrollmentId, userId);
+
+        Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, getCurrentTenantId())
+                .orElseThrow(() -> new EnrollmentNotFoundException(enrollmentId));
+
+        // 본인 확인
+        // TODO: 관리자는 타인 취소 가능하도록 수정
+
+        // 수료 상태에서는 취소 불가
+        if (!enrollment.canCancel()) {
+            throw new CannotCancelCompletedException(enrollmentId);
+        }
+
+        // 정원 반환
+        courseTimeService.releaseSeat(enrollment.getCourseTimeId());
+
+        // 상태 변경
+        enrollment.drop();
+
+        log.info("Enrollment cancelled: enrollmentId={}", enrollmentId);
+    }
+
+    private Long getCurrentTenantId() {
+        // TODO: SecurityContext에서 tenantId 추출
+        return 1L;
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseControllerTest.java
@@ -483,7 +483,7 @@ class CourseControllerTest {
                     .andDo(print())
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.error.code").value("CM_COURSE_NOT_FOUND"));
+                    .andExpect(jsonPath("$.error.code").value("CM001"));
         }
     }
 
@@ -577,7 +577,7 @@ class CourseControllerTest {
                     .andDo(print())
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.error.code").value("CM_COURSE_NOT_FOUND"));
+                    .andExpect(jsonPath("$.error.code").value("CM001"));
         }
 
         @Test
@@ -661,7 +661,7 @@ class CourseControllerTest {
                     .andDo(print())
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.error.code").value("CM_COURSE_NOT_FOUND"));
+                    .andExpect(jsonPath("$.error.code").value("CM001"));
         }
 
         @Test

--- a/src/test/java/com/mzc/lp/domain/student/service/EnrollmentServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/student/service/EnrollmentServiceTest.java
@@ -1,0 +1,439 @@
+package com.mzc.lp.domain.student.service;
+
+import com.mzc.lp.domain.student.constant.EnrollmentStatus;
+import com.mzc.lp.domain.student.constant.EnrollmentType;
+import com.mzc.lp.domain.student.dto.request.CompleteEnrollmentRequest;
+import com.mzc.lp.domain.student.dto.request.ForceEnrollRequest;
+import com.mzc.lp.domain.student.dto.request.UpdateEnrollmentStatusRequest;
+import com.mzc.lp.domain.student.dto.request.UpdateProgressRequest;
+import com.mzc.lp.domain.student.dto.response.EnrollmentDetailResponse;
+import com.mzc.lp.domain.student.dto.response.EnrollmentResponse;
+import com.mzc.lp.domain.student.dto.response.ForceEnrollResultResponse;
+import com.mzc.lp.domain.student.entity.Enrollment;
+import com.mzc.lp.domain.student.exception.AlreadyEnrolledException;
+import com.mzc.lp.domain.student.exception.CannotCancelCompletedException;
+import com.mzc.lp.domain.student.exception.EnrollmentNotFoundException;
+import com.mzc.lp.domain.student.exception.EnrollmentPeriodClosedException;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.ts.constant.DeliveryType;
+import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import com.mzc.lp.domain.ts.service.CourseTimeService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EnrollmentServiceTest {
+
+    @InjectMocks
+    private EnrollmentServiceImpl enrollmentService;
+
+    @Mock
+    private EnrollmentRepository enrollmentRepository;
+
+    @Mock
+    private CourseTimeRepository courseTimeRepository;
+
+    @Mock
+    private CourseTimeService courseTimeService;
+
+    private static final Long TENANT_ID = 1L;
+
+    private CourseTime createTestCourseTime(boolean canEnroll) {
+        LocalDate enrollStart = LocalDate.now().minusDays(1);
+        LocalDate enrollEnd = LocalDate.now().plusDays(7);
+
+        CourseTime courseTime = CourseTime.create(
+                "테스트 차수",
+                DeliveryType.ONLINE,
+                enrollStart,
+                enrollEnd,
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(30),
+                30,
+                5,
+                EnrollmentMethod.FIRST_COME,
+                80,
+                new BigDecimal("100000"),
+                false,
+                null,
+                true,
+                1L
+        );
+
+        // canEnroll이 true면 RECRUITING 상태로 변경
+        if (canEnroll) {
+            courseTime.open();  // DRAFT -> RECRUITING
+        }
+
+        return courseTime;
+    }
+
+    private Enrollment createTestEnrollment(Long userId, Long courseTimeId, EnrollmentStatus status) {
+        Enrollment enrollment = Enrollment.createVoluntary(userId, courseTimeId);
+        if (status == EnrollmentStatus.COMPLETED) {
+            enrollment.complete(100);
+        } else if (status == EnrollmentStatus.DROPPED) {
+            enrollment.drop();
+        }
+        return enrollment;
+    }
+
+    // ==================== 수강 신청 테스트 ====================
+
+    @Nested
+    @DisplayName("enroll - 수강 신청")
+    class Enroll {
+
+        @Test
+        @DisplayName("성공 - 자발적 수강 신청")
+        void enroll_success() {
+            // given
+            Long userId = 1L;
+            Long courseTimeId = 1L;
+            CourseTime courseTime = createTestCourseTime(true);
+
+            given(courseTimeRepository.findByIdAndTenantId(courseTimeId, TENANT_ID))
+                    .willReturn(Optional.of(courseTime));
+            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, TENANT_ID))
+                    .willReturn(false);
+            given(enrollmentRepository.save(any(Enrollment.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            EnrollmentDetailResponse response = enrollmentService.enroll(courseTimeId, userId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.userId()).isEqualTo(userId);
+            assertThat(response.courseTimeId()).isEqualTo(courseTimeId);
+            assertThat(response.type()).isEqualTo(EnrollmentType.VOLUNTARY);
+            assertThat(response.status()).isEqualTo(EnrollmentStatus.ENROLLED);
+            assertThat(response.progressPercent()).isEqualTo(0);
+
+            verify(courseTimeService).occupySeat(courseTimeId);
+            verify(enrollmentRepository).save(any(Enrollment.class));
+        }
+
+        @Test
+        @DisplayName("실패 - 중복 수강 신청")
+        void enroll_fail_alreadyEnrolled() {
+            // given
+            Long userId = 1L;
+            Long courseTimeId = 1L;
+            CourseTime courseTime = createTestCourseTime(true);
+
+            given(courseTimeRepository.findByIdAndTenantId(courseTimeId, TENANT_ID))
+                    .willReturn(Optional.of(courseTime));
+            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, TENANT_ID))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> enrollmentService.enroll(courseTimeId, userId))
+                    .isInstanceOf(AlreadyEnrolledException.class);
+
+            verify(courseTimeService, never()).occupySeat(any());
+            verify(enrollmentRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 - 수강 신청 기간 외")
+        void enroll_fail_periodClosed() {
+            // given
+            Long userId = 1L;
+            Long courseTimeId = 1L;
+            CourseTime courseTime = createTestCourseTime(false);
+
+            given(courseTimeRepository.findByIdAndTenantId(courseTimeId, TENANT_ID))
+                    .willReturn(Optional.of(courseTime));
+
+            // when & then
+            assertThatThrownBy(() -> enrollmentService.enroll(courseTimeId, userId))
+                    .isInstanceOf(EnrollmentPeriodClosedException.class);
+
+            verify(courseTimeService, never()).occupySeat(any());
+            verify(enrollmentRepository, never()).save(any());
+        }
+    }
+
+    // ==================== 강제 배정 테스트 ====================
+
+    @Nested
+    @DisplayName("forceEnroll - 강제 배정")
+    class ForceEnroll {
+
+        @Test
+        @DisplayName("성공 - 다수 사용자 강제 배정")
+        void forceEnroll_success() {
+            // given
+            Long courseTimeId = 1L;
+            Long operatorId = 99L;
+            List<Long> userIds = List.of(1L, 2L, 3L);
+            ForceEnrollRequest request = new ForceEnrollRequest(userIds, null);
+            CourseTime courseTime = createTestCourseTime(true);
+
+            given(courseTimeRepository.findByIdAndTenantId(courseTimeId, TENANT_ID))
+                    .willReturn(Optional.of(courseTime));
+            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(any(), eq(courseTimeId), eq(TENANT_ID)))
+                    .willReturn(false);
+            given(enrollmentRepository.save(any(Enrollment.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            ForceEnrollResultResponse response = enrollmentService.forceEnroll(courseTimeId, request, operatorId);
+
+            // then
+            assertThat(response.enrollments()).hasSize(3);
+            assertThat(response.failures()).isEmpty();
+            assertThat(response.successCount()).isEqualTo(3);
+            assertThat(response.failCount()).isEqualTo(0);
+
+            verify(enrollmentRepository, times(3)).save(any(Enrollment.class));
+        }
+
+        @Test
+        @DisplayName("부분 성공 - 일부 사용자 이미 수강 중")
+        void forceEnroll_partialSuccess() {
+            // given
+            Long courseTimeId = 1L;
+            Long operatorId = 99L;
+            List<Long> userIds = List.of(1L, 2L, 3L);
+            ForceEnrollRequest request = new ForceEnrollRequest(userIds, null);
+            CourseTime courseTime = createTestCourseTime(true);
+
+            given(courseTimeRepository.findByIdAndTenantId(courseTimeId, TENANT_ID))
+                    .willReturn(Optional.of(courseTime));
+            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(1L, courseTimeId, TENANT_ID))
+                    .willReturn(true);  // 이미 등록됨
+            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(2L, courseTimeId, TENANT_ID))
+                    .willReturn(false);
+            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(3L, courseTimeId, TENANT_ID))
+                    .willReturn(false);
+            given(enrollmentRepository.save(any(Enrollment.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            ForceEnrollResultResponse response = enrollmentService.forceEnroll(courseTimeId, request, operatorId);
+
+            // then
+            assertThat(response.enrollments()).hasSize(2);
+            assertThat(response.failures()).hasSize(1);
+            assertThat(response.failures().get(0).userId()).isEqualTo(1L);
+
+            verify(enrollmentRepository, times(2)).save(any(Enrollment.class));
+        }
+    }
+
+    // ==================== 진도율 업데이트 테스트 ====================
+
+    @Nested
+    @DisplayName("updateProgress - 진도율 업데이트")
+    class UpdateProgress {
+
+        @Test
+        @DisplayName("성공 - 진도율 업데이트")
+        void updateProgress_success() {
+            // given
+            Long enrollmentId = 1L;
+            Long userId = 1L;
+            Enrollment enrollment = createTestEnrollment(userId, 1L, EnrollmentStatus.ENROLLED);
+            UpdateProgressRequest request = new UpdateProgressRequest(50);
+
+            given(enrollmentRepository.findByIdAndTenantId(enrollmentId, TENANT_ID))
+                    .willReturn(Optional.of(enrollment));
+
+            // when
+            EnrollmentResponse response = enrollmentService.updateProgress(enrollmentId, request, userId);
+
+            // then
+            assertThat(response.progressPercent()).isEqualTo(50);
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 수강")
+        void updateProgress_fail_notFound() {
+            // given
+            Long enrollmentId = 999L;
+            UpdateProgressRequest request = new UpdateProgressRequest(50);
+
+            given(enrollmentRepository.findByIdAndTenantId(enrollmentId, TENANT_ID))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> enrollmentService.updateProgress(enrollmentId, request, 1L))
+                    .isInstanceOf(EnrollmentNotFoundException.class);
+        }
+    }
+
+    // ==================== 수료 처리 테스트 ====================
+
+    @Nested
+    @DisplayName("completeEnrollment - 수료 처리")
+    class CompleteEnrollment {
+
+        @Test
+        @DisplayName("성공 - 수료 처리")
+        void completeEnrollment_success() {
+            // given
+            Long enrollmentId = 1L;
+            Enrollment enrollment = createTestEnrollment(1L, 1L, EnrollmentStatus.ENROLLED);
+            CompleteEnrollmentRequest request = new CompleteEnrollmentRequest(95);
+
+            given(enrollmentRepository.findByIdAndTenantId(enrollmentId, TENANT_ID))
+                    .willReturn(Optional.of(enrollment));
+
+            // when
+            EnrollmentDetailResponse response = enrollmentService.completeEnrollment(enrollmentId, request);
+
+            // then
+            assertThat(response.status()).isEqualTo(EnrollmentStatus.COMPLETED);
+            assertThat(response.score()).isEqualTo(95);
+            assertThat(response.progressPercent()).isEqualTo(100);
+            assertThat(response.completedAt()).isNotNull();
+        }
+    }
+
+    // ==================== 수강 취소 테스트 ====================
+
+    @Nested
+    @DisplayName("cancelEnrollment - 수강 취소")
+    class CancelEnrollment {
+
+        @Test
+        @DisplayName("성공 - 수강 취소")
+        void cancelEnrollment_success() {
+            // given
+            Long enrollmentId = 1L;
+            Long userId = 1L;
+            Long courseTimeId = 1L;
+            Enrollment enrollment = createTestEnrollment(userId, courseTimeId, EnrollmentStatus.ENROLLED);
+
+            given(enrollmentRepository.findByIdAndTenantId(enrollmentId, TENANT_ID))
+                    .willReturn(Optional.of(enrollment));
+
+            // when
+            enrollmentService.cancelEnrollment(enrollmentId, userId);
+
+            // then
+            assertThat(enrollment.isDropped()).isTrue();
+            verify(courseTimeService).releaseSeat(courseTimeId);
+        }
+
+        @Test
+        @DisplayName("실패 - 수료 상태에서 취소 불가")
+        void cancelEnrollment_fail_completed() {
+            // given
+            Long enrollmentId = 1L;
+            Long userId = 1L;
+            Enrollment enrollment = createTestEnrollment(userId, 1L, EnrollmentStatus.COMPLETED);
+
+            given(enrollmentRepository.findByIdAndTenantId(enrollmentId, TENANT_ID))
+                    .willReturn(Optional.of(enrollment));
+
+            // when & then
+            assertThatThrownBy(() -> enrollmentService.cancelEnrollment(enrollmentId, userId))
+                    .isInstanceOf(CannotCancelCompletedException.class);
+
+            verify(courseTimeService, never()).releaseSeat(any());
+        }
+    }
+
+    // ==================== 상태 변경 테스트 ====================
+
+    @Nested
+    @DisplayName("updateStatus - 상태 변경")
+    class UpdateStatus {
+
+        @Test
+        @DisplayName("성공 - 상태를 FAILED로 변경")
+        void updateStatus_success() {
+            // given
+            Long enrollmentId = 1L;
+            Enrollment enrollment = createTestEnrollment(1L, 1L, EnrollmentStatus.ENROLLED);
+            UpdateEnrollmentStatusRequest request = new UpdateEnrollmentStatusRequest(EnrollmentStatus.FAILED, null);
+
+            given(enrollmentRepository.findByIdAndTenantId(enrollmentId, TENANT_ID))
+                    .willReturn(Optional.of(enrollment));
+
+            // when
+            EnrollmentDetailResponse response = enrollmentService.updateStatus(enrollmentId, request);
+
+            // then
+            assertThat(response.status()).isEqualTo(EnrollmentStatus.FAILED);
+        }
+    }
+
+    // ==================== 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("getMyEnrollments - 내 수강 목록 조회")
+    class GetMyEnrollments {
+
+        @Test
+        @DisplayName("성공 - 내 수강 목록 조회")
+        void getMyEnrollments_success() {
+            // given
+            Long userId = 1L;
+            Pageable pageable = PageRequest.of(0, 20);
+            List<Enrollment> enrollments = List.of(
+                    createTestEnrollment(userId, 1L, EnrollmentStatus.ENROLLED),
+                    createTestEnrollment(userId, 2L, EnrollmentStatus.COMPLETED)
+            );
+            Page<Enrollment> page = new PageImpl<>(enrollments, pageable, enrollments.size());
+
+            given(enrollmentRepository.findByUserIdAndTenantId(userId, TENANT_ID, pageable))
+                    .willReturn(page);
+
+            // when
+            Page<EnrollmentResponse> response = enrollmentService.getMyEnrollments(userId, null, pageable);
+
+            // then
+            assertThat(response.getContent()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("성공 - 상태별 필터링")
+        void getMyEnrollments_success_withStatusFilter() {
+            // given
+            Long userId = 1L;
+            EnrollmentStatus status = EnrollmentStatus.ENROLLED;
+            Pageable pageable = PageRequest.of(0, 20);
+            List<Enrollment> enrollments = List.of(
+                    createTestEnrollment(userId, 1L, EnrollmentStatus.ENROLLED)
+            );
+            Page<Enrollment> page = new PageImpl<>(enrollments, pageable, enrollments.size());
+
+            given(enrollmentRepository.findByUserIdAndStatusAndTenantId(userId, status, TENANT_ID, pageable))
+                    .willReturn(page);
+
+            // when
+            Page<EnrollmentResponse> response = enrollmentService.getMyEnrollments(userId, status, pageable);
+
+            // then
+            assertThat(response.getContent()).hasSize(1);
+            assertThat(response.getContent().get(0).status()).isEqualTo(EnrollmentStatus.ENROLLED);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- SIS 모듈 수강신청 CRUD API 10개 엔드포인트 구현
- TS 모듈과 연동하여 정원 관리 (occupySeat/releaseSeat)
- Enrollment 엔티티 시간 타입 LocalDateTime → Instant 통일

## 변경 사항

### API 엔드포인트 (10개)
| Method | Endpoint | 설명 | 권한 |
|--------|----------|------|------|
| POST | `/api/ts/course-times/{id}/enrollments` | 수강신청 | AUTH |
| POST | `/api/ts/course-times/{id}/enrollments/force` | 강제배정 | OPERATOR |
| GET | `/api/ts/course-times/{id}/enrollments` | 수강생 목록 | OPERATOR |
| GET | `/api/enrollments/{id}` | 수강 상세 | AUTH |
| PATCH | `/api/enrollments/{id}/progress` | 진도 업데이트 | AUTH |
| PATCH | `/api/enrollments/{id}/complete` | 수료 처리 | OPERATOR |
| PATCH | `/api/enrollments/{id}/status` | 상태 변경 | OPERATOR |
| DELETE | `/api/enrollments/{id}` | 수강 취소 | AUTH |
| GET | `/api/users/me/enrollments` | 내 수강 목록 | AUTH |
| GET | `/api/users/{userId}/enrollments` | 수강 이력 조회 | OPERATOR |

### 비즈니스 규칙
- 동일 차수 중복 수강 불가
- 정원 초과 시 신청 불가
- 수강신청 기간 내에만 가능 (TS에서 검증)
- COMPLETED 상태에서 취소 불가

### 파일 추가/수정
- `EnrollmentController.java` - 컨트롤러 신규
- `EnrollmentService.java` - 서비스 인터페이스 신규
- `EnrollmentServiceImpl.java` - 서비스 구현체 신규
- Request DTO 4개 신규
- Response DTO 3개 신규
- `Enrollment.java` - LocalDateTime → Instant 변경
- `EnrollmentServiceTest.java` - 13개 테스트 케이스

## Test Plan
- [x] EnrollmentServiceTest 13개 테스트 통과
- [x] 전체 빌드 성공
- [x] MySQL 저장 테스트 완료

Closes #50