### PR TITLE
feat: Snapshot 기반 구조 구현 (Entity, Repository, DTO, Exception)

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -31,6 +31,8 @@ public enum ErrorCode {
     CM_MAX_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "CM003", "Max depth exceeded (10)"),
     CM_CIRCULAR_REFERENCE(HttpStatus.BAD_REQUEST, "CM004", "Circular reference detected"),
     CM_INVALID_PARENT(HttpStatus.BAD_REQUEST, "CM005", "Invalid parent"),
+    CM_SNAPSHOT_NOT_FOUND(HttpStatus.NOT_FOUND, "CM006", "Snapshot not found"),
+    CM_SNAPSHOT_STATE_ERROR(HttpStatus.BAD_REQUEST, "CM007", "Invalid snapshot state"),
     CM_LEARNING_OBJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "CM008", "LearningObject not found"),
 
     // Content (CMS)

--- a/src/main/java/com/mzc/lp/domain/snapshot/constant/SnapshotStatus.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/constant/SnapshotStatus.java
@@ -1,0 +1,8 @@
+package com.mzc.lp.domain.snapshot.constant;
+
+public enum SnapshotStatus {
+    DRAFT,      // 준비중/모집중
+    ACTIVE,     // 강의중
+    COMPLETED,  // 강의종료
+    ARCHIVED    // 보관됨
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/dto/request/CreateSnapshotItemRequest.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/dto/request/CreateSnapshotItemRequest.java
@@ -1,0 +1,23 @@
+package com.mzc.lp.domain.snapshot.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateSnapshotItemRequest(
+        @NotBlank(message = "항목 이름은 필수입니다")
+        @Size(max = 255, message = "항목 이름은 255자 이하여야 합니다")
+        String itemName,
+
+        Long parentId,
+
+        Long learningObjectId,
+
+        @Size(max = 20, message = "항목 타입은 20자 이하여야 합니다")
+        String itemType
+) {
+    public CreateSnapshotItemRequest {
+        if (itemName != null) {
+            itemName = itemName.trim();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/dto/request/CreateSnapshotRequest.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/dto/request/CreateSnapshotRequest.java
@@ -1,0 +1,22 @@
+package com.mzc.lp.domain.snapshot.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateSnapshotRequest(
+        @NotBlank(message = "스냅샷 이름은 필수입니다")
+        @Size(max = 255, message = "스냅샷 이름은 255자 이하여야 합니다")
+        String snapshotName,
+
+        @Size(max = 5000, message = "설명은 5000자 이하여야 합니다")
+        String description,
+
+        @Size(max = 255, message = "해시태그는 255자 이하여야 합니다")
+        String hashtags
+) {
+    public CreateSnapshotRequest {
+        if (snapshotName != null) {
+            snapshotName = snapshotName.trim();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/dto/request/UpdateSnapshotRequest.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/dto/request/UpdateSnapshotRequest.java
@@ -1,0 +1,20 @@
+package com.mzc.lp.domain.snapshot.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record UpdateSnapshotRequest(
+        @Size(max = 255, message = "스냅샷 이름은 255자 이하여야 합니다")
+        String snapshotName,
+
+        @Size(max = 5000, message = "설명은 5000자 이하여야 합니다")
+        String description,
+
+        @Size(max = 255, message = "해시태그는 255자 이하여야 합니다")
+        String hashtags
+) {
+    public UpdateSnapshotRequest {
+        if (snapshotName != null) {
+            snapshotName = snapshotName.trim();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/dto/response/SnapshotDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/dto/response/SnapshotDetailResponse.java
@@ -1,0 +1,46 @@
+package com.mzc.lp.domain.snapshot.dto.response;
+
+import com.mzc.lp.domain.snapshot.constant.SnapshotStatus;
+import com.mzc.lp.domain.snapshot.entity.CourseSnapshot;
+
+import java.time.Instant;
+import java.util.List;
+
+public record SnapshotDetailResponse(
+        Long snapshotId,
+        String snapshotName,
+        String description,
+        String hashtags,
+        Long sourceCourseId,
+        String sourceCourseName,
+        Long createdBy,
+        SnapshotStatus status,
+        Integer version,
+        Long tenantId,
+        List<SnapshotItemResponse> items,
+        Long itemCount,
+        Long totalDuration,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static SnapshotDetailResponse from(CourseSnapshot snapshot, List<SnapshotItemResponse> items,
+                                               Long itemCount, Long totalDuration) {
+        return new SnapshotDetailResponse(
+                snapshot.getId(),
+                snapshot.getSnapshotName(),
+                snapshot.getDescription(),
+                snapshot.getHashtags(),
+                snapshot.getSourceCourse() != null ? snapshot.getSourceCourse().getId() : null,
+                snapshot.getSourceCourse() != null ? snapshot.getSourceCourse().getTitle() : null,
+                snapshot.getCreatedBy(),
+                snapshot.getStatus(),
+                snapshot.getVersion(),
+                snapshot.getTenantId(),
+                items,
+                itemCount,
+                totalDuration,
+                snapshot.getCreatedAt(),
+                snapshot.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/dto/response/SnapshotItemResponse.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/dto/response/SnapshotItemResponse.java
@@ -1,0 +1,56 @@
+package com.mzc.lp.domain.snapshot.dto.response;
+
+import com.mzc.lp.domain.snapshot.entity.SnapshotItem;
+
+import java.time.Instant;
+import java.util.List;
+
+public record SnapshotItemResponse(
+        Long itemId,
+        Long snapshotId,
+        String itemName,
+        Long parentId,
+        Integer depth,
+        Boolean isFolder,
+        String itemType,
+        SnapshotLearningObjectResponse snapshotLearningObject,
+        List<SnapshotItemResponse> children,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static SnapshotItemResponse from(SnapshotItem item) {
+        return new SnapshotItemResponse(
+                item.getId(),
+                item.getSnapshot().getId(),
+                item.getItemName(),
+                item.getParent() != null ? item.getParent().getId() : null,
+                item.getDepth(),
+                item.isFolder(),
+                item.getItemType(),
+                SnapshotLearningObjectResponse.from(item.getSnapshotLearningObject()),
+                null,
+                item.getCreatedAt(),
+                item.getUpdatedAt()
+        );
+    }
+
+    public static SnapshotItemResponse fromWithChildren(SnapshotItem item) {
+        List<SnapshotItemResponse> childResponses = item.getChildren().stream()
+                .map(SnapshotItemResponse::fromWithChildren)
+                .toList();
+
+        return new SnapshotItemResponse(
+                item.getId(),
+                item.getSnapshot().getId(),
+                item.getItemName(),
+                item.getParent() != null ? item.getParent().getId() : null,
+                item.getDepth(),
+                item.isFolder(),
+                item.getItemType(),
+                SnapshotLearningObjectResponse.from(item.getSnapshotLearningObject()),
+                childResponses,
+                item.getCreatedAt(),
+                item.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/dto/response/SnapshotLearningObjectResponse.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/dto/response/SnapshotLearningObjectResponse.java
@@ -1,0 +1,30 @@
+package com.mzc.lp.domain.snapshot.dto.response;
+
+import com.mzc.lp.domain.snapshot.entity.SnapshotLearningObject;
+
+public record SnapshotLearningObjectResponse(
+        Long snapshotLoId,
+        Long sourceLoId,
+        Long contentId,
+        String displayName,
+        Integer duration,
+        String thumbnailUrl,
+        String resolution,
+        Boolean isCustomized
+) {
+    public static SnapshotLearningObjectResponse from(SnapshotLearningObject slo) {
+        if (slo == null) {
+            return null;
+        }
+        return new SnapshotLearningObjectResponse(
+                slo.getId(),
+                slo.getSourceLoId(),
+                slo.getContentId(),
+                slo.getDisplayName(),
+                slo.getDuration(),
+                slo.getThumbnailUrl(),
+                slo.getResolution(),
+                slo.getIsCustomized()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/dto/response/SnapshotResponse.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/dto/response/SnapshotResponse.java
@@ -1,0 +1,38 @@
+package com.mzc.lp.domain.snapshot.dto.response;
+
+import com.mzc.lp.domain.snapshot.constant.SnapshotStatus;
+import com.mzc.lp.domain.snapshot.entity.CourseSnapshot;
+
+import java.time.Instant;
+
+public record SnapshotResponse(
+        Long snapshotId,
+        String snapshotName,
+        String description,
+        String hashtags,
+        Long sourceCourseId,
+        String sourceCourseName,
+        Long createdBy,
+        SnapshotStatus status,
+        Integer version,
+        Long tenantId,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static SnapshotResponse from(CourseSnapshot snapshot) {
+        return new SnapshotResponse(
+                snapshot.getId(),
+                snapshot.getSnapshotName(),
+                snapshot.getDescription(),
+                snapshot.getHashtags(),
+                snapshot.getSourceCourse() != null ? snapshot.getSourceCourse().getId() : null,
+                snapshot.getSourceCourse() != null ? snapshot.getSourceCourse().getTitle() : null,
+                snapshot.getCreatedBy(),
+                snapshot.getStatus(),
+                snapshot.getVersion(),
+                snapshot.getTenantId(),
+                snapshot.getCreatedAt(),
+                snapshot.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/entity/CourseSnapshot.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/entity/CourseSnapshot.java
@@ -1,0 +1,177 @@
+package com.mzc.lp.domain.snapshot.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import com.mzc.lp.domain.course.entity.Course;
+import com.mzc.lp.domain.snapshot.constant.SnapshotStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "cm_snapshots", indexes = {
+        @Index(name = "idx_snapshot_tenant", columnList = "tenant_id"),
+        @Index(name = "idx_snapshot_status", columnList = "status"),
+        @Index(name = "idx_snapshot_created_by", columnList = "created_by"),
+        @Index(name = "idx_snapshot_source", columnList = "source_course_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CourseSnapshot extends TenantEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_course_id")
+    private Course sourceCourse;
+
+    @Column(name = "snapshot_name", nullable = false, length = 255)
+    private String snapshotName;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(length = 255)
+    private String hashtags;
+
+    @Column(name = "created_by", nullable = false)
+    private Long createdBy;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SnapshotStatus status;
+
+    @Column(nullable = false)
+    private Integer version;
+
+    @OneToMany(mappedBy = "snapshot", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SnapshotItem> items = new ArrayList<>();
+
+    @OneToMany(mappedBy = "snapshot", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SnapshotRelation> relations = new ArrayList<>();
+
+    // ===== 정적 팩토리 메서드 =====
+    public static CourseSnapshot create(String snapshotName, Long createdBy) {
+        CourseSnapshot snapshot = new CourseSnapshot();
+        snapshot.snapshotName = snapshotName;
+        snapshot.createdBy = createdBy;
+        snapshot.status = SnapshotStatus.DRAFT;
+        snapshot.version = 1;
+        return snapshot;
+    }
+
+    public static CourseSnapshot createFromCourse(Course course, Long createdBy) {
+        CourseSnapshot snapshot = new CourseSnapshot();
+        snapshot.sourceCourse = course;
+        snapshot.snapshotName = course.getTitle();
+        snapshot.description = course.getDescription();
+        snapshot.createdBy = createdBy;
+        snapshot.status = SnapshotStatus.DRAFT;
+        snapshot.version = 1;
+        return snapshot;
+    }
+
+    public static CourseSnapshot create(String snapshotName, String description,
+                                         String hashtags, Long createdBy) {
+        CourseSnapshot snapshot = new CourseSnapshot();
+        snapshot.snapshotName = snapshotName;
+        snapshot.description = description;
+        snapshot.hashtags = hashtags;
+        snapshot.createdBy = createdBy;
+        snapshot.status = SnapshotStatus.DRAFT;
+        snapshot.version = 1;
+        return snapshot;
+    }
+
+    // ===== 비즈니스 메서드 =====
+    public void updateSnapshotName(String snapshotName) {
+        validateModifiable();
+        validateSnapshotName(snapshotName);
+        this.snapshotName = snapshotName;
+    }
+
+    public void updateDescription(String description) {
+        validateModifiable();
+        this.description = description;
+    }
+
+    public void updateHashtags(String hashtags) {
+        validateModifiable();
+        this.hashtags = hashtags;
+    }
+
+    public void update(String snapshotName, String description, String hashtags) {
+        validateModifiable();
+        if (snapshotName != null) {
+            validateSnapshotName(snapshotName);
+            this.snapshotName = snapshotName;
+        }
+        this.description = description;
+        this.hashtags = hashtags;
+    }
+
+    public void publish() {
+        if (this.status != SnapshotStatus.DRAFT) {
+            throw new IllegalStateException("DRAFT 상태에서만 발행할 수 있습니다");
+        }
+        this.status = SnapshotStatus.ACTIVE;
+    }
+
+    public void complete() {
+        if (this.status != SnapshotStatus.ACTIVE) {
+            throw new IllegalStateException("ACTIVE 상태에서만 완료할 수 있습니다");
+        }
+        this.status = SnapshotStatus.COMPLETED;
+    }
+
+    public void archive() {
+        if (this.status != SnapshotStatus.COMPLETED) {
+            throw new IllegalStateException("COMPLETED 상태에서만 보관할 수 있습니다");
+        }
+        this.status = SnapshotStatus.ARCHIVED;
+    }
+
+    public boolean isDraft() {
+        return this.status == SnapshotStatus.DRAFT;
+    }
+
+    public boolean isActive() {
+        return this.status == SnapshotStatus.ACTIVE;
+    }
+
+    public boolean isModifiable() {
+        return this.status == SnapshotStatus.DRAFT || this.status == SnapshotStatus.ACTIVE;
+    }
+
+    public boolean isItemModifiable() {
+        return this.status == SnapshotStatus.DRAFT;
+    }
+
+    // ===== 연관관계 편의 메서드 =====
+    public void addItem(SnapshotItem item) {
+        this.items.add(item);
+        item.assignSnapshot(this);
+    }
+
+    public void addRelation(SnapshotRelation relation) {
+        this.relations.add(relation);
+        relation.assignSnapshot(this);
+    }
+
+    // ===== Private 검증 메서드 =====
+    private void validateModifiable() {
+        if (!isModifiable()) {
+            throw new IllegalStateException("수정할 수 없는 상태입니다: " + this.status);
+        }
+    }
+
+    private void validateSnapshotName(String snapshotName) {
+        if (snapshotName == null || snapshotName.isBlank()) {
+            throw new IllegalArgumentException("스냅샷 이름은 필수입니다");
+        }
+        if (snapshotName.length() > 255) {
+            throw new IllegalArgumentException("스냅샷 이름은 255자 이하여야 합니다");
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotItem.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotItem.java
@@ -1,0 +1,190 @@
+package com.mzc.lp.domain.snapshot.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "cm_snapshot_items", indexes = {
+        @Index(name = "idx_si_tenant", columnList = "tenant_id"),
+        @Index(name = "idx_si_snapshot", columnList = "snapshot_id"),
+        @Index(name = "idx_si_parent", columnList = "parent_id"),
+        @Index(name = "idx_si_source_item", columnList = "source_item_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SnapshotItem extends TenantEntity {
+
+    private static final int MAX_DEPTH = 9;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "snapshot_id", nullable = false)
+    private CourseSnapshot snapshot;
+
+    @Column(name = "source_item_id")
+    private Long sourceItemId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private SnapshotItem parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SnapshotItem> children = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "snapshot_lo_id")
+    private SnapshotLearningObject snapshotLearningObject;
+
+    @Column(name = "item_name", nullable = false, length = 255)
+    private String itemName;
+
+    @Column(nullable = false)
+    private Integer depth;
+
+    @Column(name = "item_type", length = 20)
+    private String itemType;
+
+    // ===== 정적 팩토리 메서드 =====
+    public static SnapshotItem createFolder(CourseSnapshot snapshot, String itemName, SnapshotItem parent) {
+        SnapshotItem item = new SnapshotItem();
+        item.snapshot = snapshot;
+        item.itemName = itemName;
+        item.parent = parent;
+        item.depth = parent != null ? parent.getDepth() + 1 : 0;
+        item.snapshotLearningObject = null;
+        item.itemType = null;
+        item.validateDepth();
+        return item;
+    }
+
+    public static SnapshotItem createItem(CourseSnapshot snapshot, String itemName,
+                                          SnapshotItem parent, SnapshotLearningObject snapshotLo,
+                                          String itemType) {
+        SnapshotItem item = new SnapshotItem();
+        item.snapshot = snapshot;
+        item.itemName = itemName;
+        item.parent = parent;
+        item.depth = parent != null ? parent.getDepth() + 1 : 0;
+        item.snapshotLearningObject = snapshotLo;
+        item.itemType = itemType;
+        item.validateDepth();
+        return item;
+    }
+
+    public static SnapshotItem createFromCourseItem(CourseSnapshot snapshot, Long sourceItemId,
+                                                     String itemName, SnapshotItem parent,
+                                                     SnapshotLearningObject snapshotLo, String itemType) {
+        SnapshotItem item = new SnapshotItem();
+        item.snapshot = snapshot;
+        item.sourceItemId = sourceItemId;
+        item.itemName = itemName;
+        item.parent = parent;
+        item.depth = parent != null ? parent.getDepth() + 1 : 0;
+        item.snapshotLearningObject = snapshotLo;
+        item.itemType = itemType;
+        item.validateDepth();
+        return item;
+    }
+
+    // ===== 비즈니스 메서드 =====
+    public boolean isFolder() {
+        return this.snapshotLearningObject == null;
+    }
+
+    public void updateItemName(String itemName) {
+        validateItemName(itemName);
+        this.itemName = itemName;
+    }
+
+    public void updateSnapshotLearningObject(SnapshotLearningObject snapshotLo) {
+        if (isFolder()) {
+            throw new IllegalStateException("폴더에는 학습 객체를 연결할 수 없습니다");
+        }
+        this.snapshotLearningObject = snapshotLo;
+    }
+
+    public void moveTo(SnapshotItem newParent) {
+        int newDepth = newParent != null ? newParent.getDepth() + 1 : 0;
+
+        int maxChildDepth = calculateMaxChildDepth();
+        int depthDiff = newDepth - this.depth;
+
+        if (maxChildDepth + depthDiff > MAX_DEPTH) {
+            throw new IllegalArgumentException("최대 깊이(10단계)를 초과할 수 없습니다");
+        }
+
+        if (newParent != null && isAncestorOf(newParent)) {
+            throw new IllegalArgumentException("하위 항목으로 이동할 수 없습니다");
+        }
+
+        if (this.parent != null) {
+            this.parent.getChildren().remove(this);
+        }
+
+        this.parent = newParent;
+        updateDepthRecursively(newDepth);
+
+        if (newParent != null) {
+            newParent.getChildren().add(this);
+        }
+    }
+
+    // ===== 연관관계 편의 메서드 =====
+    void assignSnapshot(CourseSnapshot snapshot) {
+        this.snapshot = snapshot;
+    }
+
+    public void addChild(SnapshotItem child) {
+        this.children.add(child);
+        child.parent = this;
+    }
+
+    // ===== Private 검증/헬퍼 메서드 =====
+    private void validateDepth() {
+        if (this.depth > MAX_DEPTH) {
+            throw new IllegalArgumentException("최대 깊이(10단계)를 초과할 수 없습니다");
+        }
+    }
+
+    private void validateItemName(String itemName) {
+        if (itemName == null || itemName.isBlank()) {
+            throw new IllegalArgumentException("항목 이름은 필수입니다");
+        }
+        if (itemName.length() > 255) {
+            throw new IllegalArgumentException("항목 이름은 255자 이하여야 합니다");
+        }
+    }
+
+    private int calculateMaxChildDepth() {
+        if (children.isEmpty()) {
+            return this.depth;
+        }
+        return children.stream()
+                .mapToInt(SnapshotItem::calculateMaxChildDepth)
+                .max()
+                .orElse(this.depth);
+    }
+
+    private boolean isAncestorOf(SnapshotItem item) {
+        SnapshotItem current = item;
+        while (current != null) {
+            if (current.getId() != null && current.getId().equals(this.getId())) {
+                return true;
+            }
+            current = current.getParent();
+        }
+        return false;
+    }
+
+    private void updateDepthRecursively(int newDepth) {
+        this.depth = newDepth;
+        for (SnapshotItem child : children) {
+            child.updateDepthRecursively(newDepth + 1);
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotLearningObject.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotLearningObject.java
@@ -1,0 +1,102 @@
+package com.mzc.lp.domain.snapshot.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "cm_snapshot_los", indexes = {
+        @Index(name = "idx_slo_tenant", columnList = "tenant_id"),
+        @Index(name = "idx_slo_content", columnList = "content_id"),
+        @Index(name = "idx_slo_source_lo", columnList = "source_lo_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SnapshotLearningObject extends TenantEntity {
+
+    @Column(name = "source_lo_id")
+    private Long sourceLoId;
+
+    @Column(name = "content_id", nullable = false)
+    private Long contentId;
+
+    @Column(name = "display_name", nullable = false, length = 255)
+    private String displayName;
+
+    @Column
+    private Integer duration;
+
+    @Column(name = "thumbnail_url", length = 500)
+    private String thumbnailUrl;
+
+    @Column(length = 50)
+    private String resolution;
+
+    @Column(length = 50)
+    private String codec;
+
+    @Column
+    private Long bitrate;
+
+    @Column(name = "page_count")
+    private Integer pageCount;
+
+    @Column(name = "is_customized", nullable = false)
+    private Boolean isCustomized;
+
+    // ===== 정적 팩토리 메서드 =====
+    public static SnapshotLearningObject create(Long contentId, String displayName) {
+        SnapshotLearningObject slo = new SnapshotLearningObject();
+        slo.contentId = contentId;
+        slo.displayName = displayName;
+        slo.isCustomized = false;
+        return slo;
+    }
+
+    public static SnapshotLearningObject createFromLo(Long sourceLoId, Long contentId,
+                                                       String displayName, Integer duration,
+                                                       String thumbnailUrl, String resolution,
+                                                       String codec, Long bitrate, Integer pageCount) {
+        SnapshotLearningObject slo = new SnapshotLearningObject();
+        slo.sourceLoId = sourceLoId;
+        slo.contentId = contentId;
+        slo.displayName = displayName;
+        slo.duration = duration;
+        slo.thumbnailUrl = thumbnailUrl;
+        slo.resolution = resolution;
+        slo.codec = codec;
+        slo.bitrate = bitrate;
+        slo.pageCount = pageCount;
+        slo.isCustomized = false;
+        return slo;
+    }
+
+    // ===== 비즈니스 메서드 =====
+    public void updateDisplayName(String displayName) {
+        validateDisplayName(displayName);
+        this.displayName = displayName;
+        this.isCustomized = true;
+    }
+
+    public void updateDuration(Integer duration) {
+        this.duration = duration;
+        this.isCustomized = true;
+    }
+
+    public void updateThumbnailUrl(String thumbnailUrl) {
+        this.thumbnailUrl = thumbnailUrl;
+        this.isCustomized = true;
+    }
+
+    // ===== Private 검증 메서드 =====
+    private void validateDisplayName(String displayName) {
+        if (displayName == null || displayName.isBlank()) {
+            throw new IllegalArgumentException("표시명은 필수입니다");
+        }
+        if (displayName.length() > 255) {
+            throw new IllegalArgumentException("표시명은 255자 이하여야 합니다");
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotRelation.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotRelation.java
@@ -1,0 +1,96 @@
+package com.mzc.lp.domain.snapshot.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "cm_snapshot_relations",
+       uniqueConstraints = @UniqueConstraint(name = "uk_snapshot_to_item", columnNames = "to_item_id"),
+       indexes = {
+           @Index(name = "idx_sr_tenant", columnList = "tenant_id"),
+           @Index(name = "idx_sr_snapshot", columnList = "snapshot_id"),
+           @Index(name = "idx_sr_from", columnList = "from_item_id")
+       })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SnapshotRelation extends TenantEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "snapshot_id", nullable = false)
+    private CourseSnapshot snapshot;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_item_id")
+    private SnapshotItem fromItem;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_item_id", nullable = false)
+    private SnapshotItem toItem;
+
+    // ===== 정적 팩토리 메서드 =====
+    public static SnapshotRelation create(CourseSnapshot snapshot, SnapshotItem fromItem, SnapshotItem toItem) {
+        validateRelation(fromItem, toItem);
+
+        SnapshotRelation relation = new SnapshotRelation();
+        relation.snapshot = snapshot;
+        relation.fromItem = fromItem;
+        relation.toItem = toItem;
+        return relation;
+    }
+
+    public static SnapshotRelation createStartPoint(CourseSnapshot snapshot, SnapshotItem toItem) {
+        if (toItem == null) {
+            throw new IllegalArgumentException("시작점 항목은 필수입니다");
+        }
+        if (toItem.isFolder()) {
+            throw new IllegalArgumentException("폴더는 학습 순서에 포함할 수 없습니다");
+        }
+
+        SnapshotRelation relation = new SnapshotRelation();
+        relation.snapshot = snapshot;
+        relation.fromItem = null;
+        relation.toItem = toItem;
+        return relation;
+    }
+
+    // ===== 비즈니스 메서드 =====
+    public boolean isStartPoint() {
+        return this.fromItem == null;
+    }
+
+    public void updateFromItem(SnapshotItem fromItem) {
+        validateRelation(fromItem, this.toItem);
+        this.fromItem = fromItem;
+    }
+
+    public void updateToItem(SnapshotItem toItem) {
+        validateRelation(this.fromItem, toItem);
+        this.toItem = toItem;
+    }
+
+    // ===== 연관관계 편의 메서드 =====
+    void assignSnapshot(CourseSnapshot snapshot) {
+        this.snapshot = snapshot;
+    }
+
+    // ===== Private 검증 메서드 =====
+    private static void validateRelation(SnapshotItem fromItem, SnapshotItem toItem) {
+        if (toItem == null) {
+            throw new IllegalArgumentException("대상 항목은 필수입니다");
+        }
+        if (toItem.isFolder()) {
+            throw new IllegalArgumentException("폴더는 학습 순서에 포함할 수 없습니다");
+        }
+        if (fromItem != null) {
+            if (fromItem.isFolder()) {
+                throw new IllegalArgumentException("폴더는 학습 순서에 포함할 수 없습니다");
+            }
+            if (fromItem.getId() != null && fromItem.getId().equals(toItem.getId())) {
+                throw new IllegalArgumentException("자기 자신을 참조할 수 없습니다");
+            }
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/exception/SnapshotNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/exception/SnapshotNotFoundException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.snapshot.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class SnapshotNotFoundException extends BusinessException {
+
+    public SnapshotNotFoundException() {
+        super(ErrorCode.CM_SNAPSHOT_NOT_FOUND);
+    }
+
+    public SnapshotNotFoundException(Long snapshotId) {
+        super(ErrorCode.CM_SNAPSHOT_NOT_FOUND, "스냅샷을 찾을 수 없습니다. ID: " + snapshotId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/exception/SnapshotStateException.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/exception/SnapshotStateException.java
@@ -1,0 +1,21 @@
+package com.mzc.lp.domain.snapshot.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.domain.snapshot.constant.SnapshotStatus;
+
+public class SnapshotStateException extends BusinessException {
+
+    public SnapshotStateException() {
+        super(ErrorCode.CM_SNAPSHOT_STATE_ERROR);
+    }
+
+    public SnapshotStateException(String message) {
+        super(ErrorCode.CM_SNAPSHOT_STATE_ERROR, message);
+    }
+
+    public SnapshotStateException(SnapshotStatus currentStatus, String action) {
+        super(ErrorCode.CM_SNAPSHOT_STATE_ERROR,
+              String.format("%s 상태에서는 %s 할 수 없습니다", currentStatus, action));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/repository/CourseSnapshotRepository.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/repository/CourseSnapshotRepository.java
@@ -1,0 +1,41 @@
+package com.mzc.lp.domain.snapshot.repository;
+
+import com.mzc.lp.domain.snapshot.constant.SnapshotStatus;
+import com.mzc.lp.domain.snapshot.entity.CourseSnapshot;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CourseSnapshotRepository extends JpaRepository<CourseSnapshot, Long> {
+
+    Optional<CourseSnapshot> findByIdAndTenantId(Long id, Long tenantId);
+
+    Page<CourseSnapshot> findByTenantId(Long tenantId, Pageable pageable);
+
+    Page<CourseSnapshot> findByTenantIdAndStatus(Long tenantId, SnapshotStatus status, Pageable pageable);
+
+    Page<CourseSnapshot> findByTenantIdAndCreatedBy(Long tenantId, Long createdBy, Pageable pageable);
+
+    Page<CourseSnapshot> findByTenantIdAndStatusAndCreatedBy(Long tenantId, SnapshotStatus status, Long createdBy, Pageable pageable);
+
+    List<CourseSnapshot> findBySourceCourseIdAndTenantId(Long sourceCourseId, Long tenantId);
+
+    @Query("SELECT s FROM CourseSnapshot s LEFT JOIN FETCH s.items WHERE s.id = :id AND s.tenantId = :tenantId")
+    Optional<CourseSnapshot> findByIdWithItems(@Param("id") Long id, @Param("tenantId") Long tenantId);
+
+    @Query("SELECT s FROM CourseSnapshot s LEFT JOIN FETCH s.relations WHERE s.id = :id AND s.tenantId = :tenantId")
+    Optional<CourseSnapshot> findByIdWithRelations(@Param("id") Long id, @Param("tenantId") Long tenantId);
+
+    boolean existsByIdAndTenantId(Long id, Long tenantId);
+
+    @Query("SELECT COUNT(si) FROM SnapshotItem si WHERE si.snapshot.id = :snapshotId AND si.snapshotLearningObject IS NOT NULL")
+    Long countItemsBySnapshotId(@Param("snapshotId") Long snapshotId);
+
+    @Query("SELECT COALESCE(SUM(slo.duration), 0) FROM SnapshotItem si JOIN si.snapshotLearningObject slo WHERE si.snapshot.id = :snapshotId")
+    Long sumDurationBySnapshotId(@Param("snapshotId") Long snapshotId);
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/repository/SnapshotItemRepository.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/repository/SnapshotItemRepository.java
@@ -1,0 +1,33 @@
+package com.mzc.lp.domain.snapshot.repository;
+
+import com.mzc.lp.domain.snapshot.entity.SnapshotItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SnapshotItemRepository extends JpaRepository<SnapshotItem, Long> {
+
+    Optional<SnapshotItem> findByIdAndTenantId(Long id, Long tenantId);
+
+    List<SnapshotItem> findBySnapshotIdAndTenantId(Long snapshotId, Long tenantId);
+
+    List<SnapshotItem> findBySnapshotIdAndParentIdIsNullAndTenantId(Long snapshotId, Long tenantId);
+
+    List<SnapshotItem> findBySnapshotIdAndParentIdAndTenantId(Long snapshotId, Long parentId, Long tenantId);
+
+    @Query("SELECT si FROM SnapshotItem si LEFT JOIN FETCH si.snapshotLearningObject WHERE si.snapshot.id = :snapshotId AND si.tenantId = :tenantId")
+    List<SnapshotItem> findBySnapshotIdWithLo(@Param("snapshotId") Long snapshotId, @Param("tenantId") Long tenantId);
+
+    @Query("SELECT si FROM SnapshotItem si LEFT JOIN FETCH si.snapshotLearningObject WHERE si.snapshot.id = :snapshotId AND si.parent IS NULL AND si.tenantId = :tenantId")
+    List<SnapshotItem> findRootItemsWithLo(@Param("snapshotId") Long snapshotId, @Param("tenantId") Long tenantId);
+
+    @Query("SELECT si FROM SnapshotItem si WHERE si.snapshot.id = :snapshotId AND si.snapshotLearningObject IS NOT NULL AND si.tenantId = :tenantId")
+    List<SnapshotItem> findItemsOnlyBySnapshotId(@Param("snapshotId") Long snapshotId, @Param("tenantId") Long tenantId);
+
+    boolean existsByIdAndTenantId(Long id, Long tenantId);
+
+    void deleteBySnapshotIdAndTenantId(Long snapshotId, Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/repository/SnapshotLearningObjectRepository.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/repository/SnapshotLearningObjectRepository.java
@@ -1,0 +1,20 @@
+package com.mzc.lp.domain.snapshot.repository;
+
+import com.mzc.lp.domain.snapshot.entity.SnapshotLearningObject;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SnapshotLearningObjectRepository extends JpaRepository<SnapshotLearningObject, Long> {
+
+    Optional<SnapshotLearningObject> findByIdAndTenantId(Long id, Long tenantId);
+
+    List<SnapshotLearningObject> findByContentIdAndTenantId(Long contentId, Long tenantId);
+
+    List<SnapshotLearningObject> findBySourceLoIdAndTenantId(Long sourceLoId, Long tenantId);
+
+    boolean existsByIdAndTenantId(Long id, Long tenantId);
+
+    boolean existsByContentIdAndTenantId(Long contentId, Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/repository/SnapshotRelationRepository.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/repository/SnapshotRelationRepository.java
@@ -1,0 +1,31 @@
+package com.mzc.lp.domain.snapshot.repository;
+
+import com.mzc.lp.domain.snapshot.entity.SnapshotRelation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SnapshotRelationRepository extends JpaRepository<SnapshotRelation, Long> {
+
+    Optional<SnapshotRelation> findByIdAndTenantId(Long id, Long tenantId);
+
+    List<SnapshotRelation> findBySnapshotIdAndTenantId(Long snapshotId, Long tenantId);
+
+    Optional<SnapshotRelation> findBySnapshotIdAndFromItemIsNullAndTenantId(Long snapshotId, Long tenantId);
+
+    Optional<SnapshotRelation> findByFromItemIdAndTenantId(Long fromItemId, Long tenantId);
+
+    Optional<SnapshotRelation> findByToItemIdAndTenantId(Long toItemId, Long tenantId);
+
+    @Query("SELECT sr FROM SnapshotRelation sr LEFT JOIN FETCH sr.fromItem LEFT JOIN FETCH sr.toItem WHERE sr.snapshot.id = :snapshotId AND sr.tenantId = :tenantId")
+    List<SnapshotRelation> findBySnapshotIdWithItems(@Param("snapshotId") Long snapshotId, @Param("tenantId") Long tenantId);
+
+    boolean existsByToItemIdAndTenantId(Long toItemId, Long tenantId);
+
+    boolean existsByFromItemIdAndToItemIdAndTenantId(Long fromItemId, Long toItemId, Long tenantId);
+
+    void deleteBySnapshotIdAndTenantId(Long snapshotId, Long tenantId);
+}


### PR DESCRIPTION
## Summary
- Snapshot 도메인 기반 구조 구현 (Phase 5)
- Entity, Repository, DTO, Exception 총 18개 파일 추가
- ErrorCode에 CM006, CM007 추가

## 구현 내용

### constant
- `SnapshotStatus.java` - DRAFT, ACTIVE, COMPLETED, ARCHIVED

### entity (4개)
- `CourseSnapshot.java` - 개설 강의
- `SnapshotItem.java` - 차시/폴더 복사본
- `SnapshotLearningObject.java` - LO 메타데이터 복사본
- `SnapshotRelation.java` - 학습 경로

### repository (4개)
- `CourseSnapshotRepository.java`
- `SnapshotItemRepository.java`
- `SnapshotLearningObjectRepository.java`
- `SnapshotRelationRepository.java`

### dto (7개)
- Request: CreateSnapshotRequest, UpdateSnapshotRequest, CreateSnapshotItemRequest
- Response: SnapshotResponse, SnapshotDetailResponse, SnapshotItemResponse, SnapshotLearningObjectResponse

### exception (2개)
- `SnapshotNotFoundException.java` (CM006)
- `SnapshotStateException.java` (CM007)

## Test plan
- [x] `./gradlew compileJava` 빌드 성공 확인

Closes #77