### PR TITLE
[Feat] CourseItem API 구현 (계층 구조)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/course/controller/CourseItemController.java
+++ b/src/main/java/com/mzc/lp/domain/course/controller/CourseItemController.java
@@ -1,0 +1,150 @@
+package com.mzc.lp.domain.course.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.course.dto.request.CreateFolderRequest;
+import com.mzc.lp.domain.course.dto.request.CreateItemRequest;
+import com.mzc.lp.domain.course.dto.request.MoveItemRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateItemNameRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateLearningObjectRequest;
+import com.mzc.lp.domain.course.dto.response.CourseItemHierarchyResponse;
+import com.mzc.lp.domain.course.dto.response.CourseItemResponse;
+import com.mzc.lp.domain.course.service.CourseItemService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/courses/{courseId}")
+@RequiredArgsConstructor
+@Validated
+public class CourseItemController {
+
+    private final CourseItemService courseItemService;
+
+    /**
+     * 차시 추가
+     * POST /api/courses/{courseId}/items
+     */
+    @PostMapping("/items")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseItemResponse>> createItem(
+            @PathVariable @Positive Long courseId,
+            @Valid @RequestBody CreateItemRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseItemResponse response = courseItemService.createItem(courseId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 폴더 생성
+     * POST /api/courses/{courseId}/folders
+     */
+    @PostMapping("/folders")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseItemResponse>> createFolder(
+            @PathVariable @Positive Long courseId,
+            @Valid @RequestBody CreateFolderRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseItemResponse response = courseItemService.createFolder(courseId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 계층 구조 조회
+     * GET /api/courses/{courseId}/items/hierarchy
+     */
+    @GetMapping("/items/hierarchy")
+    public ResponseEntity<ApiResponse<List<CourseItemHierarchyResponse>>> getHierarchy(
+            @PathVariable @Positive Long courseId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<CourseItemHierarchyResponse> response = courseItemService.getHierarchy(courseId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 순서대로 차시 조회
+     * GET /api/courses/{courseId}/items/ordered
+     */
+    @GetMapping("/items/ordered")
+    public ResponseEntity<ApiResponse<List<CourseItemResponse>>> getOrderedItems(
+            @PathVariable @Positive Long courseId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<CourseItemResponse> response = courseItemService.getOrderedItems(courseId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 항목 이동
+     * PUT /api/courses/{courseId}/items/move
+     */
+    @PutMapping("/items/move")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseItemResponse>> moveItem(
+            @PathVariable @Positive Long courseId,
+            @Valid @RequestBody MoveItemRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseItemResponse response = courseItemService.moveItem(courseId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 항목 이름 변경
+     * PATCH /api/courses/{courseId}/items/{itemId}/name
+     */
+    @PatchMapping("/items/{itemId}/name")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseItemResponse>> updateItemName(
+            @PathVariable @Positive Long courseId,
+            @PathVariable @Positive Long itemId,
+            @Valid @RequestBody UpdateItemNameRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseItemResponse response = courseItemService.updateItemName(courseId, itemId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 학습 객체 변경
+     * PATCH /api/courses/{courseId}/items/{itemId}/learning-object
+     */
+    @PatchMapping("/items/{itemId}/learning-object")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseItemResponse>> updateLearningObject(
+            @PathVariable @Positive Long courseId,
+            @PathVariable @Positive Long itemId,
+            @Valid @RequestBody UpdateLearningObjectRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseItemResponse response = courseItemService.updateLearningObject(courseId, itemId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 항목 삭제
+     * DELETE /api/courses/{courseId}/items/{itemId}
+     */
+    @DeleteMapping("/items/{itemId}")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> deleteItem(
+            @PathVariable @Positive Long courseId,
+            @PathVariable @Positive Long itemId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        courseItemService.deleteItem(courseId, itemId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateItemNameRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateItemNameRequest.java
@@ -1,0 +1,16 @@
+package com.mzc.lp.domain.course.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateItemNameRequest(
+        @NotBlank(message = "항목 이름은 필수입니다")
+        @Size(max = 255, message = "항목 이름은 255자 이하여야 합니다")
+        String itemName
+) {
+    public UpdateItemNameRequest {
+        if (itemName != null) {
+            itemName = itemName.trim();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateLearningObjectRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateLearningObjectRequest.java
@@ -1,0 +1,9 @@
+package com.mzc.lp.domain.course.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateLearningObjectRequest(
+        @NotNull(message = "학습 객체 ID는 필수입니다")
+        Long learningObjectId
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/course/repository/CourseItemRepository.java
+++ b/src/main/java/com/mzc/lp/domain/course/repository/CourseItemRepository.java
@@ -18,19 +18,19 @@ public interface CourseItemRepository extends JpaRepository<CourseItem, Long> {
 
     List<CourseItem> findByCourseIdAndTenantIdAndParentId(Long courseId, Long tenantId, Long parentId);
 
-    @Query("SELECT ci FROM CourseItem ci WHERE ci.course.id = :courseId AND ci.tenantId = :tenantId ORDER BY ci.depth, ci.sortOrder")
+    @Query("SELECT ci FROM CourseItem ci WHERE ci.course.id = :courseId AND ci.tenantId = :tenantId ORDER BY ci.depth, ci.id")
     List<CourseItem> findByCourseIdOrderByDepthAndSortOrder(@Param("courseId") Long courseId, @Param("tenantId") Long tenantId);
 
-    @Query("SELECT ci FROM CourseItem ci WHERE ci.course.id = :courseId AND ci.tenantId = :tenantId AND ci.learningObjectId IS NOT NULL ORDER BY ci.sortOrder")
+    @Query("SELECT ci FROM CourseItem ci WHERE ci.course.id = :courseId AND ci.tenantId = :tenantId AND ci.learningObjectId IS NOT NULL ORDER BY ci.id")
     List<CourseItem> findItemsOnlyByCourseId(@Param("courseId") Long courseId, @Param("tenantId") Long tenantId);
 
-    @Query("SELECT ci FROM CourseItem ci WHERE ci.course.id = :courseId AND ci.tenantId = :tenantId AND ci.learningObjectId IS NULL ORDER BY ci.depth, ci.sortOrder")
+    @Query("SELECT ci FROM CourseItem ci WHERE ci.course.id = :courseId AND ci.tenantId = :tenantId AND ci.learningObjectId IS NULL ORDER BY ci.depth, ci.id")
     List<CourseItem> findFoldersOnlyByCourseId(@Param("courseId") Long courseId, @Param("tenantId") Long tenantId);
 
     @Query("SELECT ci FROM CourseItem ci LEFT JOIN FETCH ci.children WHERE ci.id = :id AND ci.tenantId = :tenantId")
     Optional<CourseItem> findByIdWithChildren(@Param("id") Long id, @Param("tenantId") Long tenantId);
 
-    @Query("SELECT DISTINCT ci FROM CourseItem ci LEFT JOIN FETCH ci.children WHERE ci.course.id = :courseId AND ci.tenantId = :tenantId AND ci.parent IS NULL ORDER BY ci.sortOrder")
+    @Query("SELECT DISTINCT ci FROM CourseItem ci LEFT JOIN FETCH ci.children WHERE ci.course.id = :courseId AND ci.tenantId = :tenantId AND ci.parent IS NULL ORDER BY ci.id")
     List<CourseItem> findRootItemsWithChildren(@Param("courseId") Long courseId, @Param("tenantId") Long tenantId);
 
     boolean existsByIdAndTenantId(Long id, Long tenantId);

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseItemService.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseItemService.java
@@ -1,0 +1,77 @@
+package com.mzc.lp.domain.course.service;
+
+import com.mzc.lp.domain.course.dto.request.CreateFolderRequest;
+import com.mzc.lp.domain.course.dto.request.CreateItemRequest;
+import com.mzc.lp.domain.course.dto.request.MoveItemRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateItemNameRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateLearningObjectRequest;
+import com.mzc.lp.domain.course.dto.response.CourseItemHierarchyResponse;
+import com.mzc.lp.domain.course.dto.response.CourseItemResponse;
+
+import java.util.List;
+
+public interface CourseItemService {
+
+    /**
+     * 차시 추가
+     * @param courseId 강의 ID
+     * @param request 생성 요청 DTO
+     * @return 생성된 차시 정보
+     */
+    CourseItemResponse createItem(Long courseId, CreateItemRequest request);
+
+    /**
+     * 폴더 생성
+     * @param courseId 강의 ID
+     * @param request 생성 요청 DTO
+     * @return 생성된 폴더 정보
+     */
+    CourseItemResponse createFolder(Long courseId, CreateFolderRequest request);
+
+    /**
+     * 계층 구조 조회
+     * @param courseId 강의 ID
+     * @return 계층 구조로 정렬된 항목 목록
+     */
+    List<CourseItemHierarchyResponse> getHierarchy(Long courseId);
+
+    /**
+     * 순서대로 차시 조회 (폴더 제외, Relation 기반)
+     * @param courseId 강의 ID
+     * @return 학습 순서로 정렬된 차시 목록
+     */
+    List<CourseItemResponse> getOrderedItems(Long courseId);
+
+    /**
+     * 항목 이동
+     * @param courseId 강의 ID
+     * @param request 이동 요청 DTO
+     * @return 이동된 항목 정보
+     */
+    CourseItemResponse moveItem(Long courseId, MoveItemRequest request);
+
+    /**
+     * 항목 이름 변경
+     * @param courseId 강의 ID
+     * @param itemId 항목 ID
+     * @param request 이름 변경 요청 DTO
+     * @return 수정된 항목 정보
+     */
+    CourseItemResponse updateItemName(Long courseId, Long itemId, UpdateItemNameRequest request);
+
+    /**
+     * 학습 객체 변경 (차시 전용)
+     * @param courseId 강의 ID
+     * @param itemId 항목 ID
+     * @param request LO 변경 요청 DTO
+     * @return 수정된 항목 정보
+     */
+    CourseItemResponse updateLearningObject(Long courseId, Long itemId, UpdateLearningObjectRequest request);
+
+    /**
+     * 항목 삭제 (폴더일 경우 하위 항목도 삭제)
+     * @param courseId 강의 ID
+     * @param itemId 항목 ID
+     */
+    void deleteItem(Long courseId, Long itemId);
+}

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseItemServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseItemServiceImpl.java
@@ -1,0 +1,239 @@
+package com.mzc.lp.domain.course.service;
+
+import com.mzc.lp.domain.course.dto.request.CreateFolderRequest;
+import com.mzc.lp.domain.course.dto.request.CreateItemRequest;
+import com.mzc.lp.domain.course.dto.request.MoveItemRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateItemNameRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateLearningObjectRequest;
+import com.mzc.lp.domain.course.dto.response.CourseItemHierarchyResponse;
+import com.mzc.lp.domain.course.dto.response.CourseItemResponse;
+import com.mzc.lp.domain.course.entity.Course;
+import com.mzc.lp.domain.course.entity.CourseItem;
+import com.mzc.lp.domain.course.exception.CourseItemNotFoundException;
+import com.mzc.lp.domain.course.exception.CourseNotFoundException;
+import com.mzc.lp.domain.course.exception.InvalidParentException;
+import com.mzc.lp.domain.course.exception.MaxDepthExceededException;
+import com.mzc.lp.domain.course.repository.CourseItemRepository;
+import com.mzc.lp.domain.course.repository.CourseRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CourseItemServiceImpl implements CourseItemService {
+
+    private final CourseRepository courseRepository;
+    private final CourseItemRepository courseItemRepository;
+
+    private static final Long DEFAULT_TENANT_ID = 1L;
+
+    @Override
+    @Transactional
+    public CourseItemResponse createItem(Long courseId, CreateItemRequest request) {
+        log.info("Creating item: courseId={}, itemName={}", courseId, request.itemName());
+
+        Course course = findCourseById(courseId);
+        CourseItem parent = findParentIfExists(request.parentId());
+
+        validateParentBelongsToCourse(parent, courseId);
+
+        try {
+            CourseItem item = CourseItem.createItem(
+                    course,
+                    request.itemName(),
+                    parent,
+                    request.learningObjectId()
+            );
+
+            CourseItem savedItem = courseItemRepository.save(item);
+            log.info("Item created: id={}, name={}", savedItem.getId(), savedItem.getItemName());
+
+            return CourseItemResponse.from(savedItem);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().contains("최대 깊이")) {
+                throw new MaxDepthExceededException();
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    @Transactional
+    public CourseItemResponse createFolder(Long courseId, CreateFolderRequest request) {
+        log.info("Creating folder: courseId={}, folderName={}", courseId, request.folderName());
+
+        Course course = findCourseById(courseId);
+        CourseItem parent = findParentIfExists(request.parentId());
+
+        validateParentBelongsToCourse(parent, courseId);
+
+        try {
+            CourseItem folder = CourseItem.createFolder(
+                    course,
+                    request.folderName(),
+                    parent
+            );
+
+            CourseItem savedFolder = courseItemRepository.save(folder);
+            log.info("Folder created: id={}, name={}", savedFolder.getId(), savedFolder.getItemName());
+
+            return CourseItemResponse.from(savedFolder);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().contains("최대 깊이")) {
+                throw new MaxDepthExceededException();
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public List<CourseItemHierarchyResponse> getHierarchy(Long courseId) {
+        log.debug("Getting hierarchy: courseId={}", courseId);
+
+        validateCourseExists(courseId);
+
+        List<CourseItem> rootItems = courseItemRepository.findRootItemsWithChildren(courseId, DEFAULT_TENANT_ID);
+
+        return CourseItemHierarchyResponse.fromList(rootItems);
+    }
+
+    @Override
+    public List<CourseItemResponse> getOrderedItems(Long courseId) {
+        log.debug("Getting ordered items: courseId={}", courseId);
+
+        validateCourseExists(courseId);
+
+        List<CourseItem> items = courseItemRepository.findItemsOnlyByCourseId(courseId, DEFAULT_TENANT_ID);
+
+        return items.stream()
+                .map(CourseItemResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public CourseItemResponse moveItem(Long courseId, MoveItemRequest request) {
+        log.info("Moving item: courseId={}, itemId={}, targetParentId={}",
+                courseId, request.itemId(), request.targetParentId());
+
+        validateCourseExists(courseId);
+
+        CourseItem item = findItemById(request.itemId());
+        validateItemBelongsToCourse(item, courseId);
+
+        CourseItem newParent = findParentIfExists(request.targetParentId());
+        validateParentBelongsToCourse(newParent, courseId);
+
+        try {
+            item.moveTo(newParent);
+            log.info("Item moved: id={}, newParentId={}, newDepth={}",
+                    item.getId(), request.targetParentId(), item.getDepth());
+
+            return CourseItemResponse.from(item);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().contains("최대 깊이")) {
+                throw new MaxDepthExceededException();
+            }
+            if (e.getMessage().contains("하위 항목으로 이동")) {
+                throw new InvalidParentException("자기 자신 또는 하위 항목으로 이동할 수 없습니다");
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    @Transactional
+    public CourseItemResponse updateItemName(Long courseId, Long itemId, UpdateItemNameRequest request) {
+        log.info("Updating item name: courseId={}, itemId={}, newName={}",
+                courseId, itemId, request.itemName());
+
+        validateCourseExists(courseId);
+
+        CourseItem item = findItemById(itemId);
+        validateItemBelongsToCourse(item, courseId);
+
+        item.updateItemName(request.itemName());
+        log.info("Item name updated: id={}", itemId);
+
+        return CourseItemResponse.from(item);
+    }
+
+    @Override
+    @Transactional
+    public CourseItemResponse updateLearningObject(Long courseId, Long itemId, UpdateLearningObjectRequest request) {
+        log.info("Updating learning object: courseId={}, itemId={}, loId={}",
+                courseId, itemId, request.learningObjectId());
+
+        validateCourseExists(courseId);
+
+        CourseItem item = findItemById(itemId);
+        validateItemBelongsToCourse(item, courseId);
+
+        if (item.isFolder()) {
+            throw new InvalidParentException("폴더에는 학습 객체를 연결할 수 없습니다");
+        }
+
+        item.updateLearningObjectId(request.learningObjectId());
+        log.info("Learning object updated: itemId={}, loId={}", itemId, request.learningObjectId());
+
+        return CourseItemResponse.from(item);
+    }
+
+    @Override
+    @Transactional
+    public void deleteItem(Long courseId, Long itemId) {
+        log.info("Deleting item: courseId={}, itemId={}", courseId, itemId);
+
+        validateCourseExists(courseId);
+
+        CourseItem item = findItemById(itemId);
+        validateItemBelongsToCourse(item, courseId);
+
+        courseItemRepository.delete(item);
+        log.info("Item deleted: id={}", itemId);
+    }
+
+    // ===== Private Helper Methods =====
+
+    private Course findCourseById(Long courseId) {
+        return courseRepository.findByIdAndTenantId(courseId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new CourseNotFoundException(courseId));
+    }
+
+    private void validateCourseExists(Long courseId) {
+        if (!courseRepository.existsByIdAndTenantId(courseId, DEFAULT_TENANT_ID)) {
+            throw new CourseNotFoundException(courseId);
+        }
+    }
+
+    private CourseItem findItemById(Long itemId) {
+        return courseItemRepository.findByIdAndTenantId(itemId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new CourseItemNotFoundException(itemId));
+    }
+
+    private CourseItem findParentIfExists(Long parentId) {
+        if (parentId == null) {
+            return null;
+        }
+        return courseItemRepository.findByIdAndTenantId(parentId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new CourseItemNotFoundException(parentId));
+    }
+
+    private void validateParentBelongsToCourse(CourseItem parent, Long courseId) {
+        if (parent != null && !parent.getCourse().getId().equals(courseId)) {
+            throw new InvalidParentException("부모 항목이 해당 강의에 속하지 않습니다");
+        }
+    }
+
+    private void validateItemBelongsToCourse(CourseItem item, Long courseId) {
+        if (!item.getCourse().getId().equals(courseId)) {
+            throw new CourseItemNotFoundException(item.getId());
+        }
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseItemControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseItemControllerTest.java
@@ -1,0 +1,710 @@
+package com.mzc.lp.domain.course.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.domain.course.constant.CourseLevel;
+import com.mzc.lp.domain.course.constant.CourseType;
+import com.mzc.lp.domain.course.dto.request.CreateFolderRequest;
+import com.mzc.lp.domain.course.dto.request.CreateItemRequest;
+import com.mzc.lp.domain.course.dto.request.MoveItemRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateItemNameRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateLearningObjectRequest;
+import com.mzc.lp.domain.course.entity.Course;
+import com.mzc.lp.domain.course.entity.CourseItem;
+import com.mzc.lp.domain.course.repository.CourseItemRepository;
+import com.mzc.lp.domain.course.repository.CourseRepository;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CourseItemControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @Autowired
+    private CourseItemRepository courseItemRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private UserCourseRoleRepository userCourseRoleRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        courseItemRepository.deleteAll();
+        courseRepository.deleteAll();
+        userCourseRoleRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ===== 헬퍼 메서드 =====
+
+    private User createOperatorUser() {
+        User user = User.create("operator@example.com", "운영자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.OPERATOR);
+        return userRepository.save(user);
+    }
+
+    private User createRegularUser() {
+        User user = User.create("user@example.com", "일반사용자", passwordEncoder.encode("Password123!"));
+        return userRepository.save(user);
+    }
+
+    private String loginAndGetAccessToken(String email, String password) throws Exception {
+        LoginRequest request = new LoginRequest(email, password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("data").get("accessToken").asText();
+    }
+
+    private Course createTestCourse(String title) {
+        Course course = Course.create(
+                title,
+                "테스트 강의 설명",
+                CourseLevel.BEGINNER,
+                CourseType.ONLINE,
+                10,
+                1L,
+                null
+        );
+        return courseRepository.save(course);
+    }
+
+    private CourseItem createTestFolder(Course course, String name, CourseItem parent) {
+        CourseItem folder = CourseItem.createFolder(course, name, parent);
+        return courseItemRepository.save(folder);
+    }
+
+    private CourseItem createTestItem(Course course, String name, CourseItem parent, Long loId) {
+        CourseItem item = CourseItem.createItem(course, name, parent, loId);
+        return courseItemRepository.save(item);
+    }
+
+    // ==================== 차시 추가 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/courses/{courseId}/items - 차시 추가")
+    class CreateItem {
+
+        @Test
+        @DisplayName("성공 - 최상위에 차시 추가")
+        void createItem_success_rootLevel() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CreateItemRequest request = new CreateItemRequest(
+                    "1-1. 환경설정",
+                    null,
+                    100L
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/courses/{courseId}/items", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.itemName").value("1-1. 환경설정"))
+                    .andExpect(jsonPath("$.data.depth").value(0))
+                    .andExpect(jsonPath("$.data.parentId").isEmpty())
+                    .andExpect(jsonPath("$.data.learningObjectId").value(100))
+                    .andExpect(jsonPath("$.data.isFolder").value(false));
+        }
+
+        @Test
+        @DisplayName("성공 - 폴더 하위에 차시 추가")
+        void createItem_success_underFolder() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CourseItem folder = createTestFolder(course, "1주차", null);
+            CreateItemRequest request = new CreateItemRequest(
+                    "1-1. 환경설정",
+                    folder.getId(),
+                    100L
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/courses/{courseId}/items", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.itemName").value("1-1. 환경설정"))
+                    .andExpect(jsonPath("$.data.depth").value(1))
+                    .andExpect(jsonPath("$.data.parentId").value(folder.getId()))
+                    .andExpect(jsonPath("$.data.isFolder").value(false));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 강의")
+        void createItem_fail_courseNotFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CreateItemRequest request = new CreateItemRequest(
+                    "차시",
+                    null,
+                    100L
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/courses/{courseId}/items", 99999L)
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM001"));
+        }
+
+        @Test
+        @DisplayName("실패 - 항목 이름 누락")
+        void createItem_fail_missingName() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CreateItemRequest request = new CreateItemRequest(
+                    null,
+                    null,
+                    100L
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/courses/{courseId}/items", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("실패 - learningObjectId 누락")
+        void createItem_fail_missingLearningObjectId() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CreateItemRequest request = new CreateItemRequest(
+                    "차시 이름",
+                    null,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/courses/{courseId}/items", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 접근")
+        void createItem_fail_userRole() throws Exception {
+            // given
+            createRegularUser();
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CreateItemRequest request = new CreateItemRequest(
+                    "차시",
+                    null,
+                    100L
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/courses/{courseId}/items", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 폴더 생성 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/courses/{courseId}/folders - 폴더 생성")
+    class CreateFolder {
+
+        @Test
+        @DisplayName("성공 - 최상위에 폴더 생성")
+        void createFolder_success_rootLevel() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CreateFolderRequest request = new CreateFolderRequest(
+                    "1주차",
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/courses/{courseId}/folders", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.itemName").value("1주차"))
+                    .andExpect(jsonPath("$.data.depth").value(0))
+                    .andExpect(jsonPath("$.data.parentId").isEmpty())
+                    .andExpect(jsonPath("$.data.learningObjectId").isEmpty())
+                    .andExpect(jsonPath("$.data.isFolder").value(true));
+        }
+
+        @Test
+        @DisplayName("성공 - 중첩 폴더 생성")
+        void createFolder_success_nested() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CourseItem parentFolder = createTestFolder(course, "1주차", null);
+            CreateFolderRequest request = new CreateFolderRequest(
+                    "1주차-실습",
+                    parentFolder.getId()
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/courses/{courseId}/folders", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.itemName").value("1주차-실습"))
+                    .andExpect(jsonPath("$.data.depth").value(1))
+                    .andExpect(jsonPath("$.data.parentId").value(parentFolder.getId()))
+                    .andExpect(jsonPath("$.data.isFolder").value(true));
+        }
+
+        @Test
+        @DisplayName("실패 - 폴더 이름 누락")
+        void createFolder_fail_missingName() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CreateFolderRequest request = new CreateFolderRequest(
+                    null,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/courses/{courseId}/folders", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+    }
+
+    // ==================== 계층 구조 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/courses/{courseId}/items/hierarchy - 계층 구조 조회")
+    class GetHierarchy {
+
+        @Test
+        @DisplayName("성공 - 계층 구조 조회")
+        void getHierarchy_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CourseItem folder = createTestFolder(course, "1주차", null);
+            createTestItem(course, "1-1. 환경설정", folder, 100L);
+            createTestItem(course, "1-2. 기본 문법", folder, 101L);
+
+            // when & then
+            mockMvc.perform(get("/api/courses/{courseId}/items/hierarchy", course.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data[0].itemName").value("1주차"))
+                    .andExpect(jsonPath("$.data[0].isFolder").value(true))
+                    .andExpect(jsonPath("$.data[0].children").isArray())
+                    .andExpect(jsonPath("$.data[0].children.length()").value(2));
+        }
+
+        @Test
+        @DisplayName("성공 - 빈 구조 조회")
+        void getHierarchy_success_empty() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+
+            // when & then
+            mockMvc.perform(get("/api/courses/{courseId}/items/hierarchy", course.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(0));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 강의")
+        void getHierarchy_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/courses/{courseId}/items/hierarchy", 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+    }
+
+    // ==================== 순서대로 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/courses/{courseId}/items/ordered - 순서대로 조회")
+    class GetOrderedItems {
+
+        @Test
+        @DisplayName("성공 - 차시만 조회 (폴더 제외)")
+        void getOrderedItems_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CourseItem folder = createTestFolder(course, "1주차", null);
+            createTestItem(course, "1-1. 환경설정", folder, 100L);
+            createTestItem(course, "1-2. 기본 문법", folder, 101L);
+
+            // when & then
+            mockMvc.perform(get("/api/courses/{courseId}/items/ordered", course.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(2))
+                    .andExpect(jsonPath("$.data[0].isFolder").value(false))
+                    .andExpect(jsonPath("$.data[1].isFolder").value(false));
+        }
+    }
+
+    // ==================== 항목 이동 테스트 ====================
+
+    @Nested
+    @DisplayName("PUT /api/courses/{courseId}/items/move - 항목 이동")
+    class MoveItem {
+
+        @Test
+        @DisplayName("성공 - 다른 폴더로 이동")
+        void moveItem_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CourseItem folder1 = createTestFolder(course, "1주차", null);
+            CourseItem folder2 = createTestFolder(course, "2주차", null);
+            CourseItem item = createTestItem(course, "이동할 차시", folder1, 100L);
+            MoveItemRequest request = new MoveItemRequest(
+                    item.getId(),
+                    folder2.getId(),
+                    0
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/courses/{courseId}/items/move", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.parentId").value(folder2.getId()));
+        }
+
+        @Test
+        @DisplayName("성공 - 최상위로 이동")
+        void moveItem_success_toRoot() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CourseItem folder = createTestFolder(course, "1주차", null);
+            CourseItem item = createTestItem(course, "이동할 차시", folder, 100L);
+            MoveItemRequest request = new MoveItemRequest(
+                    item.getId(),
+                    null,
+                    0
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/courses/{courseId}/items/move", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.parentId").isEmpty())
+                    .andExpect(jsonPath("$.data.depth").value(0));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 항목")
+        void moveItem_fail_itemNotFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            MoveItemRequest request = new MoveItemRequest(
+                    99999L,
+                    null,
+                    0
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/courses/{courseId}/items/move", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+    }
+
+    // ==================== 항목 이름 변경 테스트 ====================
+
+    @Nested
+    @DisplayName("PATCH /api/courses/{courseId}/items/{itemId}/name - 이름 변경")
+    class UpdateItemName {
+
+        @Test
+        @DisplayName("성공 - 항목 이름 변경")
+        void updateItemName_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CourseItem item = createTestItem(course, "원래 이름", null, 100L);
+            UpdateItemNameRequest request = new UpdateItemNameRequest("변경된 이름");
+
+            // when & then
+            mockMvc.perform(patch("/api/courses/{courseId}/items/{itemId}/name", course.getId(), item.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.itemName").value("변경된 이름"));
+        }
+
+        @Test
+        @DisplayName("실패 - 빈 이름")
+        void updateItemName_fail_emptyName() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CourseItem item = createTestItem(course, "원래 이름", null, 100L);
+            UpdateItemNameRequest request = new UpdateItemNameRequest("   ");
+
+            // when & then
+            mockMvc.perform(patch("/api/courses/{courseId}/items/{itemId}/name", course.getId(), item.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+    }
+
+    // ==================== 학습 객체 변경 테스트 ====================
+
+    @Nested
+    @DisplayName("PATCH /api/courses/{courseId}/items/{itemId}/learning-object - LO 변경")
+    class UpdateLearningObject {
+
+        @Test
+        @DisplayName("성공 - 학습 객체 변경")
+        void updateLearningObject_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CourseItem item = createTestItem(course, "차시", null, 100L);
+            UpdateLearningObjectRequest request = new UpdateLearningObjectRequest(200L);
+
+            // when & then
+            mockMvc.perform(patch("/api/courses/{courseId}/items/{itemId}/learning-object", course.getId(), item.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.learningObjectId").value(200));
+        }
+
+        @Test
+        @DisplayName("실패 - 폴더에 LO 연결 시도")
+        void updateLearningObject_fail_folder() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CourseItem folder = createTestFolder(course, "폴더", null);
+            UpdateLearningObjectRequest request = new UpdateLearningObjectRequest(200L);
+
+            // when & then
+            mockMvc.perform(patch("/api/courses/{courseId}/items/{itemId}/learning-object", course.getId(), folder.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+    }
+
+    // ==================== 항목 삭제 테스트 ====================
+
+    @Nested
+    @DisplayName("DELETE /api/courses/{courseId}/items/{itemId} - 항목 삭제")
+    class DeleteItem {
+
+        @Test
+        @DisplayName("성공 - 차시 삭제")
+        void deleteItem_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CourseItem item = createTestItem(course, "삭제할 차시", null, 100L);
+
+            // when & then
+            mockMvc.perform(delete("/api/courses/{courseId}/items/{itemId}", course.getId(), item.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("성공 - 폴더 삭제 (하위 항목 포함)")
+        void deleteItem_success_folderWithChildren() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CourseItem folder = createTestFolder(course, "삭제할 폴더", null);
+            createTestItem(course, "하위 차시 1", folder, 100L);
+            createTestItem(course, "하위 차시 2", folder, 101L);
+
+            // when & then
+            mockMvc.perform(delete("/api/courses/{courseId}/items/{itemId}", course.getId(), folder.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+
+            // 계층 구조 확인 - 빈 목록이어야 함
+            mockMvc.perform(get("/api/courses/{courseId}/items/hierarchy", course.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(jsonPath("$.data.length()").value(0));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 항목")
+        void deleteItem_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+
+            // when & then
+            mockMvc.perform(delete("/api/courses/{courseId}/items/{itemId}", course.getId(), 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 삭제 시도")
+        void deleteItem_fail_userRole() throws Exception {
+            // given
+            createRegularUser();
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+            CourseItem item = createTestItem(course, "삭제할 차시", null, 100L);
+
+            // when & then
+            mockMvc.perform(delete("/api/courses/{courseId}/items/{itemId}", course.getId(), item.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Phase 3: CourseItem CRUD API 구현
- 차시/폴더 생성, 계층 구조 조회, 이동, 수정, 삭제 기능
- 통합 테스트 24개 전체 통과

## API 목록
| Method | Endpoint | 기능 |
|--------|----------|------|
| POST | `/api/courses/{courseId}/items` | 차시 추가 |
| POST | `/api/courses/{courseId}/folders` | 폴더 생성 |
| GET | `/api/courses/{courseId}/items/hierarchy` | 계층 구조 조회 |
| GET | `/api/courses/{courseId}/items/ordered` | 순서대로 조회 |
| PUT | `/api/courses/{courseId}/items/move` | 항목 이동 |
| PATCH | `/api/courses/{courseId}/items/{itemId}/name` | 이름 변경 |
| PATCH | `/api/courses/{courseId}/items/{itemId}/learning-object` | LO 변경 |
| DELETE | `/api/courses/{courseId}/items/{itemId}` | 항목 삭제 |

## 파일 목록
**신규:**
- `CourseItemService.java` - 서비스 인터페이스
- `CourseItemServiceImpl.java` - 서비스 구현체
- `CourseItemController.java` - REST API 컨트롤러
- `UpdateItemNameRequest.java` - 이름 변경 DTO
- `UpdateLearningObjectRequest.java` - LO 변경 DTO
- `CourseItemControllerTest.java` - 통합 테스트 (24개)

**수정:**
- `CourseItemRepository.java` - sortOrder → id 정렬 (필드 누락 수정)

## Test plan
- [x] 차시 추가 테스트 (최상위, 폴더 하위)
- [x] 폴더 생성 테스트 (최상위, 중첩)
- [x] 계층 구조 조회 테스트
- [x] 순서대로 조회 테스트
- [x] 항목 이동 테스트
- [x] 이름 변경 테스트
- [x] LO 변경 테스트
- [x] 항목 삭제 테스트 (차시, 폴더+하위 항목)
- [x] 권한 검증 테스트

Closes #64