### PR TITLE
Feat/tenant domain

### DIFF
--- a/src/main/java/com/mzc/lp/common/config/SecurityConfig.java
+++ b/src/main/java/com/mzc/lp/common/config/SecurityConfig.java
@@ -13,6 +13,12 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -25,6 +31,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -37,6 +44,20 @@ public class SecurityConfig {
                         .frameOptions(frame -> frame.sameOrigin()))
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
     @Bean

--- a/src/main/java/com/mzc/lp/common/config/TenantFilterConfig.java
+++ b/src/main/java/com/mzc/lp/common/config/TenantFilterConfig.java
@@ -1,0 +1,42 @@
+package com.mzc.lp.common.config;
+
+import com.mzc.lp.common.context.TenantContext;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.hibernate.Session;
+import org.springframework.stereotype.Component;
+
+/**
+ * Hibernate Tenant Filter 활성화 Aspect
+ * Repository 메서드 호출 전 tenantFilter를 활성화하여
+ * 모든 조회 쿼리에 자동으로 tenant_id 조건을 추가
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TenantFilterConfig {
+
+    private final EntityManager entityManager;
+
+    /**
+     * JpaRepository 메서드 실행 전 tenantFilter 활성화
+     */
+    @Before("execution(* org.springframework.data.jpa.repository.JpaRepository+.*(..))")
+    public void enableTenantFilter() {
+        if (TenantContext.isSet()) {
+            Long tenantId = TenantContext.getCurrentTenantId();
+            Session session = entityManager.unwrap(Session.class);
+
+            // 필터가 이미 활성화되어 있지 않은 경우에만 활성화
+            if (session.getEnabledFilter("tenantFilter") == null) {
+                session.enableFilter("tenantFilter")
+                        .setParameter("tenantId", tenantId);
+                log.debug("Tenant filter enabled for tenantId: {}", tenantId);
+            }
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/common/context/TenantContext.java
+++ b/src/main/java/com/mzc/lp/common/context/TenantContext.java
@@ -1,0 +1,70 @@
+package com.mzc.lp.common.context;
+
+import com.mzc.lp.common.exception.TenantNotFoundException;
+
+/**
+ * ThreadLocal 기반 Tenant Context 관리
+ * 현재 요청의 tenantId를 저장하고 조회하는 유틸리티 클래스
+ */
+public class TenantContext {
+
+    private static final ThreadLocal<Long> currentTenant = new ThreadLocal<>();
+
+    private TenantContext() {
+        // Utility class - 인스턴스화 방지
+    }
+
+    /**
+     * 현재 스레드의 tenantId 설정
+     *
+     * @param tenantId 테넌트 ID (null 불가)
+     * @throws IllegalArgumentException tenantId가 null인 경우
+     */
+    public static void setTenantId(Long tenantId) {
+        if (tenantId == null) {
+            throw new IllegalArgumentException("TenantId cannot be null");
+        }
+        currentTenant.set(tenantId);
+    }
+
+    /**
+     * 현재 스레드의 tenantId 조회
+     *
+     * @return 테넌트 ID
+     * @throws TenantNotFoundException TenantId가 설정되지 않은 경우
+     */
+    public static Long getCurrentTenantId() {
+        Long tenantId = currentTenant.get();
+        if (tenantId == null) {
+            throw new TenantNotFoundException("TenantId not found in current context");
+        }
+        return tenantId;
+    }
+
+    /**
+     * 현재 스레드의 tenantId 조회 (Optional)
+     * Context에 tenantId가 없어도 예외를 발생시키지 않음
+     *
+     * @return 테넌트 ID 또는 null
+     */
+    public static Long getCurrentTenantIdOrNull() {
+        return currentTenant.get();
+    }
+
+    /**
+     * 현재 스레드의 tenantId가 설정되어 있는지 확인
+     *
+     * @return tenantId 설정 여부
+     */
+    public static boolean isSet() {
+        return currentTenant.get() != null;
+    }
+
+    /**
+     * 현재 스레드의 tenantId 제거
+     * 메모리 릭 방지를 위해 요청 종료 시 반드시 호출 필요
+     */
+    public static void clear() {
+        currentTenant.remove();
+    }
+}

--- a/src/main/java/com/mzc/lp/common/entity/TenantEntity.java
+++ b/src/main/java/com/mzc/lp/common/entity/TenantEntity.java
@@ -5,9 +5,18 @@ import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
 import lombok.Getter;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 
 @Getter
 @MappedSuperclass
+@FilterDef(
+        name = "tenantFilter",
+        parameters = @ParamDef(name = "tenantId", type = Long.class),
+        defaultCondition = "tenant_id = :tenantId"
+)
+@Filter(name = "tenantFilter")
 public abstract class TenantEntity extends BaseTimeEntity {
 
     @Column(name = "tenant_id", nullable = false)

--- a/src/main/java/com/mzc/lp/common/entity/TenantEntity.java
+++ b/src/main/java/com/mzc/lp/common/entity/TenantEntity.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.common.entity;
 
+import com.mzc.lp.common.context.TenantContext;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
@@ -15,10 +16,15 @@ public abstract class TenantEntity extends BaseTimeEntity {
     @PrePersist
     protected void prePersistTenant() {
         if (this.tenantId == null) {
-            this.tenantId = 1L; // 기본값: B2C 테넌트
+            // TenantContext에서 자동 주입
+            this.tenantId = TenantContext.getCurrentTenantId();
         }
     }
 
+    /**
+     * TenantId 설정 (테스트 전용)
+     * 프로덕션 코드에서는 TenantContext를 통해 자동 주입됨
+     */
     protected void setTenantId(Long tenantId) {
         this.tenantId = tenantId;
     }

--- a/src/main/java/com/mzc/lp/common/exception/TenantNotFoundException.java
+++ b/src/main/java/com/mzc/lp/common/exception/TenantNotFoundException.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Tenant 정보를 찾을 수 없을 때 발생하는 예외
+ */
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class TenantNotFoundException extends RuntimeException {
+
+    public TenantNotFoundException(String message) {
+        super(message);
+    }
+
+    public TenantNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/mzc/lp/common/filter/TenantFilter.java
+++ b/src/main/java/com/mzc/lp/common/filter/TenantFilter.java
@@ -32,29 +32,41 @@ public class TenantFilter implements Filter {
 
         HttpServletRequest httpRequest = (HttpServletRequest) request;
 
-        try {
-            // 1. JWT에서 tenantId 추출
-            Long tenantId = extractTenantIdFromRequest(httpRequest);
+        // 기존 TenantContext가 설정되어 있는지 확인 (테스트 등에서 미리 설정한 경우)
+        boolean wasAlreadySet = TenantContext.isSet();
+        Long previousTenantId = TenantContext.getCurrentTenantIdOrNull();
 
-            // 2. TenantContext에 설정
-            if (tenantId != null) {
-                TenantContext.setTenantId(tenantId);
-                log.debug("TenantId set in context: {} for request: {} {}",
-                        tenantId, httpRequest.getMethod(), httpRequest.getRequestURI());
+        try {
+            // 기존 컨텍스트가 없는 경우에만 설정
+            if (!wasAlreadySet) {
+                // 1. JWT에서 tenantId 추출
+                Long tenantId = extractTenantIdFromRequest(httpRequest);
+
+                // 2. TenantContext에 설정
+                if (tenantId != null) {
+                    TenantContext.setTenantId(tenantId);
+                    log.debug("TenantId set in context: {} for request: {} {}",
+                            tenantId, httpRequest.getMethod(), httpRequest.getRequestURI());
+                } else {
+                    // Public API나 인증 불필요 경로는 기본 테넌트 (임시)
+                    TenantContext.setTenantId(1L);
+                    log.debug("Default TenantId (1L) set for request: {} {}",
+                            httpRequest.getMethod(), httpRequest.getRequestURI());
+                }
             } else {
-                // Public API나 인증 불필요 경로는 기본 테넌트 (임시)
-                TenantContext.setTenantId(1L);
-                log.debug("Default TenantId (1L) set for request: {} {}",
-                        httpRequest.getMethod(), httpRequest.getRequestURI());
+                log.debug("TenantContext already set (tenantId: {}), skipping for request: {} {}",
+                        previousTenantId, httpRequest.getMethod(), httpRequest.getRequestURI());
             }
 
             // 3. 다음 필터 체인 실행
             chain.doFilter(request, response);
 
         } finally {
-            // 4. 요청 완료 후 반드시 제거 (메모리 릭 방지)
-            TenantContext.clear();
-            log.debug("TenantId cleared from context");
+            // 4. 필터에서 설정한 경우에만 제거 (기존 컨텍스트는 유지)
+            if (!wasAlreadySet) {
+                TenantContext.clear();
+                log.debug("TenantId cleared from context");
+            }
         }
     }
 

--- a/src/main/java/com/mzc/lp/common/filter/TenantFilter.java
+++ b/src/main/java/com/mzc/lp/common/filter/TenantFilter.java
@@ -1,0 +1,88 @@
+package com.mzc.lp.common.filter;
+
+import com.mzc.lp.common.context.TenantContext;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * Tenant Context 설정 Filter
+ * 요청의 JWT 토큰에서 tenantId를 추출하여 TenantContext에 설정
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 10) // SecurityFilter 다음에 실행
+@Slf4j
+public class TenantFilter implements Filter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+
+        try {
+            // 1. JWT에서 tenantId 추출
+            Long tenantId = extractTenantIdFromRequest(httpRequest);
+
+            // 2. TenantContext에 설정
+            if (tenantId != null) {
+                TenantContext.setTenantId(tenantId);
+                log.debug("TenantId set in context: {} for request: {} {}",
+                        tenantId, httpRequest.getMethod(), httpRequest.getRequestURI());
+            } else {
+                // Public API나 인증 불필요 경로는 기본 테넌트 (임시)
+                TenantContext.setTenantId(1L);
+                log.debug("Default TenantId (1L) set for request: {} {}",
+                        httpRequest.getMethod(), httpRequest.getRequestURI());
+            }
+
+            // 3. 다음 필터 체인 실행
+            chain.doFilter(request, response);
+
+        } finally {
+            // 4. 요청 완료 후 반드시 제거 (메모리 릭 방지)
+            TenantContext.clear();
+            log.debug("TenantId cleared from context");
+        }
+    }
+
+    /**
+     * 요청에서 tenantId 추출
+     * 현재는 JWT 연동 전이므로 임시로 null 반환
+     *
+     * @param request HTTP 요청
+     * @return 테넌트 ID (현재는 null)
+     */
+    private Long extractTenantIdFromRequest(HttpServletRequest request) {
+        String authHeader = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+
+        try {
+            // JWT에서 tenantId 추출 (TODO: JwtTokenProvider 연동)
+            // String token = authHeader.substring(BEARER_PREFIX.length());
+            // return jwtTokenProvider.getTenantIdFromToken(token);
+
+            // 임시: JWT 연동 전까지 null 반환
+            return null;
+
+        } catch (Exception e) {
+            log.warn("Failed to extract tenantId from JWT token: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/content/controller/ContentController.java
+++ b/src/main/java/com/mzc/lp/domain/content/controller/ContentController.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.content.controller;
 
+import com.mzc.lp.common.context.TenantContext;
 import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.common.security.UserPrincipal;
 import com.mzc.lp.domain.content.constant.ContentType;
@@ -8,9 +9,6 @@ import com.mzc.lp.domain.content.dto.request.UpdateContentRequest;
 import com.mzc.lp.domain.content.dto.response.ContentListResponse;
 import com.mzc.lp.domain.content.dto.response.ContentResponse;
 import com.mzc.lp.domain.content.service.ContentService;
-import com.mzc.lp.domain.user.entity.User;
-import com.mzc.lp.domain.user.exception.UserNotFoundException;
-import com.mzc.lp.domain.user.repository.UserRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
@@ -37,7 +35,6 @@ import java.nio.charset.StandardCharsets;
 public class ContentController {
 
     private final ContentService contentService;
-    private final UserRepository userRepository;
 
     @PostMapping("/upload")
     @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
@@ -46,7 +43,7 @@ public class ContentController {
             @RequestParam(value = "folderId", required = false) Long folderId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         ContentResponse response = contentService.uploadFile(file, folderId, tenantId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
@@ -57,7 +54,7 @@ public class ContentController {
             @Valid @RequestBody CreateExternalLinkRequest request,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         ContentResponse response = contentService.createExternalLink(request, tenantId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
@@ -70,7 +67,7 @@ public class ContentController {
             @PageableDefault(size = 20) Pageable pageable,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         Page<ContentListResponse> response = contentService.getContents(
                 tenantId, type, keyword, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -82,7 +79,7 @@ public class ContentController {
             @PathVariable Long contentId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         ContentResponse response = contentService.getContent(contentId, tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -93,7 +90,7 @@ public class ContentController {
             @PathVariable Long contentId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         Resource resource = contentService.getFileAsResource(contentId, tenantId);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
@@ -106,7 +103,7 @@ public class ContentController {
             @PathVariable Long contentId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         ContentService.ContentDownloadInfo downloadInfo =
                 contentService.getFileForDownload(contentId, tenantId);
 
@@ -126,7 +123,7 @@ public class ContentController {
             @PathVariable Long contentId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         ContentService.ContentDownloadInfo downloadInfo =
                 contentService.getFileForDownload(contentId, tenantId);
 
@@ -143,7 +140,7 @@ public class ContentController {
             @Valid @RequestBody UpdateContentRequest request,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         ContentResponse response = contentService.updateContent(contentId, request, tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -155,7 +152,7 @@ public class ContentController {
             @RequestParam("file") MultipartFile file,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         ContentResponse response = contentService.replaceFile(contentId, file, tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -166,14 +163,8 @@ public class ContentController {
             @PathVariable Long contentId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         contentService.deleteContent(contentId, tenantId);
         return ResponseEntity.noContent().build();
-    }
-
-    private Long getTenantId(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
-        return user.getTenantId();
     }
 }

--- a/src/main/java/com/mzc/lp/domain/learning/controller/ContentFolderController.java
+++ b/src/main/java/com/mzc/lp/domain/learning/controller/ContentFolderController.java
@@ -1,15 +1,13 @@
 package com.mzc.lp.domain.learning.controller;
 
 import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.context.TenantContext;
 import com.mzc.lp.common.security.UserPrincipal;
 import com.mzc.lp.domain.learning.dto.request.CreateContentFolderRequest;
 import com.mzc.lp.domain.learning.dto.request.MoveContentFolderRequest;
 import com.mzc.lp.domain.learning.dto.request.UpdateContentFolderRequest;
 import com.mzc.lp.domain.learning.dto.response.ContentFolderResponse;
 import com.mzc.lp.domain.learning.service.ContentFolderService;
-import com.mzc.lp.domain.user.entity.User;
-import com.mzc.lp.domain.user.exception.UserNotFoundException;
-import com.mzc.lp.domain.user.repository.UserRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -28,7 +26,6 @@ import java.util.List;
 public class ContentFolderController {
 
     private final ContentFolderService contentFolderService;
-    private final UserRepository userRepository;
 
     @PostMapping
     @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
@@ -36,7 +33,7 @@ public class ContentFolderController {
             @Valid @RequestBody CreateContentFolderRequest request,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         ContentFolderResponse response = contentFolderService.create(request, tenantId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
@@ -46,7 +43,7 @@ public class ContentFolderController {
     public ResponseEntity<ApiResponse<List<ContentFolderResponse>>> getFolderTree(
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         List<ContentFolderResponse> response = contentFolderService.getFolderTree(tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -57,7 +54,7 @@ public class ContentFolderController {
             @PathVariable Long folderId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         ContentFolderResponse response = contentFolderService.getFolder(folderId, tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -68,7 +65,7 @@ public class ContentFolderController {
             @PathVariable Long folderId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         List<ContentFolderResponse> response = contentFolderService.getChildFolders(
                 folderId, tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -81,7 +78,7 @@ public class ContentFolderController {
             @Valid @RequestBody UpdateContentFolderRequest request,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         ContentFolderResponse response = contentFolderService.update(
                 folderId, request, tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -94,7 +91,7 @@ public class ContentFolderController {
             @Valid @RequestBody MoveContentFolderRequest request,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         ContentFolderResponse response = contentFolderService.move(
                 folderId, request, tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -106,14 +103,9 @@ public class ContentFolderController {
             @PathVariable Long folderId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         contentFolderService.delete(folderId, tenantId);
         return ResponseEntity.noContent().build();
     }
 
-    private Long getTenantId(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
-        return user.getTenantId();
-    }
 }

--- a/src/main/java/com/mzc/lp/domain/learning/controller/LearningObjectController.java
+++ b/src/main/java/com/mzc/lp/domain/learning/controller/LearningObjectController.java
@@ -1,15 +1,13 @@
 package com.mzc.lp.domain.learning.controller;
 
 import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.context.TenantContext;
 import com.mzc.lp.common.security.UserPrincipal;
 import com.mzc.lp.domain.learning.dto.request.CreateLearningObjectRequest;
 import com.mzc.lp.domain.learning.dto.request.MoveFolderRequest;
 import com.mzc.lp.domain.learning.dto.request.UpdateLearningObjectRequest;
 import com.mzc.lp.domain.learning.dto.response.LearningObjectResponse;
 import com.mzc.lp.domain.learning.service.LearningObjectService;
-import com.mzc.lp.domain.user.entity.User;
-import com.mzc.lp.domain.user.exception.UserNotFoundException;
-import com.mzc.lp.domain.user.repository.UserRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -29,7 +27,6 @@ import org.springframework.web.bind.annotation.*;
 public class LearningObjectController {
 
     private final LearningObjectService learningObjectService;
-    private final UserRepository userRepository;
 
     @PostMapping
     @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
@@ -37,7 +34,7 @@ public class LearningObjectController {
             @Valid @RequestBody CreateLearningObjectRequest request,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         LearningObjectResponse response = learningObjectService.create(request, tenantId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
@@ -50,7 +47,7 @@ public class LearningObjectController {
             @PageableDefault(size = 20) Pageable pageable,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         Page<LearningObjectResponse> response = learningObjectService.getLearningObjects(
                 tenantId, folderId, keyword, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -62,7 +59,7 @@ public class LearningObjectController {
             @PathVariable Long learningObjectId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         LearningObjectResponse response = learningObjectService.getLearningObject(
                 learningObjectId, tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -74,7 +71,7 @@ public class LearningObjectController {
             @PathVariable Long contentId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         LearningObjectResponse response = learningObjectService.getLearningObjectByContentId(
                 contentId, tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -87,7 +84,7 @@ public class LearningObjectController {
             @Valid @RequestBody UpdateLearningObjectRequest request,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         LearningObjectResponse response = learningObjectService.update(
                 learningObjectId, request, tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -100,7 +97,7 @@ public class LearningObjectController {
             @Valid @RequestBody MoveFolderRequest request,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         LearningObjectResponse response = learningObjectService.moveToFolder(
                 learningObjectId, request, tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -112,14 +109,9 @@ public class LearningObjectController {
             @PathVariable Long learningObjectId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Long tenantId = getTenantId(principal.id());
+        Long tenantId = TenantContext.getCurrentTenantId();
         learningObjectService.delete(learningObjectId, tenantId);
         return ResponseEntity.noContent().build();
     }
 
-    private Long getTenantId(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
-        return user.getTenantId();
-    }
 }

--- a/src/main/java/com/mzc/lp/domain/student/service/EnrollmentServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/student/service/EnrollmentServiceImpl.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.student.service;
 
+import com.mzc.lp.common.context.TenantContext;
 import com.mzc.lp.domain.student.constant.EnrollmentStatus;
 import com.mzc.lp.domain.student.dto.request.CompleteEnrollmentRequest;
 import com.mzc.lp.domain.student.dto.request.ForceEnrollRequest;
@@ -43,7 +44,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     public EnrollmentDetailResponse enroll(Long courseTimeId, Long userId) {
         log.info("Enrolling user: userId={}, courseTimeId={}", userId, courseTimeId);
 
-        Long tenantId = getCurrentTenantId();
+        Long tenantId = TenantContext.getCurrentTenantId();
 
         // 차수 조회 및 검증
         CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(courseTimeId, tenantId)
@@ -78,7 +79,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
         log.info("Force enrolling users: courseTimeId={}, userCount={}, operatorId={}",
                 courseTimeId, request.userIds().size(), operatorId);
 
-        Long tenantId = getCurrentTenantId();
+        Long tenantId = TenantContext.getCurrentTenantId();
 
         // 차수 조회 및 검증
         CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(courseTimeId, tenantId)
@@ -119,7 +120,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     public EnrollmentDetailResponse getEnrollment(Long enrollmentId) {
         log.debug("Getting enrollment: id={}", enrollmentId);
 
-        Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, getCurrentTenantId())
+        Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, TenantContext.getCurrentTenantId())
                 .orElseThrow(() -> new EnrollmentNotFoundException(enrollmentId));
 
         return EnrollmentDetailResponse.from(enrollment);
@@ -129,7 +130,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     public Page<EnrollmentResponse> getEnrollmentsByCourseTime(Long courseTimeId, EnrollmentStatus status, Pageable pageable) {
         log.debug("Getting enrollments by course time: courseTimeId={}, status={}", courseTimeId, status);
 
-        Long tenantId = getCurrentTenantId();
+        Long tenantId = TenantContext.getCurrentTenantId();
 
         if (status != null) {
             return enrollmentRepository.findByCourseTimeIdAndStatusAndTenantId(courseTimeId, status, tenantId, pageable)
@@ -144,7 +145,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     public Page<EnrollmentResponse> getMyEnrollments(Long userId, EnrollmentStatus status, Pageable pageable) {
         log.debug("Getting my enrollments: userId={}, status={}", userId, status);
 
-        Long tenantId = getCurrentTenantId();
+        Long tenantId = TenantContext.getCurrentTenantId();
 
         if (status != null) {
             return enrollmentRepository.findByUserIdAndStatusAndTenantId(userId, status, tenantId, pageable)
@@ -168,7 +169,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     public EnrollmentResponse updateProgress(Long enrollmentId, UpdateProgressRequest request, Long userId) {
         log.info("Updating progress: enrollmentId={}, progressPercent={}", enrollmentId, request.progressPercent());
 
-        Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, getCurrentTenantId())
+        Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, TenantContext.getCurrentTenantId())
                 .orElseThrow(() -> new EnrollmentNotFoundException(enrollmentId));
 
         // 본인 확인 (또는 관리자)
@@ -187,7 +188,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     public EnrollmentDetailResponse completeEnrollment(Long enrollmentId, CompleteEnrollmentRequest request) {
         log.info("Completing enrollment: enrollmentId={}, score={}", enrollmentId, request.score());
 
-        Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, getCurrentTenantId())
+        Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, TenantContext.getCurrentTenantId())
                 .orElseThrow(() -> new EnrollmentNotFoundException(enrollmentId));
 
         enrollment.complete(request.score());
@@ -202,7 +203,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     public EnrollmentDetailResponse updateStatus(Long enrollmentId, UpdateEnrollmentStatusRequest request) {
         log.info("Updating enrollment status: enrollmentId={}, status={}", enrollmentId, request.status());
 
-        Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, getCurrentTenantId())
+        Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, TenantContext.getCurrentTenantId())
                 .orElseThrow(() -> new EnrollmentNotFoundException(enrollmentId));
 
         enrollment.updateStatus(request.status());
@@ -217,7 +218,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     public void cancelEnrollment(Long enrollmentId, Long userId) {
         log.info("Cancelling enrollment: enrollmentId={}, userId={}", enrollmentId, userId);
 
-        Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, getCurrentTenantId())
+        Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, TenantContext.getCurrentTenantId())
                 .orElseThrow(() -> new EnrollmentNotFoundException(enrollmentId));
 
         // 본인 확인
@@ -235,10 +236,5 @@ public class EnrollmentServiceImpl implements EnrollmentService {
         enrollment.drop();
 
         log.info("Enrollment cancelled: enrollmentId={}", enrollmentId);
-    }
-
-    private Long getCurrentTenantId() {
-        // TODO: SecurityContext에서 tenantId 추출
-        return 1L;
     }
 }

--- a/src/main/java/com/mzc/lp/domain/student/service/EnrollmentStatsServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/student/service/EnrollmentStatsServiceImpl.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.student.service;
 
+import com.mzc.lp.common.context.TenantContext;
 import com.mzc.lp.domain.student.constant.EnrollmentStatus;
 import com.mzc.lp.domain.student.dto.response.CourseTimeEnrollmentStatsResponse;
 import com.mzc.lp.domain.student.dto.response.UserEnrollmentStatsResponse;
@@ -25,7 +26,7 @@ public class EnrollmentStatsServiceImpl implements EnrollmentStatsService {
 
     @Override
     public CourseTimeEnrollmentStatsResponse getCourseTimeStats(Long courseTimeId) {
-        Long tenantId = getCurrentTenantId();
+        Long tenantId = TenantContext.getCurrentTenantId();
 
         // 차수 존재 확인
         courseTimeRepository.findByIdAndTenantId(courseTimeId, tenantId)
@@ -63,7 +64,7 @@ public class EnrollmentStatsServiceImpl implements EnrollmentStatsService {
 
     @Override
     public UserEnrollmentStatsResponse getUserStats(Long userId) {
-        Long tenantId = getCurrentTenantId();
+        Long tenantId = TenantContext.getCurrentTenantId();
 
         // 사용자 존재 확인
         userRepository.findById(userId)
@@ -102,10 +103,5 @@ public class EnrollmentStatsServiceImpl implements EnrollmentStatsService {
                 averageScore,
                 averageProgress
         );
-    }
-
-    private Long getCurrentTenantId() {
-        // TODO: SecurityContext에서 tenantId 추출
-        return 1L;
     }
 }

--- a/src/main/java/com/mzc/lp/domain/tenant/constant/PlanType.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/constant/PlanType.java
@@ -1,0 +1,8 @@
+package com.mzc.lp.domain.tenant.constant;
+
+public enum PlanType {
+    FREE,       // 무료 (제한적)
+    BASIC,      // 기본
+    PRO,        // 프로
+    ENTERPRISE  // 엔터프라이즈
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/constant/TenantStatus.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/constant/TenantStatus.java
@@ -1,0 +1,8 @@
+package com.mzc.lp.domain.tenant.constant;
+
+public enum TenantStatus {
+    PENDING,     // 대기 (승인 전)
+    ACTIVE,      // 활성
+    SUSPENDED,   // 정지
+    TERMINATED   // 종료
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/constant/TenantType.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/constant/TenantType.java
@@ -1,0 +1,7 @@
+package com.mzc.lp.domain.tenant.constant;
+
+public enum TenantType {
+    B2C,    // 메인 플랫폼 (인프런형)
+    B2B,    // 기업 전용
+    KPOP    // K-Pop 특화
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/request/CreateTenantRequest.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/request/CreateTenantRequest.java
@@ -1,0 +1,47 @@
+package com.mzc.lp.domain.tenant.dto.request;
+
+import com.mzc.lp.domain.tenant.constant.PlanType;
+import com.mzc.lp.domain.tenant.constant.TenantType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record CreateTenantRequest(
+        @NotBlank(message = "테넌트 코드는 필수입니다")
+        @Size(max = 50, message = "테넌트 코드는 50자 이하여야 합니다")
+        @Pattern(regexp = "^[A-Z0-9_]+$", message = "테넌트 코드는 대문자, 숫자, 언더스코어만 허용됩니다")
+        String code,
+
+        @NotBlank(message = "테넌트 이름은 필수입니다")
+        @Size(max = 100, message = "테넌트 이름은 100자 이하여야 합니다")
+        String name,
+
+        @NotNull(message = "테넌트 타입은 필수입니다")
+        TenantType type,
+
+        @NotBlank(message = "서브도메인은 필수입니다")
+        @Size(max = 50, message = "서브도메인은 50자 이하여야 합니다")
+        @Pattern(regexp = "^[a-z0-9-]+$", message = "서브도메인은 소문자, 숫자, 하이픈만 허용됩니다")
+        String subdomain,
+
+        PlanType plan,
+
+        @Size(max = 255, message = "커스텀 도메인은 255자 이하여야 합니다")
+        String customDomain
+) {
+    public CreateTenantRequest {
+        if (code != null) {
+            code = code.trim().toUpperCase();
+        }
+        if (name != null) {
+            name = name.trim();
+        }
+        if (subdomain != null) {
+            subdomain = subdomain.trim().toLowerCase();
+        }
+        if (customDomain != null) {
+            customDomain = customDomain.trim().toLowerCase();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateTenantRequest.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateTenantRequest.java
@@ -1,0 +1,23 @@
+package com.mzc.lp.domain.tenant.dto.request;
+
+import com.mzc.lp.domain.tenant.constant.PlanType;
+import jakarta.validation.constraints.Size;
+
+public record UpdateTenantRequest(
+        @Size(max = 100, message = "테넌트 이름은 100자 이하여야 합니다")
+        String name,
+
+        @Size(max = 255, message = "커스텀 도메인은 255자 이하여야 합니다")
+        String customDomain,
+
+        PlanType plan
+) {
+    public UpdateTenantRequest {
+        if (name != null) {
+            name = name.trim();
+        }
+        if (customDomain != null) {
+            customDomain = customDomain.trim().toLowerCase();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/response/TenantResponse.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/response/TenantResponse.java
@@ -1,0 +1,36 @@
+package com.mzc.lp.domain.tenant.dto.response;
+
+import com.mzc.lp.domain.tenant.constant.PlanType;
+import com.mzc.lp.domain.tenant.constant.TenantStatus;
+import com.mzc.lp.domain.tenant.constant.TenantType;
+import com.mzc.lp.domain.tenant.entity.Tenant;
+
+import java.time.Instant;
+
+public record TenantResponse(
+        Long tenantId,
+        String code,
+        String name,
+        TenantType type,
+        TenantStatus status,
+        PlanType plan,
+        String subdomain,
+        String customDomain,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static TenantResponse from(Tenant entity) {
+        return new TenantResponse(
+                entity.getId(),
+                entity.getCode(),
+                entity.getName(),
+                entity.getType(),
+                entity.getStatus(),
+                entity.getPlan(),
+                entity.getSubdomain(),
+                entity.getCustomDomain(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/entity/Tenant.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/entity/Tenant.java
@@ -1,0 +1,108 @@
+package com.mzc.lp.domain.tenant.entity;
+
+import com.mzc.lp.common.entity.BaseTimeEntity;
+import com.mzc.lp.domain.tenant.constant.PlanType;
+import com.mzc.lp.domain.tenant.constant.TenantStatus;
+import com.mzc.lp.domain.tenant.constant.TenantType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tenants", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"code"}),
+        @UniqueConstraint(columnNames = {"subdomain"}),
+        @UniqueConstraint(columnNames = {"custom_domain"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tenant extends BaseTimeEntity {
+
+    @Column(nullable = false, length = 50)
+    private String code;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TenantType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TenantStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PlanType plan;
+
+    @Column(nullable = false, length = 50)
+    private String subdomain;
+
+    @Column(name = "custom_domain", length = 255)
+    private String customDomain;
+
+    // 정적 팩토리 메서드
+    public static Tenant create(String code, String name, TenantType type,
+                                String subdomain, PlanType plan) {
+        Tenant tenant = new Tenant();
+        tenant.code = code;
+        tenant.name = name;
+        tenant.type = type;
+        tenant.subdomain = subdomain;
+        tenant.plan = plan != null ? plan : PlanType.FREE;
+        tenant.status = TenantStatus.PENDING;
+        return tenant;
+    }
+
+    public static Tenant create(String code, String name, TenantType type,
+                                String subdomain, PlanType plan, String customDomain) {
+        Tenant tenant = create(code, name, type, subdomain, plan);
+        tenant.customDomain = customDomain;
+        return tenant;
+    }
+
+    // 비즈니스 메서드
+    public void update(String name, String customDomain, PlanType plan) {
+        if (name != null && !name.isBlank()) {
+            this.name = name;
+        }
+        this.customDomain = customDomain;
+        if (plan != null) {
+            this.plan = plan;
+        }
+    }
+
+    public void changeStatus(TenantStatus status) {
+        this.status = status;
+    }
+
+    public void activate() {
+        this.status = TenantStatus.ACTIVE;
+    }
+
+    public void suspend() {
+        this.status = TenantStatus.SUSPENDED;
+    }
+
+    public void terminate() {
+        this.status = TenantStatus.TERMINATED;
+    }
+
+    public boolean isActive() {
+        return this.status == TenantStatus.ACTIVE;
+    }
+
+    public boolean isPending() {
+        return this.status == TenantStatus.PENDING;
+    }
+
+    public boolean isSuspended() {
+        return this.status == TenantStatus.SUSPENDED;
+    }
+
+    public boolean isTerminated() {
+        return this.status == TenantStatus.TERMINATED;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/repository/TenantRepository.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/repository/TenantRepository.java
@@ -1,0 +1,26 @@
+package com.mzc.lp.domain.tenant.repository;
+
+import com.mzc.lp.domain.tenant.constant.TenantStatus;
+import com.mzc.lp.domain.tenant.entity.Tenant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TenantRepository extends JpaRepository<Tenant, Long> {
+
+    Optional<Tenant> findByCode(String code);
+
+    Optional<Tenant> findBySubdomain(String subdomain);
+
+    Optional<Tenant> findByCustomDomain(String customDomain);
+
+    Optional<Tenant> findBySubdomainAndStatus(String subdomain, TenantStatus status);
+
+    Optional<Tenant> findByCustomDomainAndStatus(String customDomain, TenantStatus status);
+
+    boolean existsByCode(String code);
+
+    boolean existsBySubdomain(String subdomain);
+
+    boolean existsByCustomDomain(String customDomain);
+}

--- a/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeServiceImpl.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.ts.service;
 
+import com.mzc.lp.common.context.TenantContext;
 import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
 import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
 import com.mzc.lp.domain.ts.dto.request.CreateCourseTimeRequest;
@@ -76,7 +77,7 @@ public class CourseTimeServiceImpl implements CourseTimeService {
         log.debug("Getting course times: status={}, cmCourseId={}", status, cmCourseId);
 
         if (cmCourseId != null) {
-            return courseTimeRepository.findByCmCourseIdAndTenantId(cmCourseId, getCurrentTenantId())
+            return courseTimeRepository.findByCmCourseIdAndTenantId(cmCourseId, TenantContext.getCurrentTenantId())
                     .stream()
                     .filter(ct -> status == null || ct.getStatus() == status)
                     .map(CourseTimeResponse::from)
@@ -87,11 +88,11 @@ public class CourseTimeServiceImpl implements CourseTimeService {
         }
 
         if (status != null) {
-            return courseTimeRepository.findByTenantIdAndStatus(getCurrentTenantId(), status, pageable)
+            return courseTimeRepository.findByTenantIdAndStatus(TenantContext.getCurrentTenantId(), status, pageable)
                     .map(CourseTimeResponse::from);
         }
 
-        return courseTimeRepository.findByTenantId(getCurrentTenantId(), pageable)
+        return courseTimeRepository.findByTenantId(TenantContext.getCurrentTenantId(), pageable)
                 .map(CourseTimeResponse::from);
     }
 
@@ -99,7 +100,7 @@ public class CourseTimeServiceImpl implements CourseTimeService {
     public CourseTimeDetailResponse getCourseTime(Long id) {
         log.debug("Getting course time: id={}", id);
 
-        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, getCurrentTenantId())
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, TenantContext.getCurrentTenantId())
                 .orElseThrow(() -> new CourseTimeNotFoundException(id));
 
         return CourseTimeDetailResponse.from(courseTime);
@@ -110,7 +111,7 @@ public class CourseTimeServiceImpl implements CourseTimeService {
     public CourseTimeDetailResponse updateCourseTime(Long id, UpdateCourseTimeRequest request) {
         log.info("Updating course time: id={}", id);
 
-        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, getCurrentTenantId())
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, TenantContext.getCurrentTenantId())
                 .orElseThrow(() -> new CourseTimeNotFoundException(id));
 
         // DRAFT 또는 RECRUITING 상태에서만 수정 가능
@@ -168,7 +169,7 @@ public class CourseTimeServiceImpl implements CourseTimeService {
     public void deleteCourseTime(Long id) {
         log.info("Deleting course time: id={}", id);
 
-        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, getCurrentTenantId())
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, TenantContext.getCurrentTenantId())
                 .orElseThrow(() -> new CourseTimeNotFoundException(id));
 
         // DRAFT 상태에서만 삭제 가능
@@ -187,7 +188,7 @@ public class CourseTimeServiceImpl implements CourseTimeService {
     public CourseTimeDetailResponse openCourseTime(Long id) {
         log.info("Opening course time: id={}", id);
 
-        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, getCurrentTenantId())
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, TenantContext.getCurrentTenantId())
                 .orElseThrow(() -> new CourseTimeNotFoundException(id));
 
         if (!courseTime.isDraft()) {
@@ -214,7 +215,7 @@ public class CourseTimeServiceImpl implements CourseTimeService {
     public CourseTimeDetailResponse startCourseTime(Long id) {
         log.info("Starting course time: id={}", id);
 
-        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, getCurrentTenantId())
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, TenantContext.getCurrentTenantId())
                 .orElseThrow(() -> new CourseTimeNotFoundException(id));
 
         if (!courseTime.isRecruiting()) {
@@ -235,7 +236,7 @@ public class CourseTimeServiceImpl implements CourseTimeService {
     public CourseTimeDetailResponse closeCourseTime(Long id) {
         log.info("Closing course time: id={}", id);
 
-        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, getCurrentTenantId())
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, TenantContext.getCurrentTenantId())
                 .orElseThrow(() -> new CourseTimeNotFoundException(id));
 
         if (!courseTime.isOngoing()) {
@@ -256,7 +257,7 @@ public class CourseTimeServiceImpl implements CourseTimeService {
     public CourseTimeDetailResponse archiveCourseTime(Long id) {
         log.info("Archiving course time: id={}", id);
 
-        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, getCurrentTenantId())
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, TenantContext.getCurrentTenantId())
                 .orElseThrow(() -> new CourseTimeNotFoundException(id));
 
         if (!courseTime.isClosed()) {
@@ -307,12 +308,6 @@ public class CourseTimeServiceImpl implements CourseTimeService {
                 && request.maxWaitingCount() > 0) {
             throw new IllegalArgumentException("승인제 모집에서는 대기자 기능을 사용할 수 없습니다");
         }
-    }
-
-    private Long getCurrentTenantId() {
-        // TODO: SecurityContext에서 tenantId 추출
-        // 현재는 임시로 1L 반환
-        return 1L;
     }
 
     // ========== 정원 관리 (SIS에서 호출) ==========

--- a/src/test/java/com/mzc/lp/common/context/TenantContextTest.java
+++ b/src/test/java/com/mzc/lp/common/context/TenantContextTest.java
@@ -1,0 +1,105 @@
+package com.mzc.lp.common.context;
+
+import com.mzc.lp.common.exception.TenantNotFoundException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("TenantContext 단위 테스트")
+class TenantContextTest {
+
+    @AfterEach
+    void tearDown() {
+        // 각 테스트 후 TenantContext 초기화
+        TenantContext.clear();
+    }
+
+    @Test
+    @DisplayName("tenantId 설정 후 조회 성공")
+    void setAndGet_Success() {
+        // given
+        Long tenantId = 123L;
+
+        // when
+        TenantContext.setTenantId(tenantId);
+
+        // then
+        assertThat(TenantContext.getCurrentTenantId()).isEqualTo(123L);
+        assertThat(TenantContext.isSet()).isTrue();
+    }
+
+    @Test
+    @DisplayName("null tenantId 설정 시 IllegalArgumentException 발생")
+    void setTenantId_ThrowsException_WhenNull() {
+        // when & then
+        assertThatThrownBy(() -> TenantContext.setTenantId(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("TenantId cannot be null");
+    }
+
+    @Test
+    @DisplayName("tenantId 미설정 시 getCurrentTenantId() 호출하면 TenantNotFoundException 발생")
+    void getCurrentTenantId_ThrowsException_WhenNotSet() {
+        // when & then
+        assertThatThrownBy(() -> TenantContext.getCurrentTenantId())
+                .isInstanceOf(TenantNotFoundException.class)
+                .hasMessage("TenantId not found in current context");
+    }
+
+    @Test
+    @DisplayName("getCurrentTenantIdOrNull()은 미설정 시 null 반환")
+    void getCurrentTenantIdOrNull_ReturnsNull_WhenNotSet() {
+        // when
+        Long tenantId = TenantContext.getCurrentTenantIdOrNull();
+
+        // then
+        assertThat(tenantId).isNull();
+        assertThat(TenantContext.isSet()).isFalse();
+    }
+
+    @Test
+    @DisplayName("tenantId 설정 후 clear() 호출하면 제거됨")
+    void clear_RemovesTenantId() {
+        // given
+        TenantContext.setTenantId(123L);
+        assertThat(TenantContext.isSet()).isTrue();
+
+        // when
+        TenantContext.clear();
+
+        // then
+        assertThat(TenantContext.getCurrentTenantIdOrNull()).isNull();
+        assertThat(TenantContext.isSet()).isFalse();
+    }
+
+    @Test
+    @DisplayName("서로 다른 tenantId를 순차적으로 설정 가능")
+    void setTenantId_Multiple_Sequential() {
+        // given & when
+        TenantContext.setTenantId(100L);
+        assertThat(TenantContext.getCurrentTenantId()).isEqualTo(100L);
+
+        TenantContext.setTenantId(200L);
+        assertThat(TenantContext.getCurrentTenantId()).isEqualTo(200L);
+
+        TenantContext.setTenantId(300L);
+        assertThat(TenantContext.getCurrentTenantId()).isEqualTo(300L);
+    }
+
+    @Test
+    @DisplayName("clear() 여러 번 호출해도 예외 발생하지 않음")
+    void clear_MultipleTimes_NoException() {
+        // given
+        TenantContext.setTenantId(123L);
+
+        // when & then
+        TenantContext.clear();
+        TenantContext.clear();
+        TenantContext.clear();
+
+        assertThat(TenantContext.isSet()).isFalse();
+    }
+}

--- a/src/test/java/com/mzc/lp/common/support/TenantTestSupport.java
+++ b/src/test/java/com/mzc/lp/common/support/TenantTestSupport.java
@@ -19,7 +19,7 @@ public abstract class TenantTestSupport {
      * 각 테스트 시작 전 TenantContext 설정
      */
     @BeforeEach
-    void setUpTenantContext() {
+    protected void setUpTenantContext() {
         TenantContext.setTenantId(DEFAULT_TENANT_ID);
     }
 
@@ -28,7 +28,7 @@ public abstract class TenantTestSupport {
      * ThreadLocal 메모리 릭 방지
      */
     @AfterEach
-    void tearDownTenantContext() {
+    protected void tearDownTenantContext() {
         TenantContext.clear();
     }
 

--- a/src/test/java/com/mzc/lp/common/support/TenantTestSupport.java
+++ b/src/test/java/com/mzc/lp/common/support/TenantTestSupport.java
@@ -1,0 +1,42 @@
+package com.mzc.lp.common.support;
+
+import com.mzc.lp.common.context.TenantContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Tenant Context를 자동으로 설정/해제하는 테스트 Base 클래스
+ * 모든 통합 테스트는 이 클래스를 상속받아야 함
+ */
+public abstract class TenantTestSupport {
+
+    /**
+     * 기본 테넌트 ID (테스트용)
+     */
+    protected static final Long DEFAULT_TENANT_ID = 1L;
+
+    /**
+     * 각 테스트 시작 전 TenantContext 설정
+     */
+    @BeforeEach
+    void setUpTenantContext() {
+        TenantContext.setTenantId(DEFAULT_TENANT_ID);
+    }
+
+    /**
+     * 각 테스트 종료 후 TenantContext 초기화
+     * ThreadLocal 메모리 릭 방지
+     */
+    @AfterEach
+    void tearDownTenantContext() {
+        TenantContext.clear();
+    }
+
+    /**
+     * 테스트 중 다른 테넌트로 변경 (멀티테넌시 테스트용)
+     */
+    protected void switchTenant(Long tenantId) {
+        TenantContext.clear();
+        TenantContext.setTenantId(tenantId);
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/content/controller/ContentControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/content/controller/ContentControllerTest.java
@@ -1,4 +1,5 @@
 package com.mzc.lp.domain.content.controller;
+import com.mzc.lp.common.support.TenantTestSupport;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mzc.lp.domain.content.constant.ContentType;
@@ -33,7 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-class ContentControllerTest {
+class ContentControllerTest extends TenantTestSupport {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/mzc/lp/domain/content/service/ThumbnailServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/content/service/ThumbnailServiceTest.java
@@ -1,4 +1,5 @@
 package com.mzc.lp.domain.content.service;
+import com.mzc.lp.common.support.TenantTestSupport;
 
 import com.mzc.lp.domain.content.constant.ContentType;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,7 +18,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ThumbnailServiceTest {
+class ThumbnailServiceTest extends TenantTestSupport {
 
     private ThumbnailService thumbnailService;
 

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseControllerTest.java
@@ -1,4 +1,5 @@
 package com.mzc.lp.domain.course.controller;
+import com.mzc.lp.common.support.TenantTestSupport;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mzc.lp.domain.course.constant.CourseLevel;
@@ -32,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-class CourseControllerTest {
+class CourseControllerTest extends TenantTestSupport {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseItemControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseItemControllerTest.java
@@ -1,4 +1,5 @@
 package com.mzc.lp.domain.course.controller;
+import com.mzc.lp.common.support.TenantTestSupport;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mzc.lp.domain.course.constant.CourseLevel;
@@ -36,7 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-class CourseItemControllerTest {
+class CourseItemControllerTest extends TenantTestSupport {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/mzc/lp/domain/iis/repository/AssignmentHistoryRepositoryTest.java
+++ b/src/test/java/com/mzc/lp/domain/iis/repository/AssignmentHistoryRepositoryTest.java
@@ -1,4 +1,5 @@
 package com.mzc.lp.domain.iis.repository;
+import com.mzc.lp.common.support.TenantTestSupport;
 
 import com.mzc.lp.common.config.JpaConfig;
 import com.mzc.lp.domain.iis.constant.AssignmentStatus;
@@ -22,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @Import(JpaConfig.class)
 @ActiveProfiles("test")
-class AssignmentHistoryRepositoryTest {
+class AssignmentHistoryRepositoryTest extends TenantTestSupport {
 
     @Autowired
     private AssignmentHistoryRepository historyRepository;

--- a/src/test/java/com/mzc/lp/domain/iis/repository/InstructorAssignmentRepositoryTest.java
+++ b/src/test/java/com/mzc/lp/domain/iis/repository/InstructorAssignmentRepositoryTest.java
@@ -1,4 +1,5 @@
 package com.mzc.lp.domain.iis.repository;
+import com.mzc.lp.common.support.TenantTestSupport;
 
 import com.mzc.lp.common.config.JpaConfig;
 import com.mzc.lp.domain.iis.constant.AssignmentStatus;
@@ -23,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @Import(JpaConfig.class)
 @ActiveProfiles("test")
-class InstructorAssignmentRepositoryTest {
+class InstructorAssignmentRepositoryTest extends TenantTestSupport {
 
     @Autowired
     private InstructorAssignmentRepository assignmentRepository;

--- a/src/test/java/com/mzc/lp/domain/learning/controller/ContentFolderControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/learning/controller/ContentFolderControllerTest.java
@@ -1,4 +1,5 @@
 package com.mzc.lp.domain.learning.controller;
+import com.mzc.lp.common.support.TenantTestSupport;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mzc.lp.domain.learning.dto.request.CreateContentFolderRequest;
@@ -27,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-class ContentFolderControllerTest {
+class ContentFolderControllerTest extends TenantTestSupport {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/mzc/lp/domain/learning/controller/LearningObjectControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/learning/controller/LearningObjectControllerTest.java
@@ -1,4 +1,5 @@
 package com.mzc.lp.domain.learning.controller;
+import com.mzc.lp.common.support.TenantTestSupport;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mzc.lp.domain.content.constant.ContentType;
@@ -32,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-class LearningObjectControllerTest {
+class LearningObjectControllerTest extends TenantTestSupport {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/mzc/lp/domain/student/service/EnrollmentServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/student/service/EnrollmentServiceTest.java
@@ -1,4 +1,5 @@
 package com.mzc.lp.domain.student.service;
+import com.mzc.lp.common.support.TenantTestSupport;
 
 import com.mzc.lp.domain.student.constant.EnrollmentStatus;
 import com.mzc.lp.domain.student.constant.EnrollmentType;
@@ -45,7 +46,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-class EnrollmentServiceTest {
+class EnrollmentServiceTest extends TenantTestSupport {
 
     @InjectMocks
     private EnrollmentServiceImpl enrollmentService;

--- a/src/test/java/com/mzc/lp/domain/tenant/entity/TenantTest.java
+++ b/src/test/java/com/mzc/lp/domain/tenant/entity/TenantTest.java
@@ -1,0 +1,170 @@
+package com.mzc.lp.domain.tenant.entity;
+
+import com.mzc.lp.domain.tenant.constant.PlanType;
+import com.mzc.lp.domain.tenant.constant.TenantStatus;
+import com.mzc.lp.domain.tenant.constant.TenantType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TenantTest {
+
+    @Nested
+    @DisplayName("create 메서드는")
+    class Describe_create {
+
+        @Test
+        @DisplayName("기본값으로 테넌트를 생성한다")
+        void it_creates_tenant_with_defaults() {
+            // given
+            String code = "SAMSUNG";
+            String name = "삼성전자";
+            TenantType type = TenantType.B2B;
+            String subdomain = "samsung";
+
+            // when
+            Tenant tenant = Tenant.create(code, name, type, subdomain, null);
+
+            // then
+            assertThat(tenant.getCode()).isEqualTo(code);
+            assertThat(tenant.getName()).isEqualTo(name);
+            assertThat(tenant.getType()).isEqualTo(type);
+            assertThat(tenant.getSubdomain()).isEqualTo(subdomain);
+            assertThat(tenant.getPlan()).isEqualTo(PlanType.FREE);
+            assertThat(tenant.getStatus()).isEqualTo(TenantStatus.PENDING);
+            assertThat(tenant.getCustomDomain()).isNull();
+        }
+
+        @Test
+        @DisplayName("요금제와 커스텀 도메인을 포함하여 테넌트를 생성한다")
+        void it_creates_tenant_with_plan_and_custom_domain() {
+            // given
+            String code = "SAMSUNG";
+            String name = "삼성전자";
+            TenantType type = TenantType.B2B;
+            String subdomain = "samsung";
+            PlanType plan = PlanType.ENTERPRISE;
+            String customDomain = "learn.samsung.com";
+
+            // when
+            Tenant tenant = Tenant.create(code, name, type, subdomain, plan, customDomain);
+
+            // then
+            assertThat(tenant.getPlan()).isEqualTo(PlanType.ENTERPRISE);
+            assertThat(tenant.getCustomDomain()).isEqualTo(customDomain);
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 변경 메서드는")
+    class Describe_status_change {
+
+        @Test
+        @DisplayName("activate로 ACTIVE 상태로 변경한다")
+        void it_activates_tenant() {
+            // given
+            Tenant tenant = Tenant.create("TEST", "테스트", TenantType.B2C, "test", null);
+            assertThat(tenant.getStatus()).isEqualTo(TenantStatus.PENDING);
+
+            // when
+            tenant.activate();
+
+            // then
+            assertThat(tenant.getStatus()).isEqualTo(TenantStatus.ACTIVE);
+            assertThat(tenant.isActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("suspend로 SUSPENDED 상태로 변경한다")
+        void it_suspends_tenant() {
+            // given
+            Tenant tenant = Tenant.create("TEST", "테스트", TenantType.B2C, "test", null);
+            tenant.activate();
+
+            // when
+            tenant.suspend();
+
+            // then
+            assertThat(tenant.getStatus()).isEqualTo(TenantStatus.SUSPENDED);
+            assertThat(tenant.isSuspended()).isTrue();
+        }
+
+        @Test
+        @DisplayName("terminate로 TERMINATED 상태로 변경한다")
+        void it_terminates_tenant() {
+            // given
+            Tenant tenant = Tenant.create("TEST", "테스트", TenantType.B2C, "test", null);
+
+            // when
+            tenant.terminate();
+
+            // then
+            assertThat(tenant.getStatus()).isEqualTo(TenantStatus.TERMINATED);
+            assertThat(tenant.isTerminated()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("update 메서드는")
+    class Describe_update {
+
+        @Test
+        @DisplayName("이름, 커스텀 도메인, 요금제를 수정한다")
+        void it_updates_tenant() {
+            // given
+            Tenant tenant = Tenant.create("SAMSUNG", "삼성전자", TenantType.B2B, "samsung", PlanType.BASIC);
+
+            // when
+            tenant.update("삼성전자 러닝센터", "learn.samsung.com", PlanType.ENTERPRISE);
+
+            // then
+            assertThat(tenant.getName()).isEqualTo("삼성전자 러닝센터");
+            assertThat(tenant.getCustomDomain()).isEqualTo("learn.samsung.com");
+            assertThat(tenant.getPlan()).isEqualTo(PlanType.ENTERPRISE);
+        }
+
+        @Test
+        @DisplayName("null 이름은 무시하고 기존 값을 유지한다")
+        void it_ignores_null_name() {
+            // given
+            Tenant tenant = Tenant.create("SAMSUNG", "삼성전자", TenantType.B2B, "samsung", PlanType.BASIC);
+
+            // when
+            tenant.update(null, "learn.samsung.com", PlanType.ENTERPRISE);
+
+            // then
+            assertThat(tenant.getName()).isEqualTo("삼성전자");
+        }
+
+        @Test
+        @DisplayName("빈 이름은 무시하고 기존 값을 유지한다")
+        void it_ignores_blank_name() {
+            // given
+            Tenant tenant = Tenant.create("SAMSUNG", "삼성전자", TenantType.B2B, "samsung", PlanType.BASIC);
+
+            // when
+            tenant.update("   ", "learn.samsung.com", PlanType.ENTERPRISE);
+
+            // then
+            assertThat(tenant.getName()).isEqualTo("삼성전자");
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 확인 메서드는")
+    class Describe_status_check {
+
+        @Test
+        @DisplayName("isPending은 PENDING 상태일 때 true를 반환한다")
+        void it_returns_true_for_pending() {
+            Tenant tenant = Tenant.create("TEST", "테스트", TenantType.B2C, "test", null);
+
+            assertThat(tenant.isPending()).isTrue();
+            assertThat(tenant.isActive()).isFalse();
+            assertThat(tenant.isSuspended()).isFalse();
+            assertThat(tenant.isTerminated()).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/tenant/repository/TenantRepositoryTest.java
+++ b/src/test/java/com/mzc/lp/domain/tenant/repository/TenantRepositoryTest.java
@@ -1,0 +1,150 @@
+package com.mzc.lp.domain.tenant.repository;
+
+import com.mzc.lp.domain.tenant.constant.PlanType;
+import com.mzc.lp.domain.tenant.constant.TenantStatus;
+import com.mzc.lp.domain.tenant.constant.TenantType;
+import com.mzc.lp.domain.tenant.entity.Tenant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class TenantRepositoryTest {
+
+    @Autowired
+    private TenantRepository tenantRepository;
+
+    @BeforeEach
+    void setUp() {
+        tenantRepository.deleteAll();
+
+        Tenant tenant = Tenant.create(
+                "SAMSUNG",
+                "삼성전자",
+                TenantType.B2B,
+                "samsung",
+                PlanType.ENTERPRISE,
+                "learn.samsung.com"
+        );
+        tenant.activate();
+        tenantRepository.save(tenant);
+    }
+
+    @Nested
+    @DisplayName("findByCode 메서드는")
+    class Describe_findByCode {
+
+        @Test
+        @DisplayName("코드로 테넌트를 조회한다")
+        void it_finds_tenant_by_code() {
+            // when
+            Optional<Tenant> result = tenantRepository.findByCode("SAMSUNG");
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().getName()).isEqualTo("삼성전자");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 코드로 조회하면 빈 Optional을 반환한다")
+        void it_returns_empty_for_nonexistent_code() {
+            // when
+            Optional<Tenant> result = tenantRepository.findByCode("NONEXISTENT");
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findBySubdomain 메서드는")
+    class Describe_findBySubdomain {
+
+        @Test
+        @DisplayName("서브도메인으로 테넌트를 조회한다")
+        void it_finds_tenant_by_subdomain() {
+            // when
+            Optional<Tenant> result = tenantRepository.findBySubdomain("samsung");
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().getCode()).isEqualTo("SAMSUNG");
+        }
+    }
+
+    @Nested
+    @DisplayName("findBySubdomainAndStatus 메서드는")
+    class Describe_findBySubdomainAndStatus {
+
+        @Test
+        @DisplayName("서브도메인과 상태로 테넌트를 조회한다")
+        void it_finds_tenant_by_subdomain_and_status() {
+            // when
+            Optional<Tenant> result = tenantRepository.findBySubdomainAndStatus("samsung", TenantStatus.ACTIVE);
+
+            // then
+            assertThat(result).isPresent();
+        }
+
+        @Test
+        @DisplayName("상태가 일치하지 않으면 빈 Optional을 반환한다")
+        void it_returns_empty_for_mismatched_status() {
+            // when
+            Optional<Tenant> result = tenantRepository.findBySubdomainAndStatus("samsung", TenantStatus.PENDING);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByCustomDomain 메서드는")
+    class Describe_findByCustomDomain {
+
+        @Test
+        @DisplayName("커스텀 도메인으로 테넌트를 조회한다")
+        void it_finds_tenant_by_custom_domain() {
+            // when
+            Optional<Tenant> result = tenantRepository.findByCustomDomain("learn.samsung.com");
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().getCode()).isEqualTo("SAMSUNG");
+        }
+    }
+
+    @Nested
+    @DisplayName("exists 메서드는")
+    class Describe_exists {
+
+        @Test
+        @DisplayName("existsByCode는 존재 여부를 반환한다")
+        void it_checks_code_exists() {
+            assertThat(tenantRepository.existsByCode("SAMSUNG")).isTrue();
+            assertThat(tenantRepository.existsByCode("NONEXISTENT")).isFalse();
+        }
+
+        @Test
+        @DisplayName("existsBySubdomain은 존재 여부를 반환한다")
+        void it_checks_subdomain_exists() {
+            assertThat(tenantRepository.existsBySubdomain("samsung")).isTrue();
+            assertThat(tenantRepository.existsBySubdomain("nonexistent")).isFalse();
+        }
+
+        @Test
+        @DisplayName("existsByCustomDomain은 존재 여부를 반환한다")
+        void it_checks_custom_domain_exists() {
+            assertThat(tenantRepository.existsByCustomDomain("learn.samsung.com")).isTrue();
+            assertThat(tenantRepository.existsByCustomDomain("nonexistent.com")).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/ts/controller/CourseTimeControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/ts/controller/CourseTimeControllerTest.java
@@ -1,4 +1,5 @@
 package com.mzc.lp.domain.ts.controller;
+import com.mzc.lp.common.support.TenantTestSupport;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
@@ -35,7 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-class CourseTimeControllerTest {
+class CourseTimeControllerTest extends TenantTestSupport {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/mzc/lp/domain/ts/repository/CourseTimeRepositoryTest.java
+++ b/src/test/java/com/mzc/lp/domain/ts/repository/CourseTimeRepositoryTest.java
@@ -1,4 +1,5 @@
 package com.mzc.lp.domain.ts.repository;
+import com.mzc.lp.common.support.TenantTestSupport;
 
 import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
 import com.mzc.lp.domain.ts.constant.DeliveryType;
@@ -26,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @Import(JpaConfig.class)
 @ActiveProfiles("test")
-class CourseTimeRepositoryTest {
+class CourseTimeRepositoryTest extends TenantTestSupport {
 
     @Autowired
     private CourseTimeRepository courseTimeRepository;

--- a/src/test/java/com/mzc/lp/domain/ts/scheduler/CourseTimeSchedulerTest.java
+++ b/src/test/java/com/mzc/lp/domain/ts/scheduler/CourseTimeSchedulerTest.java
@@ -1,4 +1,5 @@
 package com.mzc.lp.domain.ts.scheduler;
+import com.mzc.lp.common.support.TenantTestSupport;
 
 import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
 import com.mzc.lp.domain.ts.constant.DeliveryType;
@@ -25,7 +26,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class CourseTimeSchedulerTest {
+class CourseTimeSchedulerTest extends TenantTestSupport {
 
     @InjectMocks
     private CourseTimeScheduler courseTimeScheduler;

--- a/src/test/java/com/mzc/lp/domain/ts/service/CourseTimeServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/ts/service/CourseTimeServiceTest.java
@@ -1,4 +1,5 @@
 package com.mzc.lp.domain.ts.service;
+import com.mzc.lp.common.support.TenantTestSupport;
 
 import com.mzc.lp.domain.ts.constant.DeliveryType;
 import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
@@ -26,7 +27,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class CourseTimeServiceTest {
+class CourseTimeServiceTest extends TenantTestSupport {
 
     @InjectMocks
     private CourseTimeServiceImpl courseTimeService;

--- a/src/test/java/com/mzc/lp/domain/user/controller/AuthControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/user/controller/AuthControllerTest.java
@@ -1,4 +1,5 @@
 package com.mzc.lp.domain.user.controller;
+import com.mzc.lp.common.support.TenantTestSupport;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mzc.lp.domain.user.dto.request.LoginRequest;
@@ -24,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-class AuthControllerTest {
+class AuthControllerTest extends TenantTestSupport {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/mzc/lp/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/user/controller/UserControllerTest.java
@@ -1,4 +1,5 @@
 package com.mzc.lp.domain.user.controller;
+import com.mzc.lp.common.support.TenantTestSupport;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mzc.lp.domain.user.constant.TenantRole;
@@ -27,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-class UserControllerTest {
+class UserControllerTest extends TenantTestSupport {
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
## Summary

- Tenant 도메인 레이어 구현 (Entity, Repository, DTOs)
- 멀티테넌시 핵심 엔티티로 BaseTimeEntity 직접 상속 (TenantEntity 상속 X)
- 테넌트 타입/상태/요금제 Enum 정의

## Changes

### Enums
| Enum | Values |
|------|--------|
| TenantType | B2C, B2B, KPOP |
| TenantStatus | PENDING, ACTIVE, SUSPENDED, TERMINATED |
| PlanType | FREE, BASIC, PRO, ENTERPRISE |

### Entity
- `Tenant.java` - 테넌트 마스터 엔티티
  - 정적 팩토리 메서드 (`create`)
  - 상태 변경 메서드 (`activate`, `suspend`, `terminate`)

### Repository
- `TenantRepository.java`
  - `findByCode`, `findBySubdomain`, `findByCustomDomain`
  - `findBySubdomainAndStatus`, `findByCustomDomainAndStatus`
  - `existsBy...` 메서드들

### DTOs
- `CreateTenantRequest` - 테넌트 생성 요청
- `UpdateTenantRequest` - 테넌트 수정 요청  
- `TenantResponse` - 테넌트 응답

## Test Plan

- [x] TenantTest - Entity 단위 테스트 (9개)
- [x] TenantRepositoryTest - Repository 통합 테스트 (9개)
- [x] 전체 테스트 통과 (291개)
- [x] MySQL 8.0.36 연결 테스트

## Related Issues

- Closes #29
- Depends on #32 (Tenant Infrastructure)