### PR TITLE
feat: Tenant CRUD API 구현 (#34)

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -72,7 +72,14 @@ public enum ErrorCode {
     INSTRUCTOR_ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "IIS001", "Instructor assignment not found"),
     INSTRUCTOR_ALREADY_ASSIGNED(HttpStatus.CONFLICT, "IIS002", "Instructor already assigned to this course time"),
     MAIN_INSTRUCTOR_ALREADY_EXISTS(HttpStatus.CONFLICT, "IIS003", "Main instructor already exists for this course time"),
-    CANNOT_MODIFY_INACTIVE_ASSIGNMENT(HttpStatus.BAD_REQUEST, "IIS004", "Cannot modify inactive assignment");
+    CANNOT_MODIFY_INACTIVE_ASSIGNMENT(HttpStatus.BAD_REQUEST, "IIS004", "Cannot modify inactive assignment"),
+
+    // Tenant (TN)
+    TENANT_NOT_FOUND(HttpStatus.NOT_FOUND, "TN001", "Tenant not found"),
+    DUPLICATE_TENANT_CODE(HttpStatus.CONFLICT, "TN002", "Tenant code already exists"),
+    DUPLICATE_SUBDOMAIN(HttpStatus.CONFLICT, "TN003", "Subdomain already exists"),
+    DUPLICATE_CUSTOM_DOMAIN(HttpStatus.CONFLICT, "TN004", "Custom domain already exists"),
+    INVALID_TENANT_STATUS(HttpStatus.BAD_REQUEST, "TN005", "Invalid tenant status transition");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/mzc/lp/domain/tenant/controller/TenantController.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/controller/TenantController.java
@@ -1,0 +1,122 @@
+package com.mzc.lp.domain.tenant.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.domain.tenant.dto.request.CreateTenantRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateTenantRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateTenantStatusRequest;
+import com.mzc.lp.domain.tenant.dto.response.TenantResponse;
+import com.mzc.lp.domain.tenant.service.TenantService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/tenants")
+@RequiredArgsConstructor
+@Validated
+public class TenantController {
+
+    private final TenantService tenantService;
+
+    /**
+     * 테넌트 생성
+     * POST /api/tenants
+     */
+    @PostMapping
+    @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+    public ResponseEntity<ApiResponse<TenantResponse>> createTenant(
+            @Valid @RequestBody CreateTenantRequest request
+    ) {
+        TenantResponse response = tenantService.createTenant(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 테넌트 목록 조회 (페이징, 키워드 검색)
+     * GET /api/tenants
+     */
+    @GetMapping
+    @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+    public ResponseEntity<ApiResponse<Page<TenantResponse>>> getTenants(
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<TenantResponse> response = tenantService.getTenants(keyword, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 테넌트 상세 조회
+     * GET /api/tenants/{tenantId}
+     */
+    @GetMapping("/{tenantId}")
+    @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+    public ResponseEntity<ApiResponse<TenantResponse>> getTenant(
+            @PathVariable @Positive Long tenantId
+    ) {
+        TenantResponse response = tenantService.getTenant(tenantId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 테넌트 코드로 조회
+     * GET /api/tenants/code/{code}
+     */
+    @GetMapping("/code/{code}")
+    @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+    public ResponseEntity<ApiResponse<TenantResponse>> getTenantByCode(
+            @PathVariable String code
+    ) {
+        TenantResponse response = tenantService.getTenantByCode(code);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 테넌트 수정
+     * PUT /api/tenants/{tenantId}
+     */
+    @PutMapping("/{tenantId}")
+    @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+    public ResponseEntity<ApiResponse<TenantResponse>> updateTenant(
+            @PathVariable @Positive Long tenantId,
+            @Valid @RequestBody UpdateTenantRequest request
+    ) {
+        TenantResponse response = tenantService.updateTenant(tenantId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 테넌트 상태 변경
+     * PATCH /api/tenants/{tenantId}/status
+     */
+    @PatchMapping("/{tenantId}/status")
+    @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+    public ResponseEntity<ApiResponse<TenantResponse>> updateTenantStatus(
+            @PathVariable @Positive Long tenantId,
+            @Valid @RequestBody UpdateTenantStatusRequest request
+    ) {
+        TenantResponse response = tenantService.updateTenantStatus(tenantId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 테넌트 삭제
+     * DELETE /api/tenants/{tenantId}
+     */
+    @DeleteMapping("/{tenantId}")
+    @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+    public ResponseEntity<Void> deleteTenant(
+            @PathVariable @Positive Long tenantId
+    ) {
+        tenantService.deleteTenant(tenantId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateTenantStatusRequest.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateTenantStatusRequest.java
@@ -1,0 +1,10 @@
+package com.mzc.lp.domain.tenant.dto.request;
+
+import com.mzc.lp.domain.tenant.constant.TenantStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateTenantStatusRequest(
+        @NotNull(message = "변경할 상태는 필수입니다")
+        TenantStatus status
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/exception/DuplicateCustomDomainException.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/exception/DuplicateCustomDomainException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.tenant.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class DuplicateCustomDomainException extends BusinessException {
+
+    public DuplicateCustomDomainException() {
+        super(ErrorCode.DUPLICATE_CUSTOM_DOMAIN);
+    }
+
+    public DuplicateCustomDomainException(String customDomain) {
+        super(ErrorCode.DUPLICATE_CUSTOM_DOMAIN, "이미 존재하는 커스텀 도메인입니다: " + customDomain);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/exception/DuplicateSubdomainException.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/exception/DuplicateSubdomainException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.tenant.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class DuplicateSubdomainException extends BusinessException {
+
+    public DuplicateSubdomainException() {
+        super(ErrorCode.DUPLICATE_SUBDOMAIN);
+    }
+
+    public DuplicateSubdomainException(String subdomain) {
+        super(ErrorCode.DUPLICATE_SUBDOMAIN, "이미 존재하는 서브도메인입니다: " + subdomain);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/exception/DuplicateTenantCodeException.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/exception/DuplicateTenantCodeException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.tenant.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class DuplicateTenantCodeException extends BusinessException {
+
+    public DuplicateTenantCodeException() {
+        super(ErrorCode.DUPLICATE_TENANT_CODE);
+    }
+
+    public DuplicateTenantCodeException(String code) {
+        super(ErrorCode.DUPLICATE_TENANT_CODE, "이미 존재하는 테넌트 코드입니다: " + code);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/exception/InvalidTenantStatusException.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/exception/InvalidTenantStatusException.java
@@ -1,0 +1,21 @@
+package com.mzc.lp.domain.tenant.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.domain.tenant.constant.TenantStatus;
+
+public class InvalidTenantStatusException extends BusinessException {
+
+    public InvalidTenantStatusException() {
+        super(ErrorCode.INVALID_TENANT_STATUS);
+    }
+
+    public InvalidTenantStatusException(TenantStatus from, TenantStatus to) {
+        super(ErrorCode.INVALID_TENANT_STATUS,
+                String.format("잘못된 상태 전환입니다: %s -> %s", from, to));
+    }
+
+    public InvalidTenantStatusException(String message) {
+        super(ErrorCode.INVALID_TENANT_STATUS, message);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/exception/TenantDomainNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/exception/TenantDomainNotFoundException.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.domain.tenant.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class TenantDomainNotFoundException extends BusinessException {
+
+    public TenantDomainNotFoundException() {
+        super(ErrorCode.TENANT_NOT_FOUND);
+    }
+
+    public TenantDomainNotFoundException(Long tenantId) {
+        super(ErrorCode.TENANT_NOT_FOUND, "테넌트를 찾을 수 없습니다: " + tenantId);
+    }
+
+    public TenantDomainNotFoundException(String message) {
+        super(ErrorCode.TENANT_NOT_FOUND, message);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/repository/TenantRepository.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/repository/TenantRepository.java
@@ -2,6 +2,8 @@ package com.mzc.lp.domain.tenant.repository;
 
 import com.mzc.lp.domain.tenant.constant.TenantStatus;
 import com.mzc.lp.domain.tenant.entity.Tenant;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -23,4 +25,7 @@ public interface TenantRepository extends JpaRepository<Tenant, Long> {
     boolean existsBySubdomain(String subdomain);
 
     boolean existsByCustomDomain(String customDomain);
+
+    Page<Tenant> findByNameContainingIgnoreCaseOrCodeContainingIgnoreCase(
+            String name, String code, Pageable pageable);
 }

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantService.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantService.java
@@ -1,0 +1,46 @@
+package com.mzc.lp.domain.tenant.service;
+
+import com.mzc.lp.domain.tenant.dto.request.CreateTenantRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateTenantRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateTenantStatusRequest;
+import com.mzc.lp.domain.tenant.dto.response.TenantResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface TenantService {
+
+    /**
+     * 테넌트 생성
+     */
+    TenantResponse createTenant(CreateTenantRequest request);
+
+    /**
+     * 테넌트 목록 조회 (페이징)
+     */
+    Page<TenantResponse> getTenants(String keyword, Pageable pageable);
+
+    /**
+     * 테넌트 상세 조회
+     */
+    TenantResponse getTenant(Long tenantId);
+
+    /**
+     * 테넌트 코드로 조회
+     */
+    TenantResponse getTenantByCode(String code);
+
+    /**
+     * 테넌트 수정
+     */
+    TenantResponse updateTenant(Long tenantId, UpdateTenantRequest request);
+
+    /**
+     * 테넌트 상태 변경
+     */
+    TenantResponse updateTenantStatus(Long tenantId, UpdateTenantStatusRequest request);
+
+    /**
+     * 테넌트 삭제
+     */
+    void deleteTenant(Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantServiceImpl.java
@@ -1,0 +1,153 @@
+package com.mzc.lp.domain.tenant.service;
+
+import com.mzc.lp.domain.tenant.dto.request.CreateTenantRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateTenantRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateTenantStatusRequest;
+import com.mzc.lp.domain.tenant.dto.response.TenantResponse;
+import com.mzc.lp.domain.tenant.entity.Tenant;
+import com.mzc.lp.domain.tenant.exception.DuplicateCustomDomainException;
+import com.mzc.lp.domain.tenant.exception.DuplicateSubdomainException;
+import com.mzc.lp.domain.tenant.exception.DuplicateTenantCodeException;
+import com.mzc.lp.domain.tenant.exception.TenantDomainNotFoundException;
+import com.mzc.lp.domain.tenant.repository.TenantRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TenantServiceImpl implements TenantService {
+
+    private final TenantRepository tenantRepository;
+
+    @Override
+    @Transactional
+    public TenantResponse createTenant(CreateTenantRequest request) {
+        log.info("Creating tenant: code={}, name={}", request.code(), request.name());
+
+        // 중복 검증
+        validateDuplicateCode(request.code());
+        validateDuplicateSubdomain(request.subdomain());
+        if (request.customDomain() != null && !request.customDomain().isBlank()) {
+            validateDuplicateCustomDomain(request.customDomain());
+        }
+
+        Tenant tenant = Tenant.create(
+                request.code(),
+                request.name(),
+                request.type(),
+                request.subdomain(),
+                request.plan(),
+                request.customDomain()
+        );
+
+        Tenant saved = tenantRepository.save(tenant);
+        log.info("Tenant created: tenantId={}, code={}", saved.getId(), saved.getCode());
+
+        return TenantResponse.from(saved);
+    }
+
+    @Override
+    public Page<TenantResponse> getTenants(String keyword, Pageable pageable) {
+        log.debug("Getting tenants: keyword={}", keyword);
+
+        Page<Tenant> tenants;
+        if (keyword != null && !keyword.isBlank()) {
+            tenants = tenantRepository.findByNameContainingIgnoreCaseOrCodeContainingIgnoreCase(
+                    keyword, keyword, pageable);
+        } else {
+            tenants = tenantRepository.findAll(pageable);
+        }
+
+        return tenants.map(TenantResponse::from);
+    }
+
+    @Override
+    public TenantResponse getTenant(Long tenantId) {
+        log.debug("Getting tenant: tenantId={}", tenantId);
+
+        Tenant tenant = findTenantById(tenantId);
+        return TenantResponse.from(tenant);
+    }
+
+    @Override
+    public TenantResponse getTenantByCode(String code) {
+        log.debug("Getting tenant by code: code={}", code);
+
+        Tenant tenant = tenantRepository.findByCode(code)
+                .orElseThrow(() -> new TenantDomainNotFoundException("테넌트를 찾을 수 없습니다: " + code));
+        return TenantResponse.from(tenant);
+    }
+
+    @Override
+    @Transactional
+    public TenantResponse updateTenant(Long tenantId, UpdateTenantRequest request) {
+        log.info("Updating tenant: tenantId={}", tenantId);
+
+        Tenant tenant = findTenantById(tenantId);
+
+        // 커스텀 도메인 중복 검증 (변경된 경우에만)
+        if (request.customDomain() != null && !request.customDomain().isBlank()) {
+            if (!request.customDomain().equals(tenant.getCustomDomain())) {
+                validateDuplicateCustomDomain(request.customDomain());
+            }
+        }
+
+        tenant.update(request.name(), request.customDomain(), request.plan());
+        log.info("Tenant updated: tenantId={}", tenantId);
+
+        return TenantResponse.from(tenant);
+    }
+
+    @Override
+    @Transactional
+    public TenantResponse updateTenantStatus(Long tenantId, UpdateTenantStatusRequest request) {
+        log.info("Updating tenant status: tenantId={}, status={}", tenantId, request.status());
+
+        Tenant tenant = findTenantById(tenantId);
+        tenant.changeStatus(request.status());
+        log.info("Tenant status updated: tenantId={}, newStatus={}", tenantId, request.status());
+
+        return TenantResponse.from(tenant);
+    }
+
+    @Override
+    @Transactional
+    public void deleteTenant(Long tenantId) {
+        log.info("Deleting tenant: tenantId={}", tenantId);
+
+        Tenant tenant = findTenantById(tenantId);
+        tenantRepository.delete(tenant);
+        log.info("Tenant deleted: tenantId={}", tenantId);
+    }
+
+    // === Private Helper Methods ===
+
+    private Tenant findTenantById(Long tenantId) {
+        return tenantRepository.findById(tenantId)
+                .orElseThrow(() -> new TenantDomainNotFoundException(tenantId));
+    }
+
+    private void validateDuplicateCode(String code) {
+        if (tenantRepository.existsByCode(code)) {
+            throw new DuplicateTenantCodeException(code);
+        }
+    }
+
+    private void validateDuplicateSubdomain(String subdomain) {
+        if (tenantRepository.existsBySubdomain(subdomain)) {
+            throw new DuplicateSubdomainException(subdomain);
+        }
+    }
+
+    private void validateDuplicateCustomDomain(String customDomain) {
+        if (tenantRepository.existsByCustomDomain(customDomain)) {
+            throw new DuplicateCustomDomainException(customDomain);
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/constant/TenantRole.java
+++ b/src/main/java/com/mzc/lp/domain/user/constant/TenantRole.java
@@ -1,6 +1,7 @@
 package com.mzc.lp.domain.user.constant;
 
 public enum TenantRole {
+    SYSTEM_ADMIN,   // 시스템 최고 관리자 (테넌트 관리)
     TENANT_ADMIN,   // 테넌트 최고 관리자
     OPERATOR,       // 운영자 (강의 검토, 차수 생성, 역할 부여)
     USER            // 일반 사용자 (수강)

--- a/src/test/java/com/mzc/lp/domain/tenant/controller/TenantControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/tenant/controller/TenantControllerTest.java
@@ -1,0 +1,359 @@
+package com.mzc.lp.domain.tenant.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.tenant.constant.PlanType;
+import com.mzc.lp.domain.tenant.constant.TenantStatus;
+import com.mzc.lp.domain.tenant.constant.TenantType;
+import com.mzc.lp.domain.tenant.dto.request.CreateTenantRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateTenantRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateTenantStatusRequest;
+import com.mzc.lp.domain.tenant.entity.Tenant;
+import com.mzc.lp.domain.tenant.repository.TenantRepository;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class TenantControllerTest extends TenantTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private TenantRepository tenantRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        tenantRepository.deleteAll();
+    }
+
+    // ===== 헬퍼 메서드 =====
+
+    private User createSystemAdmin() {
+        User user = User.create("sysadmin@example.com", "시스템관리자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.SYSTEM_ADMIN);
+        return userRepository.save(user);
+    }
+
+    private User createTenantAdmin() {
+        User user = User.create("admin@example.com", "테넌트관리자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.TENANT_ADMIN);
+        return userRepository.save(user);
+    }
+
+    private String loginAndGetAccessToken(String email, String password) throws Exception {
+        LoginRequest request = new LoginRequest(email, password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String responseBody = result.getResponse().getContentAsString();
+        return objectMapper.readTree(responseBody).get("data").get("accessToken").asText();
+    }
+
+    private Tenant createTestTenant(String code, String name, String subdomain) {
+        Tenant tenant = Tenant.create(code, name, TenantType.B2B, subdomain, PlanType.BASIC);
+        return tenantRepository.save(tenant);
+    }
+
+    @Nested
+    @DisplayName("POST /api/tenants - 테넌트 생성")
+    class CreateTenant {
+
+        @Test
+        @DisplayName("시스템 관리자가 테넌트를 생성한다")
+        void createTenant_success() throws Exception {
+            // given
+            createSystemAdmin();
+            String accessToken = loginAndGetAccessToken("sysadmin@example.com", "Password123!");
+
+            CreateTenantRequest request = new CreateTenantRequest(
+                    "NEWCOMPANY",
+                    "새회사",
+                    TenantType.B2B,
+                    "newcompany",
+                    PlanType.PRO,
+                    "learn.newcompany.com"
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/tenants")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.code").value("NEWCOMPANY"))
+                    .andExpect(jsonPath("$.data.name").value("새회사"))
+                    .andExpect(jsonPath("$.data.status").value("PENDING"));
+        }
+
+        @Test
+        @DisplayName("테넌트 관리자는 테넌트 생성 권한이 없다")
+        void createTenant_forbidden() throws Exception {
+            // given
+            createTenantAdmin();
+            String accessToken = loginAndGetAccessToken("admin@example.com", "Password123!");
+
+            CreateTenantRequest request = new CreateTenantRequest(
+                    "NEWCOMPANY",
+                    "새회사",
+                    TenantType.B2B,
+                    "newcompany",
+                    PlanType.PRO,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/tenants")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("중복된 코드로 생성 시 실패한다")
+        void createTenant_duplicateCode() throws Exception {
+            // given
+            createSystemAdmin();
+            String accessToken = loginAndGetAccessToken("sysadmin@example.com", "Password123!");
+            createTestTenant("DUPLICATE", "기존회사", "existing");
+
+            CreateTenantRequest request = new CreateTenantRequest(
+                    "DUPLICATE",
+                    "새회사",
+                    TenantType.B2B,
+                    "newcompany",
+                    PlanType.PRO,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/tenants")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isConflict());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/tenants - 테넌트 목록 조회")
+    class GetTenants {
+
+        @Test
+        @DisplayName("시스템 관리자가 테넌트 목록을 조회한다")
+        void getTenants_success() throws Exception {
+            // given
+            createSystemAdmin();
+            String accessToken = loginAndGetAccessToken("sysadmin@example.com", "Password123!");
+            createTestTenant("COMPANY_A", "회사A", "companya");
+            createTestTenant("COMPANY_B", "회사B", "companyb");
+
+            // when & then
+            mockMvc.perform(get("/api/tenants")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.content").isArray());
+        }
+
+        @Test
+        @DisplayName("키워드로 테넌트를 검색한다")
+        void getTenants_withKeyword() throws Exception {
+            // given
+            createSystemAdmin();
+            String accessToken = loginAndGetAccessToken("sysadmin@example.com", "Password123!");
+            createTestTenant("SAMSUNG", "삼성전자", "samsung");
+            createTestTenant("LG", "LG전자", "lg");
+
+            // when & then
+            mockMvc.perform(get("/api/tenants")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("keyword", "삼성"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/tenants/{tenantId} - 테넌트 상세 조회")
+    class GetTenant {
+
+        @Test
+        @DisplayName("시스템 관리자가 테넌트 상세를 조회한다")
+        void getTenant_success() throws Exception {
+            // given
+            createSystemAdmin();
+            String accessToken = loginAndGetAccessToken("sysadmin@example.com", "Password123!");
+            Tenant tenant = createTestTenant("TESTCO", "테스트회사", "testco");
+
+            // when & then
+            mockMvc.perform(get("/api/tenants/{tenantId}", tenant.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.code").value("TESTCO"))
+                    .andExpect(jsonPath("$.data.name").value("테스트회사"));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 테넌트 조회 시 404를 반환한다")
+        void getTenant_notFound() throws Exception {
+            // given
+            createSystemAdmin();
+            String accessToken = loginAndGetAccessToken("sysadmin@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/tenants/{tenantId}", 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/tenants/{tenantId} - 테넌트 수정")
+    class UpdateTenant {
+
+        @Test
+        @DisplayName("시스템 관리자가 테넌트를 수정한다")
+        void updateTenant_success() throws Exception {
+            // given
+            createSystemAdmin();
+            String accessToken = loginAndGetAccessToken("sysadmin@example.com", "Password123!");
+            Tenant tenant = createTestTenant("TESTCO", "테스트회사", "testco");
+
+            UpdateTenantRequest request = new UpdateTenantRequest(
+                    "수정된회사명",
+                    "new.domain.com",
+                    PlanType.ENTERPRISE
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/tenants/{tenantId}", tenant.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.name").value("수정된회사명"))
+                    .andExpect(jsonPath("$.data.customDomain").value("new.domain.com"))
+                    .andExpect(jsonPath("$.data.plan").value("ENTERPRISE"));
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/tenants/{tenantId}/status - 테넌트 상태 변경")
+    class UpdateTenantStatus {
+
+        @Test
+        @DisplayName("시스템 관리자가 테넌트 상태를 변경한다")
+        void updateTenantStatus_success() throws Exception {
+            // given
+            createSystemAdmin();
+            String accessToken = loginAndGetAccessToken("sysadmin@example.com", "Password123!");
+            Tenant tenant = createTestTenant("TESTCO", "테스트회사", "testco");
+
+            UpdateTenantStatusRequest request = new UpdateTenantStatusRequest(TenantStatus.ACTIVE);
+
+            // when & then
+            mockMvc.perform(patch("/api/tenants/{tenantId}/status", tenant.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/tenants/{tenantId} - 테넌트 삭제")
+    class DeleteTenant {
+
+        @Test
+        @DisplayName("시스템 관리자가 테넌트를 삭제한다")
+        void deleteTenant_success() throws Exception {
+            // given
+            createSystemAdmin();
+            String accessToken = loginAndGetAccessToken("sysadmin@example.com", "Password123!");
+            Tenant tenant = createTestTenant("DELETEME", "삭제할회사", "deleteme");
+
+            // when & then
+            mockMvc.perform(delete("/api/tenants/{tenantId}", tenant.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/tenants/code/{code} - 코드로 테넌트 조회")
+    class GetTenantByCode {
+
+        @Test
+        @DisplayName("시스템 관리자가 코드로 테넌트를 조회한다")
+        void getTenantByCode_success() throws Exception {
+            // given
+            createSystemAdmin();
+            String accessToken = loginAndGetAccessToken("sysadmin@example.com", "Password123!");
+            createTestTenant("BYCODE", "코드조회회사", "bycode");
+
+            // when & then
+            mockMvc.perform(get("/api/tenants/code/{code}", "BYCODE")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.code").value("BYCODE"))
+                    .andExpect(jsonPath("$.data.name").value("코드조회회사"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Tenant CRUD API 구현 (생성/조회/수정/삭제)
- Tenant 상태 관리 API 구현
- SYSTEM_ADMIN 역할 추가 및 권한 설정

## Changes

### Controller
| 엔드포인트 | 설명 |
|-----------|------|
| POST /api/tenants | 테넌트 생성 |
| GET /api/tenants | 테넌트 목록 조회 (페이징, 키워드 검색) |
| GET /api/tenants/{tenantId} | 테넌트 상세 조회 |
| PUT /api/tenants/{tenantId} | 테넌트 수정 |
| DELETE /api/tenants/{tenantId} | 테넌트 삭제 |
| PATCH /api/tenants/{tenantId}/status | 테넌트 상태 변경 |
| GET /api/tenants/code/{code} | 코드로 테넌트 조회 |

### Service
- TenantService 인터페이스 및 구현체
- 도메인 중복 검증 (code, subdomain, customDomain)

### Exception
- TenantDomainNotFoundException
- DuplicateTenantCodeException
- DuplicateSubdomainException
- DuplicateCustomDomainException
- InvalidTenantStatusException

### ErrorCode
- TN001 ~ TN005 추가

### TenantRole
- SYSTEM_ADMIN 역할 추가 (테넌트 관리 권한)

## Test Plan

- [x] TenantControllerTest 통합 테스트 (10개)
- [x] 전체 테스트 통과 (322개)
- [x] MySQL 8.0.36 연결 테스트

## Related Issues

- Closes #34
- Depends on #29 (Tenant Entity)