### PR TITLE
fix: IllegalArgumentException 예외 처리 및 테스트 수정

### DIFF
--- a/src/main/java/com/mzc/lp/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mzc/lp/common/exception/GlobalExceptionHandler.java
@@ -42,6 +42,14 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(ErrorCode.ACCESS_DENIED));
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.error("IllegalArgumentException: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
+                .body(ApiResponse.error(ErrorCode.INVALID_INPUT_VALUE, e.getMessage()));
+    }
+
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         log.error("Exception: {}", e.getMessage(), e);

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseRelationControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseRelationControllerTest.java
@@ -17,6 +17,7 @@ import com.mzc.lp.domain.user.entity.User;
 import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
 import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
 import com.mzc.lp.domain.user.repository.UserRepository;
+import com.mzc.lp.common.support.TenantTestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,6 +28,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.util.List;
@@ -37,7 +39,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-class CourseRelationControllerTest {
+@ActiveProfiles("test")
+class CourseRelationControllerTest extends TenantTestSupport {
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
## Summary

- GlobalExceptionHandler에 IllegalArgumentException 핸들러 추가
- CourseRelationControllerTest 멀티테넌트 테스트 환경 설정

## Changes

### GlobalExceptionHandler
| 변경 내용 | 설명 |
|---------|------|
| IllegalArgumentException 핸들러 추가 | 500 → 400 Bad Request 반환 |
| ErrorCode | INVALID_INPUT_VALUE 사용 |

### CourseRelationControllerTest
| 변경 내용 | 설명 |
|---------|------|
| TenantTestSupport 상속 | 멀티테넌트 컨텍스트 설정 |
| @ActiveProfiles("test") | 테스트 프로파일 활성화 |

## Why

- Tenant Infrastructure (#32) 병합 후 TenantNotFoundException 발생으로 15개 테스트 실패
- IllegalArgumentException이 Generic Exception 핸들러로 처리되어 5개 테스트 실패 (expected 400 but 500)

## Test Plan

- [x] 전체 테스트 통과 (311개)
- [x] CourseRelationControllerTest 정상 동작 확인 (15개)
- [x] 유효성 검사 실패 시 400 응답 확인

## Related Issues

- Depends on #32 (Tenant Infrastructure)