### PR TITLE
[Feat] TS 배치 Job 구현 - 차수 상태 자동 전환 기능

### DIFF
--- a/src/main/java/com/mzc/lp/LpApplication.java
+++ b/src/main/java/com/mzc/lp/LpApplication.java
@@ -2,8 +2,10 @@ package com.mzc.lp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class LpApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/mzc/lp/domain/ts/repository/CourseTimeRepository.java
+++ b/src/main/java/com/mzc/lp/domain/ts/repository/CourseTimeRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -42,4 +43,18 @@ public interface CourseTimeRepository extends JpaRepository<CourseTime, Long> {
     );
 
     boolean existsByCmCourseIdAndTenantIdAndStatus(Long cmCourseId, Long tenantId, CourseTimeStatus status);
+
+    // ===== 배치 Job용 쿼리 =====
+
+    /**
+     * RECRUITING 상태이면서 classStartDate가 도래한 차수 조회
+     * (상시 모집 차수는 classStartDate가 9999-12-31이므로 자연스럽게 제외)
+     */
+    List<CourseTime> findByStatusAndClassStartDateLessThanEqual(CourseTimeStatus status, LocalDate today);
+
+    /**
+     * ONGOING 상태이면서 classEndDate가 경과한 차수 조회
+     * (상시 모집 차수는 classEndDate가 9999-12-31이므로 자연스럽게 제외)
+     */
+    List<CourseTime> findByStatusAndClassEndDateLessThan(CourseTimeStatus status, LocalDate today);
 }

--- a/src/main/java/com/mzc/lp/domain/ts/scheduler/CourseTimeScheduler.java
+++ b/src/main/java/com/mzc/lp/domain/ts/scheduler/CourseTimeScheduler.java
@@ -1,0 +1,99 @@
+package com.mzc.lp.domain.ts.scheduler;
+
+import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CourseTimeScheduler {
+
+    private final CourseTimeRepository courseTimeRepository;
+
+    /**
+     * RECRUITING → ONGOING 상태 전환 배치
+     * classStartDate가 도래한 차수를 ONGOING으로 전환
+     * 매일 자정(00:00)에 실행
+     */
+    @Scheduled(cron = "${scheduler.course-time.start-class:0 0 0 * * *}")
+    @Transactional
+    public void startCourseTimes() {
+        LocalDate today = LocalDate.now();
+        log.info("[Batch] Starting course times: date={}", today);
+
+        List<CourseTime> courseTimesToStart = courseTimeRepository
+                .findByStatusAndClassStartDateLessThanEqual(CourseTimeStatus.RECRUITING, today);
+
+        if (courseTimesToStart.isEmpty()) {
+            log.info("[Batch] No course times to start");
+            return;
+        }
+
+        int successCount = 0;
+        int failCount = 0;
+
+        for (CourseTime courseTime : courseTimesToStart) {
+            try {
+                courseTime.startClass();
+                successCount++;
+                log.info("[Batch] Course time started: id={}, title={}",
+                        courseTime.getId(), courseTime.getTitle());
+            } catch (Exception e) {
+                failCount++;
+                log.error("[Batch] Failed to start course time: id={}, error={}",
+                        courseTime.getId(), e.getMessage());
+            }
+        }
+
+        log.info("[Batch] Start course times completed: total={}, success={}, fail={}",
+                courseTimesToStart.size(), successCount, failCount);
+    }
+
+    /**
+     * ONGOING → CLOSED 상태 전환 배치
+     * classEndDate가 경과한 차수를 CLOSED로 전환
+     * 매일 자정(00:00)에 실행
+     */
+    @Scheduled(cron = "${scheduler.course-time.close-class:0 0 0 * * *}")
+    @Transactional
+    public void closeCourseTimes() {
+        LocalDate today = LocalDate.now();
+        log.info("[Batch] Closing course times: date={}", today);
+
+        List<CourseTime> courseTimesToClose = courseTimeRepository
+                .findByStatusAndClassEndDateLessThan(CourseTimeStatus.ONGOING, today);
+
+        if (courseTimesToClose.isEmpty()) {
+            log.info("[Batch] No course times to close");
+            return;
+        }
+
+        int successCount = 0;
+        int failCount = 0;
+
+        for (CourseTime courseTime : courseTimesToClose) {
+            try {
+                courseTime.close();
+                successCount++;
+                log.info("[Batch] Course time closed: id={}, title={}",
+                        courseTime.getId(), courseTime.getTitle());
+            } catch (Exception e) {
+                failCount++;
+                log.error("[Batch] Failed to close course time: id={}, error={}",
+                        courseTime.getId(), e.getMessage());
+            }
+        }
+
+        log.info("[Batch] Close course times completed: total={}, success={}, fail={}",
+                courseTimesToClose.size(), successCount, failCount);
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/ts/scheduler/CourseTimeSchedulerTest.java
+++ b/src/test/java/com/mzc/lp/domain/ts/scheduler/CourseTimeSchedulerTest.java
@@ -1,0 +1,242 @@
+package com.mzc.lp.domain.ts.scheduler;
+
+import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+import com.mzc.lp.domain.ts.constant.DeliveryType;
+import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CourseTimeSchedulerTest {
+
+    @InjectMocks
+    private CourseTimeScheduler courseTimeScheduler;
+
+    @Mock
+    private CourseTimeRepository courseTimeRepository;
+
+    private CourseTime createTestCourseTime(LocalDate classStartDate, LocalDate classEndDate) {
+        return CourseTime.create(
+                "테스트 차수",
+                DeliveryType.ONLINE,
+                LocalDate.now().minusDays(30),
+                LocalDate.now().minusDays(1),
+                classStartDate,
+                classEndDate,
+                30,
+                5,
+                EnrollmentMethod.FIRST_COME,
+                80,
+                new BigDecimal("100000"),
+                false,
+                null,
+                true,
+                1L
+        );
+    }
+
+    // ==================== startCourseTimes 테스트 ====================
+
+    @Nested
+    @DisplayName("startCourseTimes - RECRUITING → ONGOING 배치")
+    class StartCourseTimes {
+
+        @Test
+        @DisplayName("성공 - classStartDate 도래한 차수 ONGOING으로 전환")
+        void startCourseTimes_success() {
+            // given
+            CourseTime courseTime = createTestCourseTime(
+                    LocalDate.now(),
+                    LocalDate.now().plusDays(30)
+            );
+            courseTime.open(); // RECRUITING 상태로 변경
+
+            given(courseTimeRepository.findByStatusAndClassStartDateLessThanEqual(
+                    eq(CourseTimeStatus.RECRUITING), any(LocalDate.class)))
+                    .willReturn(List.of(courseTime));
+
+            // when
+            courseTimeScheduler.startCourseTimes();
+
+            // then
+            assertThat(courseTime.getStatus()).isEqualTo(CourseTimeStatus.ONGOING);
+            verify(courseTimeRepository).findByStatusAndClassStartDateLessThanEqual(
+                    eq(CourseTimeStatus.RECRUITING), any(LocalDate.class));
+        }
+
+        @Test
+        @DisplayName("성공 - 전환할 차수가 없는 경우")
+        void startCourseTimes_noCourseTimes() {
+            // given
+            given(courseTimeRepository.findByStatusAndClassStartDateLessThanEqual(
+                    eq(CourseTimeStatus.RECRUITING), any(LocalDate.class)))
+                    .willReturn(Collections.emptyList());
+
+            // when
+            courseTimeScheduler.startCourseTimes();
+
+            // then
+            verify(courseTimeRepository).findByStatusAndClassStartDateLessThanEqual(
+                    eq(CourseTimeStatus.RECRUITING), any(LocalDate.class));
+        }
+
+        @Test
+        @DisplayName("성공 - 여러 차수 일괄 전환")
+        void startCourseTimes_multipleCourseTimes() {
+            // given
+            CourseTime courseTime1 = createTestCourseTime(
+                    LocalDate.now(),
+                    LocalDate.now().plusDays(30)
+            );
+            courseTime1.open();
+
+            CourseTime courseTime2 = createTestCourseTime(
+                    LocalDate.now().minusDays(1),
+                    LocalDate.now().plusDays(29)
+            );
+            courseTime2.open();
+
+            given(courseTimeRepository.findByStatusAndClassStartDateLessThanEqual(
+                    eq(CourseTimeStatus.RECRUITING), any(LocalDate.class)))
+                    .willReturn(List.of(courseTime1, courseTime2));
+
+            // when
+            courseTimeScheduler.startCourseTimes();
+
+            // then
+            assertThat(courseTime1.getStatus()).isEqualTo(CourseTimeStatus.ONGOING);
+            assertThat(courseTime2.getStatus()).isEqualTo(CourseTimeStatus.ONGOING);
+        }
+    }
+
+    // ==================== closeCourseTimes 테스트 ====================
+
+    @Nested
+    @DisplayName("closeCourseTimes - ONGOING → CLOSED 배치")
+    class CloseCourseTimes {
+
+        @Test
+        @DisplayName("성공 - classEndDate 경과한 차수 CLOSED로 전환")
+        void closeCourseTimes_success() {
+            // given
+            CourseTime courseTime = createTestCourseTime(
+                    LocalDate.now().minusDays(30),
+                    LocalDate.now().minusDays(1)
+            );
+            courseTime.open();
+            courseTime.startClass(); // ONGOING 상태로 변경
+
+            given(courseTimeRepository.findByStatusAndClassEndDateLessThan(
+                    eq(CourseTimeStatus.ONGOING), any(LocalDate.class)))
+                    .willReturn(List.of(courseTime));
+
+            // when
+            courseTimeScheduler.closeCourseTimes();
+
+            // then
+            assertThat(courseTime.getStatus()).isEqualTo(CourseTimeStatus.CLOSED);
+            verify(courseTimeRepository).findByStatusAndClassEndDateLessThan(
+                    eq(CourseTimeStatus.ONGOING), any(LocalDate.class));
+        }
+
+        @Test
+        @DisplayName("성공 - 종료할 차수가 없는 경우")
+        void closeCourseTimes_noCourseTimes() {
+            // given
+            given(courseTimeRepository.findByStatusAndClassEndDateLessThan(
+                    eq(CourseTimeStatus.ONGOING), any(LocalDate.class)))
+                    .willReturn(Collections.emptyList());
+
+            // when
+            courseTimeScheduler.closeCourseTimes();
+
+            // then
+            verify(courseTimeRepository).findByStatusAndClassEndDateLessThan(
+                    eq(CourseTimeStatus.ONGOING), any(LocalDate.class));
+        }
+
+        @Test
+        @DisplayName("성공 - 여러 차수 일괄 종료")
+        void closeCourseTimes_multipleCourseTimes() {
+            // given
+            CourseTime courseTime1 = createTestCourseTime(
+                    LocalDate.now().minusDays(60),
+                    LocalDate.now().minusDays(1)
+            );
+            courseTime1.open();
+            courseTime1.startClass();
+
+            CourseTime courseTime2 = createTestCourseTime(
+                    LocalDate.now().minusDays(45),
+                    LocalDate.now().minusDays(2)
+            );
+            courseTime2.open();
+            courseTime2.startClass();
+
+            given(courseTimeRepository.findByStatusAndClassEndDateLessThan(
+                    eq(CourseTimeStatus.ONGOING), any(LocalDate.class)))
+                    .willReturn(List.of(courseTime1, courseTime2));
+
+            // when
+            courseTimeScheduler.closeCourseTimes();
+
+            // then
+            assertThat(courseTime1.getStatus()).isEqualTo(CourseTimeStatus.CLOSED);
+            assertThat(courseTime2.getStatus()).isEqualTo(CourseTimeStatus.CLOSED);
+        }
+    }
+
+    // ==================== B2C 상시 모집 제외 테스트 ====================
+
+    @Nested
+    @DisplayName("B2C 상시 모집 차수 제외")
+    class AlwaysOpenExclusion {
+
+        @Test
+        @DisplayName("상시 모집 차수(9999-12-31)는 배치에서 제외됨을 검증")
+        void alwaysOpen_excludedByDateCondition() {
+            // given
+            // 상시 모집 차수는 classEndDate가 9999-12-31
+            // 쿼리 조건: ct.classEndDate < :today
+            // 9999-12-31 < today는 항상 false이므로 조회되지 않음
+
+            // 일반 차수만 조회됨
+            CourseTime normalCourseTime = createTestCourseTime(
+                    LocalDate.now().minusDays(30),
+                    LocalDate.now().minusDays(1)
+            );
+            normalCourseTime.open();
+            normalCourseTime.startClass();
+
+            given(courseTimeRepository.findByStatusAndClassEndDateLessThan(
+                    eq(CourseTimeStatus.ONGOING), any(LocalDate.class)))
+                    .willReturn(List.of(normalCourseTime));
+
+            // when
+            courseTimeScheduler.closeCourseTimes();
+
+            // then
+            assertThat(normalCourseTime.getStatus()).isEqualTo(CourseTimeStatus.CLOSED);
+            verify(courseTimeRepository).findByStatusAndClassEndDateLessThan(
+                    eq(CourseTimeStatus.ONGOING), any(LocalDate.class));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

TS 배치 Job 구현: 차수 상태 자동 전환 기능
- RECRUITING → ONGOING: classStartDate 도래 시 자동 전환
- ONGOING → CLOSED: classEndDate 경과 시 자동 전환
- B2C 상시 모집(9999-12-31) 자연스럽게 제외

## Related Issue

- Closes #30

## Changes

- `LpApplication.java`: `@EnableScheduling` 추가
- `CourseTimeRepository.java`: 배치용 쿼리 메서드 2개 추가
- `CourseTimeScheduler.java`: 스케줄러 컴포넌트 신규 생성
- `CourseTimeSchedulerTest.java`: 단위 테스트 7개 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Test Plan

- [x] 단위 테스트 통과 (CourseTimeSchedulerTest - 7개 케이스)
- [x] DB 기능 테스트 완료:
  - [x] RECRUITING + classStartDate=오늘 → ONGOING 전환 확인
  - [x] RECRUITING + classStartDate=과거 → ONGOING 전환 확인
  - [x] RECRUITING + classStartDate=미래 → RECRUITING 유지 확인
  - [x] ONGOING + classEndDate=과거 → CLOSED 전환 확인
  - [x] ONGOING + classEndDate=오늘 → ONGOING 유지 확인 (LessThan 조건)
  - [x] ONGOING + classEndDate=미래 → ONGOING 유지 확인
  - [x] B2C 상시모집(9999-12-31) → 배치에서 제외 확인

## Additional Notes

- 스케줄 cron 설정은 외부 설정으로 오버라이드 가능: `scheduler.course-time.start-class`, `scheduler.course-time.close-class`
- 기본값: 매일 자정(00:00) 실행