### PR TITLE
feat(sis): 학습 통계 API 구현

### DIFF
--- a/src/main/java/com/mzc/lp/domain/student/controller/EnrollmentController.java
+++ b/src/main/java/com/mzc/lp/domain/student/controller/EnrollmentController.java
@@ -7,10 +7,13 @@ import com.mzc.lp.domain.student.dto.request.CompleteEnrollmentRequest;
 import com.mzc.lp.domain.student.dto.request.ForceEnrollRequest;
 import com.mzc.lp.domain.student.dto.request.UpdateEnrollmentStatusRequest;
 import com.mzc.lp.domain.student.dto.request.UpdateProgressRequest;
+import com.mzc.lp.domain.student.dto.response.CourseTimeEnrollmentStatsResponse;
 import com.mzc.lp.domain.student.dto.response.EnrollmentDetailResponse;
 import com.mzc.lp.domain.student.dto.response.EnrollmentResponse;
 import com.mzc.lp.domain.student.dto.response.ForceEnrollResultResponse;
+import com.mzc.lp.domain.student.dto.response.UserEnrollmentStatsResponse;
 import com.mzc.lp.domain.student.service.EnrollmentService;
+import com.mzc.lp.domain.student.service.EnrollmentStatsService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -29,6 +32,7 @@ import org.springframework.web.bind.annotation.*;
 public class EnrollmentController {
 
     private final EnrollmentService enrollmentService;
+    private final EnrollmentStatsService enrollmentStatsService;
 
     // ========== 수강 신청 API (TS 기반) ==========
 
@@ -167,6 +171,32 @@ public class EnrollmentController {
             @PageableDefault(size = 20) Pageable pageable
     ) {
         Page<EnrollmentResponse> response = enrollmentService.getEnrollmentsByUser(userId, status, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // ========== 통계 API ==========
+
+    /**
+     * 차수별 수강 통계 조회
+     */
+    @GetMapping("/api/ts/course-times/{courseTimeId}/enrollments/stats")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseTimeEnrollmentStatsResponse>> getCourseTimeStats(
+            @PathVariable Long courseTimeId
+    ) {
+        CourseTimeEnrollmentStatsResponse response = enrollmentStatsService.getCourseTimeStats(courseTimeId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 사용자별 수강 통계 조회
+     */
+    @GetMapping("/api/users/{userId}/enrollments/stats")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<UserEnrollmentStatsResponse>> getUserStats(
+            @PathVariable Long userId
+    ) {
+        UserEnrollmentStatsResponse response = enrollmentStatsService.getUserStats(userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/student/dto/response/CourseTimeEnrollmentStatsResponse.java
+++ b/src/main/java/com/mzc/lp/domain/student/dto/response/CourseTimeEnrollmentStatsResponse.java
@@ -1,0 +1,46 @@
+package com.mzc.lp.domain.student.dto.response;
+
+import java.math.BigDecimal;
+
+/**
+ * 차수별 수강 통계 Response
+ */
+public record CourseTimeEnrollmentStatsResponse(
+        Long courseTimeId,
+        Long totalEnrollments,          // 총 수강생 수
+        Long enrolledCount,             // 수강 중
+        Long completedCount,            // 수료
+        Long droppedCount,              // 중도 탈락
+        Long failedCount,               // 미수료
+        BigDecimal averageProgress,     // 평균 진도율 (0-100)
+        BigDecimal completionRate       // 수료율 (%)
+) {
+    public static CourseTimeEnrollmentStatsResponse of(
+            Long courseTimeId,
+            Long totalEnrollments,
+            Long enrolledCount,
+            Long completedCount,
+            Long droppedCount,
+            Long failedCount,
+            Double averageProgress
+    ) {
+        BigDecimal avgProgress = averageProgress != null
+                ? BigDecimal.valueOf(averageProgress).setScale(2, BigDecimal.ROUND_HALF_UP)
+                : BigDecimal.ZERO;
+
+        BigDecimal completionRate = totalEnrollments > 0
+                ? BigDecimal.valueOf(completedCount * 100.0 / totalEnrollments).setScale(2, BigDecimal.ROUND_HALF_UP)
+                : BigDecimal.ZERO;
+
+        return new CourseTimeEnrollmentStatsResponse(
+                courseTimeId,
+                totalEnrollments,
+                enrolledCount,
+                completedCount,
+                droppedCount,
+                failedCount,
+                avgProgress,
+                completionRate
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/student/dto/response/UserEnrollmentStatsResponse.java
+++ b/src/main/java/com/mzc/lp/domain/student/dto/response/UserEnrollmentStatsResponse.java
@@ -1,0 +1,53 @@
+package com.mzc.lp.domain.student.dto.response;
+
+import java.math.BigDecimal;
+
+/**
+ * 사용자별 수강 통계 Response
+ */
+public record UserEnrollmentStatsResponse(
+        Long userId,
+        Long totalEnrollments,          // 총 수강 횟수
+        Long completedCount,            // 수료 횟수
+        Long inProgressCount,           // 진행 중
+        Long droppedCount,              // 중도 탈락
+        Long failedCount,               // 미수료
+        BigDecimal completionRate,      // 수료율 (%)
+        BigDecimal averageScore,        // 평균 점수 (수료한 과정만)
+        BigDecimal averageProgress      // 평균 진도율
+) {
+    public static UserEnrollmentStatsResponse of(
+            Long userId,
+            Long totalEnrollments,
+            Long completedCount,
+            Long inProgressCount,
+            Long droppedCount,
+            Long failedCount,
+            Double averageScore,
+            Double averageProgress
+    ) {
+        BigDecimal completionRate = totalEnrollments > 0
+                ? BigDecimal.valueOf(completedCount * 100.0 / totalEnrollments).setScale(2, BigDecimal.ROUND_HALF_UP)
+                : BigDecimal.ZERO;
+
+        BigDecimal avgScore = averageScore != null
+                ? BigDecimal.valueOf(averageScore).setScale(2, BigDecimal.ROUND_HALF_UP)
+                : null;
+
+        BigDecimal avgProgress = averageProgress != null
+                ? BigDecimal.valueOf(averageProgress).setScale(2, BigDecimal.ROUND_HALF_UP)
+                : BigDecimal.ZERO;
+
+        return new UserEnrollmentStatsResponse(
+                userId,
+                totalEnrollments,
+                completedCount,
+                inProgressCount,
+                droppedCount,
+                failedCount,
+                completionRate,
+                avgScore,
+                avgProgress
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/student/repository/EnrollmentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/student/repository/EnrollmentRepository.java
@@ -66,4 +66,21 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
     // 사용자별 전체 카운트
     long countByUserIdAndTenantId(Long userId, Long tenantId);
+
+    // ==================== 통계 조회 ====================
+
+    // 차수별 평균 진도율
+    @Query("SELECT AVG(e.progressPercent) FROM Enrollment e WHERE e.courseTimeId = :courseTimeId AND e.tenantId = :tenantId")
+    Double findAverageProgressByCourseTimeId(@Param("courseTimeId") Long courseTimeId, @Param("tenantId") Long tenantId);
+
+    // 차수별 전체 카운트
+    long countByCourseTimeIdAndTenantId(Long courseTimeId, Long tenantId);
+
+    // 사용자별 평균 진도율
+    @Query("SELECT AVG(e.progressPercent) FROM Enrollment e WHERE e.userId = :userId AND e.tenantId = :tenantId")
+    Double findAverageProgressByUserId(@Param("userId") Long userId, @Param("tenantId") Long tenantId);
+
+    // 사용자별 평균 점수 (수료한 과정만)
+    @Query("SELECT AVG(e.score) FROM Enrollment e WHERE e.userId = :userId AND e.tenantId = :tenantId AND e.status = 'COMPLETED' AND e.score IS NOT NULL")
+    Double findAverageScoreByUserId(@Param("userId") Long userId, @Param("tenantId") Long tenantId);
 }

--- a/src/main/java/com/mzc/lp/domain/student/service/EnrollmentStatsService.java
+++ b/src/main/java/com/mzc/lp/domain/student/service/EnrollmentStatsService.java
@@ -1,0 +1,26 @@
+package com.mzc.lp.domain.student.service;
+
+import com.mzc.lp.domain.student.dto.response.CourseTimeEnrollmentStatsResponse;
+import com.mzc.lp.domain.student.dto.response.UserEnrollmentStatsResponse;
+
+/**
+ * 수강 통계 서비스 인터페이스
+ */
+public interface EnrollmentStatsService {
+
+    /**
+     * 차수별 수강 통계 조회
+     *
+     * @param courseTimeId 차수 ID
+     * @return 차수별 수강 통계
+     */
+    CourseTimeEnrollmentStatsResponse getCourseTimeStats(Long courseTimeId);
+
+    /**
+     * 사용자별 수강 통계 조회
+     *
+     * @param userId 사용자 ID
+     * @return 사용자별 수강 통계
+     */
+    UserEnrollmentStatsResponse getUserStats(Long userId);
+}

--- a/src/main/java/com/mzc/lp/domain/student/service/EnrollmentStatsServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/student/service/EnrollmentStatsServiceImpl.java
@@ -1,0 +1,111 @@
+package com.mzc.lp.domain.student.service;
+
+import com.mzc.lp.domain.student.constant.EnrollmentStatus;
+import com.mzc.lp.domain.student.dto.response.CourseTimeEnrollmentStatsResponse;
+import com.mzc.lp.domain.student.dto.response.UserEnrollmentStatsResponse;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.ts.exception.CourseTimeNotFoundException;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import com.mzc.lp.domain.user.exception.UserNotFoundException;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EnrollmentStatsServiceImpl implements EnrollmentStatsService {
+
+    private final EnrollmentRepository enrollmentRepository;
+    private final CourseTimeRepository courseTimeRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public CourseTimeEnrollmentStatsResponse getCourseTimeStats(Long courseTimeId) {
+        Long tenantId = getCurrentTenantId();
+
+        // 차수 존재 확인
+        courseTimeRepository.findByIdAndTenantId(courseTimeId, tenantId)
+                .orElseThrow(() -> new CourseTimeNotFoundException(courseTimeId));
+
+        // 전체 수강생 수
+        long totalEnrollments = enrollmentRepository.countByCourseTimeIdAndTenantId(courseTimeId, tenantId);
+
+        // 상태별 카운트
+        long enrolledCount = enrollmentRepository.countByCourseTimeIdAndStatusAndTenantId(
+                courseTimeId, EnrollmentStatus.ENROLLED, tenantId);
+        long completedCount = enrollmentRepository.countByCourseTimeIdAndStatusAndTenantId(
+                courseTimeId, EnrollmentStatus.COMPLETED, tenantId);
+        long droppedCount = enrollmentRepository.countByCourseTimeIdAndStatusAndTenantId(
+                courseTimeId, EnrollmentStatus.DROPPED, tenantId);
+        long failedCount = enrollmentRepository.countByCourseTimeIdAndStatusAndTenantId(
+                courseTimeId, EnrollmentStatus.FAILED, tenantId);
+
+        // 평균 진도율
+        Double averageProgress = enrollmentRepository.findAverageProgressByCourseTimeId(courseTimeId, tenantId);
+
+        log.debug("차수별 통계 조회 - 차수 ID: {}, 전체: {}, 수강중: {}, 수료: {}",
+                courseTimeId, totalEnrollments, enrolledCount, completedCount);
+
+        return CourseTimeEnrollmentStatsResponse.of(
+                courseTimeId,
+                totalEnrollments,
+                enrolledCount,
+                completedCount,
+                droppedCount,
+                failedCount,
+                averageProgress
+        );
+    }
+
+    @Override
+    public UserEnrollmentStatsResponse getUserStats(Long userId) {
+        Long tenantId = getCurrentTenantId();
+
+        // 사용자 존재 확인
+        userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        // 전체 수강 횟수
+        long totalEnrollments = enrollmentRepository.countByUserIdAndTenantId(userId, tenantId);
+
+        // 상태별 카운트
+        long completedCount = enrollmentRepository.countByUserIdAndStatusAndTenantId(
+                userId, EnrollmentStatus.COMPLETED, tenantId);
+        long inProgressCount = enrollmentRepository.countByUserIdAndStatusAndTenantId(
+                userId, EnrollmentStatus.ENROLLED, tenantId);
+        long droppedCount = enrollmentRepository.countByUserIdAndStatusAndTenantId(
+                userId, EnrollmentStatus.DROPPED, tenantId);
+        long failedCount = enrollmentRepository.countByUserIdAndStatusAndTenantId(
+                userId, EnrollmentStatus.FAILED, tenantId);
+
+        // 평균 점수 (수료한 과정만)
+        Double averageScore = enrollmentRepository.findAverageScoreByUserId(userId, tenantId);
+
+        // 평균 진도율
+        Double averageProgress = enrollmentRepository.findAverageProgressByUserId(userId, tenantId);
+
+        log.debug("사용자별 통계 조회 - 사용자 ID: {}, 전체: {}, 수료: {}, 수료율: {}%",
+                userId, totalEnrollments, completedCount,
+                totalEnrollments > 0 ? (completedCount * 100.0 / totalEnrollments) : 0);
+
+        return UserEnrollmentStatsResponse.of(
+                userId,
+                totalEnrollments,
+                completedCount,
+                inProgressCount,
+                droppedCount,
+                failedCount,
+                averageScore,
+                averageProgress
+        );
+    }
+
+    private Long getCurrentTenantId() {
+        // TODO: SecurityContext에서 tenantId 추출
+        return 1L;
+    }
+}


### PR DESCRIPTION
## Summary
SIS 모듈의 학습 통계 조회 API 2개를 구현했습니다.
- 차수별 수강 통계 (총 수강생, 상태별 카운트, 평균 진도율, 수료율)
- 사용자별 수강 통계 (총 수강 횟수, 수료율, 평균 점수, 평균 진도율)

## 변경 사항

### API 엔드포인트 (2개)
| Method | Endpoint | 설명 | 권한 |
|--------|----------|------|------|
| GET | `/api/ts/course-times/{id}/enrollments/stats` | 차수별 수강 통계 | OPERATOR |
| GET | `/api/users/{userId}/enrollments/stats` | 사용자별 수강 통계 | OPERATOR |

### 차수별 통계 항목
- `totalEnrollments`: 총 수강생 수
- `enrolledCount`: 수강 중
- `completedCount`: 수료
- `droppedCount`: 중도 탈락
- `failedCount`: 미수료
- `averageProgress`: 평균 진도율 (0-100)
- `completionRate`: 수료율 (%)

### 사용자별 통계 항목
- `totalEnrollments`: 총 수강 횟수
- `completedCount`: 수료 횟수
- `inProgressCount`: 진행 중
- `droppedCount`: 중도 탈락
- `failedCount`: 미수료
- `completionRate`: 수료율 (%)
- `averageScore`: 평균 점수 (수료한 과정만)
- `averageProgress`: 평균 진도율

### 파일 추가/수정 (6개)
- `CourseTimeEnrollmentStatsResponse.java` - 차수별 통계 Response DTO
- `UserEnrollmentStatsResponse.java` - 사용자별 통계 Response DTO
- `EnrollmentStatsService.java` - 통계 서비스 인터페이스
- `EnrollmentStatsServiceImpl.java` - 통계 서비스 구현체
- `EnrollmentRepository.java` - 통계 조회 메서드 5개 추가
  - `findAverageProgressByCourseTimeId()`: 차수별 평균 진도율
  - `countByCourseTimeIdAndTenantId()`: 차수별 전체 카운트
  - `findAverageProgressByUserId()`: 사용자별 평균 진도율
  - `findAverageScoreByUserId()`: 사용자별 평균 점수
- `EnrollmentController.java` - 엔드포인트 2개 추가

## 구현 상세

### Response DTO 설계
```java
// 차수별 통계
public record CourseTimeEnrollmentStatsResponse(
    Long courseTimeId,
    Long totalEnrollments,
    Long enrolledCount,
    Long completedCount,
    Long droppedCount,
    Long failedCount,
    BigDecimal averageProgress,
    BigDecimal completionRate
) { ... }

// 사용자별 통계
public record UserEnrollmentStatsResponse(
    Long userId,
    Long totalEnrollments,
    Long completedCount,
    Long inProgressCount,
    Long droppedCount,
    Long failedCount,
    BigDecimal completionRate,
    BigDecimal averageScore,
    BigDecimal averageProgress
) { ... }
```

### Service 계층
- 차수/사용자 존재 여부 검증
- Repository 집계 함수 활용 (COUNT, AVG)
- 수료율 계산 (수료 횟수 / 전체 수강 횟수 * 100)
- BigDecimal로 소수점 2자리 반올림 처리

## Test Plan
- [x] 빌드 성공
- [x] 전체 테스트 통과
- [x] MySQL 기존 데이터 확인 (3건)
- [ ] 통합 테스트 (서버 실행 후 API 호출)

## 비고
- 운영자(OPERATOR) 권한만 조회 가능
- 평균 점수는 수료(COMPLETED) 상태이며 점수가 있는 경우만 계산
- tenantId는 현재 하드코딩(1L), 추후 SecurityContext에서 추출 예정

Closes #56