### PR TITLE
Feat: IIS 강사 배정 CRUD API 구현

### DIFF
--- a/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
+++ b/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
@@ -1,0 +1,122 @@
+package com.mzc.lp.domain.iis.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.dto.request.AssignInstructorRequest;
+import com.mzc.lp.domain.iis.dto.request.CancelAssignmentRequest;
+import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
+import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
+import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
+import com.mzc.lp.domain.iis.service.InstructorAssignmentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class InstructorAssignmentController {
+
+    private final InstructorAssignmentService assignmentService;
+
+    // ========== 차수 기준 API ==========
+
+    @PostMapping("/api/times/{timeId}/instructors")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<InstructorAssignmentResponse>> assignInstructor(
+            @PathVariable Long timeId,
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody AssignInstructorRequest request
+    ) {
+        InstructorAssignmentResponse response = assignmentService.assignInstructor(
+                timeId, request, principal.id());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    @GetMapping("/api/times/{timeId}/instructors")
+    public ResponseEntity<ApiResponse<List<InstructorAssignmentResponse>>> getInstructorsByTimeId(
+            @PathVariable Long timeId,
+            @RequestParam(required = false) AssignmentStatus status
+    ) {
+        List<InstructorAssignmentResponse> response = assignmentService.getInstructorsByTimeId(timeId, status);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // ========== 배정 단건 API ==========
+
+    @GetMapping("/api/instructor-assignments/{id}")
+    public ResponseEntity<ApiResponse<InstructorAssignmentResponse>> getAssignment(
+            @PathVariable Long id
+    ) {
+        InstructorAssignmentResponse response = assignmentService.getAssignment(id);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PutMapping("/api/instructor-assignments/{id}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<InstructorAssignmentResponse>> updateRole(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody UpdateRoleRequest request
+    ) {
+        InstructorAssignmentResponse response = assignmentService.updateRole(id, request, principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/api/instructor-assignments/{id}/replace")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<InstructorAssignmentResponse>> replaceInstructor(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody ReplaceInstructorRequest request
+    ) {
+        InstructorAssignmentResponse response = assignmentService.replaceInstructor(id, request, principal.id());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/api/instructor-assignments/{id}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> cancelAssignment(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody(required = false) CancelAssignmentRequest request
+    ) {
+        assignmentService.cancelAssignment(id,
+                request != null ? request : new CancelAssignmentRequest(null),
+                principal.id());
+        return ResponseEntity.noContent().build();
+    }
+
+    // ========== 사용자 기준 API ==========
+
+    @GetMapping("/api/users/{userId}/instructor-assignments")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<Page<InstructorAssignmentResponse>>> getAssignmentsByUserId(
+            @PathVariable Long userId,
+            @RequestParam(required = false) AssignmentStatus status,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<InstructorAssignmentResponse> response = assignmentService.getAssignmentsByUserId(
+                userId, status, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/api/users/me/instructor-assignments")
+    public ResponseEntity<ApiResponse<List<InstructorAssignmentResponse>>> getMyAssignments(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<InstructorAssignmentResponse> response = assignmentService.getMyAssignments(principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/iis/repository/InstructorAssignmentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/iis/repository/InstructorAssignmentRepository.java
@@ -58,4 +58,25 @@ public interface InstructorAssignmentRepository extends JpaRepository<Instructor
             "AND ia.tenantId = :tenantId " +
             "AND ia.status = 'ACTIVE'")
     long countActiveByUserKey(@Param("userKey") Long userKey, @Param("tenantId") Long tenantId);
+
+    // ========== TS 모듈 연동용 메서드 ==========
+
+    // MAIN 강사 존재 여부 확인
+    @Query("SELECT CASE WHEN COUNT(ia) > 0 THEN true ELSE false END " +
+            "FROM InstructorAssignment ia " +
+            "WHERE ia.timeKey = :timeKey " +
+            "AND ia.tenantId = :tenantId " +
+            "AND ia.role = 'MAIN' " +
+            "AND ia.status = 'ACTIVE'")
+    boolean existsActiveMainInstructor(@Param("timeKey") Long timeKey, @Param("tenantId") Long tenantId);
+
+    // 여러 차수의 강사 목록 Bulk 조회 (N+1 방지)
+    @Query("SELECT ia FROM InstructorAssignment ia " +
+            "WHERE ia.timeKey IN :timeKeys " +
+            "AND ia.tenantId = :tenantId " +
+            "AND ia.status = 'ACTIVE' " +
+            "ORDER BY ia.timeKey, ia.role")
+    List<InstructorAssignment> findActiveByTimeKeyIn(
+            @Param("timeKeys") List<Long> timeKeys,
+            @Param("tenantId") Long tenantId);
 }

--- a/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentService.java
+++ b/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentService.java
@@ -1,0 +1,50 @@
+package com.mzc.lp.domain.iis.service;
+
+import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.dto.request.AssignInstructorRequest;
+import com.mzc.lp.domain.iis.dto.request.CancelAssignmentRequest;
+import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
+import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
+import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Map;
+
+public interface InstructorAssignmentService {
+
+    // 배정
+    InstructorAssignmentResponse assignInstructor(Long timeId, AssignInstructorRequest request, Long operatorId);
+
+    // 조회
+    List<InstructorAssignmentResponse> getInstructorsByTimeId(Long timeId, AssignmentStatus status);
+
+    InstructorAssignmentResponse getAssignment(Long id);
+
+    Page<InstructorAssignmentResponse> getAssignmentsByUserId(Long userId, AssignmentStatus status, Pageable pageable);
+
+    List<InstructorAssignmentResponse> getMyAssignments(Long userId);
+
+    // 수정
+    InstructorAssignmentResponse updateRole(Long id, UpdateRoleRequest request, Long operatorId);
+
+    InstructorAssignmentResponse replaceInstructor(Long id, ReplaceInstructorRequest request, Long operatorId);
+
+    void cancelAssignment(Long id, CancelAssignmentRequest request, Long operatorId);
+
+    // ========== TS 모듈 연동용 메서드 ==========
+
+    /**
+     * [검증용] 특정 차수에 ACTIVE 상태인 MAIN 강사가 존재하는지 확인
+     * 용도: TS 모듈에서 CourseTime.open() 호출 시 검증 로직에 사용
+     */
+    boolean existsMainInstructor(Long timeId);
+
+    /**
+     * [성능용] 여러 차수의 강사 정보를 한 번에 조회 (Bulk)
+     * 용도: TS 모듈의 '차수 목록(List)' 조회 시 N+1 문제 방지
+     * 반환: Key=timeId, Value=강사목록
+     */
+    Map<Long, List<InstructorAssignmentResponse>> getInstructorsByTimeIds(List<Long> timeIds);
+}

--- a/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentServiceImpl.java
@@ -1,0 +1,263 @@
+package com.mzc.lp.domain.iis.service;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.constant.InstructorRole;
+import com.mzc.lp.domain.iis.dto.request.AssignInstructorRequest;
+import com.mzc.lp.domain.iis.dto.request.CancelAssignmentRequest;
+import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
+import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
+import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
+import com.mzc.lp.domain.iis.entity.AssignmentHistory;
+import com.mzc.lp.domain.iis.entity.InstructorAssignment;
+import com.mzc.lp.domain.iis.exception.CannotModifyInactiveAssignmentException;
+import com.mzc.lp.domain.iis.exception.InstructorAlreadyAssignedException;
+import com.mzc.lp.domain.iis.exception.InstructorAssignmentNotFoundException;
+import com.mzc.lp.domain.iis.exception.MainInstructorAlreadyExistsException;
+import com.mzc.lp.domain.iis.repository.AssignmentHistoryRepository;
+import com.mzc.lp.domain.iis.repository.InstructorAssignmentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InstructorAssignmentServiceImpl implements InstructorAssignmentService {
+
+    private final InstructorAssignmentRepository assignmentRepository;
+    private final AssignmentHistoryRepository historyRepository;
+
+    @Override
+    @Transactional
+    public InstructorAssignmentResponse assignInstructor(Long timeId, AssignInstructorRequest request, Long operatorId) {
+        log.info("Assigning instructor: timeId={}, userId={}, role={}", timeId, request.userId(), request.role());
+
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 중복 배정 체크
+        if (assignmentRepository.existsByTimeKeyAndUserKeyAndTenantIdAndStatus(
+                timeId, request.userId(), tenantId, AssignmentStatus.ACTIVE)) {
+            throw new InstructorAlreadyAssignedException(request.userId(), timeId);
+        }
+
+        // MAIN 역할인 경우 기존 MAIN 강사 체크
+        if (request.role() == InstructorRole.MAIN) {
+            assignmentRepository.findActiveByTimeKeyAndRole(timeId, tenantId, InstructorRole.MAIN)
+                    .ifPresent(existing -> {
+                        throw new MainInstructorAlreadyExistsException(timeId);
+                    });
+        }
+
+        // 배정 생성
+        InstructorAssignment assignment = InstructorAssignment.create(
+                request.userId(),
+                timeId,
+                request.role(),
+                operatorId
+        );
+
+        InstructorAssignment saved = assignmentRepository.save(assignment);
+
+        // 이력 저장
+        historyRepository.save(AssignmentHistory.ofAssign(saved.getId(), request.role(), operatorId));
+
+        log.info("Instructor assigned: assignmentId={}", saved.getId());
+        return InstructorAssignmentResponse.from(saved);
+    }
+
+    @Override
+    public List<InstructorAssignmentResponse> getInstructorsByTimeId(Long timeId, AssignmentStatus status) {
+        log.debug("Getting instructors by timeId: timeId={}, status={}", timeId, status);
+
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        List<InstructorAssignment> assignments;
+        if (status != null) {
+            assignments = assignmentRepository.findByTimeKeyAndTenantIdAndStatus(timeId, tenantId, status);
+        } else {
+            assignments = assignmentRepository.findByTimeKeyAndTenantId(timeId, tenantId);
+        }
+
+        return assignments.stream()
+                .map(InstructorAssignmentResponse::from)
+                .toList();
+    }
+
+    @Override
+    public InstructorAssignmentResponse getAssignment(Long id) {
+        log.debug("Getting assignment: id={}", id);
+
+        InstructorAssignment assignment = findAssignmentById(id);
+        return InstructorAssignmentResponse.from(assignment);
+    }
+
+    @Override
+    public Page<InstructorAssignmentResponse> getAssignmentsByUserId(Long userId, AssignmentStatus status, Pageable pageable) {
+        log.debug("Getting assignments by userId: userId={}, status={}", userId, status);
+
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        if (status != null) {
+            return assignmentRepository.findByUserKeyAndTenantIdAndStatus(userId, tenantId, status, pageable)
+                    .map(InstructorAssignmentResponse::from);
+        }
+
+        return assignmentRepository.findByUserKeyAndTenantId(userId, tenantId, pageable)
+                .map(InstructorAssignmentResponse::from);
+    }
+
+    @Override
+    public List<InstructorAssignmentResponse> getMyAssignments(Long userId) {
+        log.debug("Getting my assignments: userId={}", userId);
+
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        return assignmentRepository.findByUserKeyAndTenantIdAndStatus(userId, tenantId, AssignmentStatus.ACTIVE,
+                        Pageable.unpaged())
+                .map(InstructorAssignmentResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public InstructorAssignmentResponse updateRole(Long id, UpdateRoleRequest request, Long operatorId) {
+        log.info("Updating role: id={}, newRole={}", id, request.role());
+
+        InstructorAssignment assignment = findAssignmentById(id);
+
+        // ACTIVE 상태 체크
+        validateActiveStatus(assignment);
+
+        InstructorRole oldRole = assignment.getRole();
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // MAIN으로 변경 시 기존 MAIN 체크
+        if (request.role() == InstructorRole.MAIN && oldRole != InstructorRole.MAIN) {
+            assignmentRepository.findActiveByTimeKeyAndRole(assignment.getTimeKey(), tenantId, InstructorRole.MAIN)
+                    .ifPresent(existing -> {
+                        throw new MainInstructorAlreadyExistsException(assignment.getTimeKey());
+                    });
+        }
+
+        // 역할 변경
+        assignment.updateRole(request.role());
+
+        // 이력 저장
+        historyRepository.save(AssignmentHistory.ofRoleChange(
+                id, oldRole, request.role(), request.reason(), operatorId));
+
+        log.info("Role updated: id={}, oldRole={}, newRole={}", id, oldRole, request.role());
+        return InstructorAssignmentResponse.from(assignment);
+    }
+
+    @Override
+    @Transactional
+    public InstructorAssignmentResponse replaceInstructor(Long id, ReplaceInstructorRequest request, Long operatorId) {
+        log.info("Replacing instructor: id={}, newUserId={}", id, request.newUserId());
+
+        InstructorAssignment oldAssignment = findAssignmentById(id);
+
+        // ACTIVE 상태 체크
+        validateActiveStatus(oldAssignment);
+
+        Long tenantId = TenantContext.getCurrentTenantId();
+        Long timeId = oldAssignment.getTimeKey();
+
+        // 새 강사 중복 배정 체크
+        if (assignmentRepository.existsByTimeKeyAndUserKeyAndTenantIdAndStatus(
+                timeId, request.newUserId(), tenantId, AssignmentStatus.ACTIVE)) {
+            throw new InstructorAlreadyAssignedException(request.newUserId(), timeId);
+        }
+
+        // 기존 배정 교체 처리
+        oldAssignment.replace();
+        historyRepository.save(AssignmentHistory.ofReplace(id, request.reason(), operatorId));
+
+        // 새 배정 생성
+        InstructorAssignment newAssignment = InstructorAssignment.create(
+                request.newUserId(),
+                timeId,
+                request.role(),
+                operatorId
+        );
+        InstructorAssignment saved = assignmentRepository.save(newAssignment);
+        historyRepository.save(AssignmentHistory.ofAssign(saved.getId(), request.role(), operatorId));
+
+        log.info("Instructor replaced: oldId={}, newId={}", id, saved.getId());
+        return InstructorAssignmentResponse.from(saved);
+    }
+
+    @Override
+    @Transactional
+    public void cancelAssignment(Long id, CancelAssignmentRequest request, Long operatorId) {
+        log.info("Cancelling assignment: id={}", id);
+
+        InstructorAssignment assignment = findAssignmentById(id);
+
+        // ACTIVE 상태 체크
+        validateActiveStatus(assignment);
+
+        // 취소 처리
+        assignment.cancel();
+
+        // 이력 저장
+        historyRepository.save(AssignmentHistory.ofCancel(id, request.reason(), operatorId));
+
+        log.info("Assignment cancelled: id={}", id);
+    }
+
+    // ========== TS 모듈 연동용 메서드 ==========
+
+    @Override
+    public boolean existsMainInstructor(Long timeId) {
+        log.debug("Checking main instructor exists: timeId={}", timeId);
+
+        Long tenantId = TenantContext.getCurrentTenantId();
+        return assignmentRepository.existsActiveMainInstructor(timeId, tenantId);
+    }
+
+    @Override
+    public Map<Long, List<InstructorAssignmentResponse>> getInstructorsByTimeIds(List<Long> timeIds) {
+        log.debug("Getting instructors by timeIds: count={}", timeIds.size());
+
+        if (timeIds == null || timeIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        List<InstructorAssignment> assignments = assignmentRepository.findActiveByTimeKeyIn(timeIds, tenantId);
+
+        return assignments.stream()
+                .collect(Collectors.groupingBy(
+                        InstructorAssignment::getTimeKey,
+                        Collectors.mapping(
+                                InstructorAssignmentResponse::from,
+                                Collectors.toList()
+                        )
+                ));
+    }
+
+    // ========== Private Methods ==========
+
+    private InstructorAssignment findAssignmentById(Long id) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        return assignmentRepository.findByIdAndTenantId(id, tenantId)
+                .orElseThrow(() -> new InstructorAssignmentNotFoundException(id));
+    }
+
+    private void validateActiveStatus(InstructorAssignment assignment) {
+        if (!assignment.isActive()) {
+            throw new CannotModifyInactiveAssignmentException(assignment.getId());
+        }
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentControllerTest.java
@@ -1,0 +1,374 @@
+package com.mzc.lp.domain.iis.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.constant.InstructorRole;
+import com.mzc.lp.domain.iis.dto.request.AssignInstructorRequest;
+import com.mzc.lp.domain.iis.dto.request.CancelAssignmentRequest;
+import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
+import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
+import com.mzc.lp.domain.iis.entity.InstructorAssignment;
+import com.mzc.lp.domain.iis.repository.AssignmentHistoryRepository;
+import com.mzc.lp.domain.iis.repository.InstructorAssignmentRepository;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class InstructorAssignmentControllerTest extends TenantTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private InstructorAssignmentRepository assignmentRepository;
+
+    @Autowired
+    private AssignmentHistoryRepository historyRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private UserCourseRoleRepository userCourseRoleRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private static final Long TIME_ID = 100L;
+
+    @BeforeEach
+    void setUp() {
+        historyRepository.deleteAll();
+        assignmentRepository.deleteAll();
+        userCourseRoleRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ========== Helper Methods ==========
+
+    private User createOperatorUser() {
+        User user = User.create("operator@example.com", "운영자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.OPERATOR);
+        return userRepository.save(user);
+    }
+
+    private User createInstructorUser() {
+        User user = User.create("instructor@example.com", "강사", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.USER);
+        return userRepository.save(user);
+    }
+
+    private String loginAndGetAccessToken(String email, String password) throws Exception {
+        LoginRequest request = new LoginRequest(email, password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("data").get("accessToken").asText();
+    }
+
+    private InstructorAssignment createAssignment(Long userId, Long timeId, InstructorRole role) {
+        return assignmentRepository.save(InstructorAssignment.create(userId, timeId, role, 1L));
+    }
+
+    // ==================== 배정 API 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/times/{timeId}/instructors - 강사 배정")
+    class AssignInstructor {
+
+        @Test
+        @DisplayName("성공 - 강사 배정")
+        void assignInstructor_success() throws Exception {
+            // given
+            User operator = createOperatorUser();
+            User instructor = createInstructorUser();
+            String token = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            AssignInstructorRequest request = new AssignInstructorRequest(instructor.getId(), InstructorRole.MAIN);
+
+            // when & then
+            mockMvc.perform(post("/api/times/{timeId}/instructors", TIME_ID)
+                            .header("Authorization", "Bearer " + token)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.userId").value(instructor.getId()))
+                    .andExpect(jsonPath("$.data.role").value("MAIN"))
+                    .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+        }
+
+        @Test
+        @DisplayName("실패 - 권한 없음")
+        void assignInstructor_fail_forbidden() throws Exception {
+            // given
+            User instructor = createInstructorUser();
+            String token = loginAndGetAccessToken("instructor@example.com", "Password123!");
+
+            AssignInstructorRequest request = new AssignInstructorRequest(instructor.getId(), InstructorRole.MAIN);
+
+            // when & then
+            mockMvc.perform(post("/api/times/{timeId}/instructors", TIME_ID)
+                            .header("Authorization", "Bearer " + token)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("실패 - 중복 배정")
+        void assignInstructor_fail_duplicate() throws Exception {
+            // given
+            User operator = createOperatorUser();
+            User instructor = createInstructorUser();
+            String token = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            createAssignment(instructor.getId(), TIME_ID, InstructorRole.SUB);
+
+            AssignInstructorRequest request = new AssignInstructorRequest(instructor.getId(), InstructorRole.MAIN);
+
+            // when & then
+            mockMvc.perform(post("/api/times/{timeId}/instructors", TIME_ID)
+                            .header("Authorization", "Bearer " + token)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.errorCode").value("IIS002"));
+        }
+    }
+
+    // ==================== 조회 API 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/times/{timeId}/instructors - 차수별 강사 목록 조회")
+    class GetInstructorsByTimeId {
+
+        @Test
+        @DisplayName("성공 - 전체 조회")
+        void getInstructorsByTimeId_success() throws Exception {
+            // given
+            User operator = createOperatorUser();
+            User instructor = createInstructorUser();
+            String token = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            createAssignment(instructor.getId(), TIME_ID, InstructorRole.MAIN);
+
+            // when & then
+            mockMvc.perform(get("/api/times/{timeId}/instructors", TIME_ID)
+                            .header("Authorization", "Bearer " + token))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.length()").value(1));
+        }
+
+        @Test
+        @DisplayName("성공 - 상태별 필터 조회")
+        void getInstructorsByTimeId_success_byStatus() throws Exception {
+            // given
+            User operator = createOperatorUser();
+            User instructor = createInstructorUser();
+            String token = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            createAssignment(instructor.getId(), TIME_ID, InstructorRole.MAIN);
+
+            // when & then
+            mockMvc.perform(get("/api/times/{timeId}/instructors", TIME_ID)
+                            .header("Authorization", "Bearer " + token)
+                            .param("status", "ACTIVE"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.length()").value(1));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/instructor-assignments/{id} - 배정 단건 조회")
+    class GetAssignment {
+
+        @Test
+        @DisplayName("성공 - 배정 조회")
+        void getAssignment_success() throws Exception {
+            // given
+            User operator = createOperatorUser();
+            User instructor = createInstructorUser();
+            String token = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            InstructorAssignment assignment = createAssignment(instructor.getId(), TIME_ID, InstructorRole.MAIN);
+
+            // when & then
+            mockMvc.perform(get("/api/instructor-assignments/{id}", assignment.getId())
+                            .header("Authorization", "Bearer " + token))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.id").value(assignment.getId()))
+                    .andExpect(jsonPath("$.data.role").value("MAIN"));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 배정")
+        void getAssignment_fail_notFound() throws Exception {
+            // given
+            User operator = createOperatorUser();
+            String token = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/instructor-assignments/{id}", 999L)
+                            .header("Authorization", "Bearer " + token))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.errorCode").value("IIS001"));
+        }
+    }
+
+    // ==================== 역할 변경 API 테스트 ====================
+
+    @Nested
+    @DisplayName("PUT /api/instructor-assignments/{id} - 역할 변경")
+    class UpdateRole {
+
+        @Test
+        @DisplayName("성공 - 역할 변경")
+        void updateRole_success() throws Exception {
+            // given
+            User operator = createOperatorUser();
+            User instructor = createInstructorUser();
+            String token = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            InstructorAssignment assignment = createAssignment(instructor.getId(), TIME_ID, InstructorRole.SUB);
+
+            UpdateRoleRequest request = new UpdateRoleRequest(InstructorRole.MAIN, "주강사 승격");
+
+            // when & then
+            mockMvc.perform(put("/api/instructor-assignments/{id}", assignment.getId())
+                            .header("Authorization", "Bearer " + token)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.role").value("MAIN"));
+        }
+    }
+
+    // ==================== 교체 API 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/instructor-assignments/{id}/replace - 강사 교체")
+    class ReplaceInstructor {
+
+        @Test
+        @DisplayName("성공 - 강사 교체")
+        void replaceInstructor_success() throws Exception {
+            // given
+            User operator = createOperatorUser();
+            User instructor1 = createInstructorUser();
+            User instructor2 = User.create("instructor2@example.com", "강사2", passwordEncoder.encode("Password123!"));
+            instructor2.updateRole(TenantRole.USER);
+            instructor2 = userRepository.save(instructor2);
+
+            String token = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            InstructorAssignment assignment = createAssignment(instructor1.getId(), TIME_ID, InstructorRole.MAIN);
+
+            ReplaceInstructorRequest request = new ReplaceInstructorRequest(
+                    instructor2.getId(), InstructorRole.MAIN, "강사 교체");
+
+            // when & then
+            mockMvc.perform(post("/api/instructor-assignments/{id}/replace", assignment.getId())
+                            .header("Authorization", "Bearer " + token)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.data.userId").value(instructor2.getId()));
+        }
+    }
+
+    // ==================== 취소 API 테스트 ====================
+
+    @Nested
+    @DisplayName("DELETE /api/instructor-assignments/{id} - 배정 취소")
+    class CancelAssignment {
+
+        @Test
+        @DisplayName("성공 - 배정 취소")
+        void cancelAssignment_success() throws Exception {
+            // given
+            User operator = createOperatorUser();
+            User instructor = createInstructorUser();
+            String token = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            InstructorAssignment assignment = createAssignment(instructor.getId(), TIME_ID, InstructorRole.MAIN);
+
+            CancelAssignmentRequest request = new CancelAssignmentRequest("취소 사유");
+
+            // when & then
+            mockMvc.perform(delete("/api/instructor-assignments/{id}", assignment.getId())
+                            .header("Authorization", "Bearer " + token)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+        }
+    }
+
+    // ==================== 사용자 기준 API 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/users/me/instructor-assignments - 내 배정 목록")
+    class GetMyAssignments {
+
+        @Test
+        @DisplayName("성공 - 내 배정 목록 조회")
+        void getMyAssignments_success() throws Exception {
+            // given
+            User instructor = createInstructorUser();
+            String token = loginAndGetAccessToken("instructor@example.com", "Password123!");
+
+            createAssignment(instructor.getId(), TIME_ID, InstructorRole.MAIN);
+            createAssignment(instructor.getId(), 200L, InstructorRole.SUB);
+
+            // when & then
+            mockMvc.perform(get("/api/users/me/instructor-assignments")
+                            .header("Authorization", "Bearer " + token))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.length()").value(2));
+        }
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/iis/service/InstructorAssignmentServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/iis/service/InstructorAssignmentServiceTest.java
@@ -1,0 +1,391 @@
+package com.mzc.lp.domain.iis.service;
+
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.constant.InstructorRole;
+import com.mzc.lp.domain.iis.dto.request.AssignInstructorRequest;
+import com.mzc.lp.domain.iis.dto.request.CancelAssignmentRequest;
+import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
+import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
+import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
+import com.mzc.lp.domain.iis.entity.InstructorAssignment;
+import com.mzc.lp.domain.iis.exception.CannotModifyInactiveAssignmentException;
+import com.mzc.lp.domain.iis.exception.InstructorAlreadyAssignedException;
+import com.mzc.lp.domain.iis.exception.InstructorAssignmentNotFoundException;
+import com.mzc.lp.domain.iis.exception.MainInstructorAlreadyExistsException;
+import com.mzc.lp.domain.iis.repository.AssignmentHistoryRepository;
+import com.mzc.lp.domain.iis.repository.InstructorAssignmentRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class InstructorAssignmentServiceTest extends TenantTestSupport {
+
+    @InjectMocks
+    private InstructorAssignmentServiceImpl assignmentService;
+
+    @Mock
+    private InstructorAssignmentRepository assignmentRepository;
+
+    @Mock
+    private AssignmentHistoryRepository historyRepository;
+
+    private static final Long TENANT_ID = 1L;
+    private static final Long TIME_ID = 100L;
+    private static final Long USER_ID = 10L;
+    private static final Long OPERATOR_ID = 1L;
+
+    private InstructorAssignment createTestAssignment(Long id, Long userId, Long timeId, InstructorRole role) {
+        InstructorAssignment assignment = InstructorAssignment.create(userId, timeId, role, OPERATOR_ID);
+        // Reflection으로 ID 설정 (BaseEntity까지 올라가야 함)
+        try {
+            var idField = com.mzc.lp.common.entity.BaseEntity.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(assignment, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return assignment;
+    }
+
+    // ==================== 배정 테스트 ====================
+
+    @Nested
+    @DisplayName("assignInstructor - 강사 배정")
+    class AssignInstructor {
+
+        @Test
+        @DisplayName("성공 - MAIN 강사 배정")
+        void assignInstructor_success_main() {
+            // given
+            AssignInstructorRequest request = new AssignInstructorRequest(USER_ID, InstructorRole.MAIN);
+            InstructorAssignment saved = createTestAssignment(1L, USER_ID, TIME_ID, InstructorRole.MAIN);
+
+            given(assignmentRepository.existsByTimeKeyAndUserKeyAndTenantIdAndStatus(
+                    TIME_ID, USER_ID, TENANT_ID, AssignmentStatus.ACTIVE)).willReturn(false);
+            given(assignmentRepository.findActiveByTimeKeyAndRole(TIME_ID, TENANT_ID, InstructorRole.MAIN))
+                    .willReturn(Optional.empty());
+            given(assignmentRepository.save(any())).willReturn(saved);
+
+            // when
+            InstructorAssignmentResponse response = assignmentService.assignInstructor(TIME_ID, request, OPERATOR_ID);
+
+            // then
+            assertThat(response.id()).isEqualTo(1L);
+            assertThat(response.userId()).isEqualTo(USER_ID);
+            assertThat(response.role()).isEqualTo(InstructorRole.MAIN);
+            verify(historyRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("성공 - SUB 강사 배정")
+        void assignInstructor_success_sub() {
+            // given
+            AssignInstructorRequest request = new AssignInstructorRequest(USER_ID, InstructorRole.SUB);
+            InstructorAssignment saved = createTestAssignment(1L, USER_ID, TIME_ID, InstructorRole.SUB);
+
+            given(assignmentRepository.existsByTimeKeyAndUserKeyAndTenantIdAndStatus(
+                    TIME_ID, USER_ID, TENANT_ID, AssignmentStatus.ACTIVE)).willReturn(false);
+            given(assignmentRepository.save(any())).willReturn(saved);
+
+            // when
+            InstructorAssignmentResponse response = assignmentService.assignInstructor(TIME_ID, request, OPERATOR_ID);
+
+            // then
+            assertThat(response.role()).isEqualTo(InstructorRole.SUB);
+        }
+
+        @Test
+        @DisplayName("실패 - 중복 배정")
+        void assignInstructor_fail_alreadyAssigned() {
+            // given
+            AssignInstructorRequest request = new AssignInstructorRequest(USER_ID, InstructorRole.MAIN);
+
+            given(assignmentRepository.existsByTimeKeyAndUserKeyAndTenantIdAndStatus(
+                    TIME_ID, USER_ID, TENANT_ID, AssignmentStatus.ACTIVE)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> assignmentService.assignInstructor(TIME_ID, request, OPERATOR_ID))
+                    .isInstanceOf(InstructorAlreadyAssignedException.class);
+        }
+
+        @Test
+        @DisplayName("실패 - 주강사 중복")
+        void assignInstructor_fail_mainAlreadyExists() {
+            // given
+            AssignInstructorRequest request = new AssignInstructorRequest(USER_ID, InstructorRole.MAIN);
+            InstructorAssignment existingMain = createTestAssignment(99L, 999L, TIME_ID, InstructorRole.MAIN);
+
+            given(assignmentRepository.existsByTimeKeyAndUserKeyAndTenantIdAndStatus(
+                    TIME_ID, USER_ID, TENANT_ID, AssignmentStatus.ACTIVE)).willReturn(false);
+            given(assignmentRepository.findActiveByTimeKeyAndRole(TIME_ID, TENANT_ID, InstructorRole.MAIN))
+                    .willReturn(Optional.of(existingMain));
+
+            // when & then
+            assertThatThrownBy(() -> assignmentService.assignInstructor(TIME_ID, request, OPERATOR_ID))
+                    .isInstanceOf(MainInstructorAlreadyExistsException.class);
+        }
+    }
+
+    // ==================== 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("getAssignment - 배정 조회")
+    class GetAssignment {
+
+        @Test
+        @DisplayName("성공 - 배정 단건 조회")
+        void getAssignment_success() {
+            // given
+            InstructorAssignment assignment = createTestAssignment(1L, USER_ID, TIME_ID, InstructorRole.MAIN);
+            given(assignmentRepository.findByIdAndTenantId(1L, TENANT_ID)).willReturn(Optional.of(assignment));
+
+            // when
+            InstructorAssignmentResponse response = assignmentService.getAssignment(1L);
+
+            // then
+            assertThat(response.id()).isEqualTo(1L);
+            assertThat(response.userId()).isEqualTo(USER_ID);
+        }
+
+        @Test
+        @DisplayName("실패 - 배정 없음")
+        void getAssignment_fail_notFound() {
+            // given
+            given(assignmentRepository.findByIdAndTenantId(999L, TENANT_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> assignmentService.getAssignment(999L))
+                    .isInstanceOf(InstructorAssignmentNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getInstructorsByTimeId - 차수별 강사 목록 조회")
+    class GetInstructorsByTimeId {
+
+        @Test
+        @DisplayName("성공 - 전체 조회")
+        void getInstructorsByTimeId_success_all() {
+            // given
+            List<InstructorAssignment> assignments = List.of(
+                    createTestAssignment(1L, 10L, TIME_ID, InstructorRole.MAIN),
+                    createTestAssignment(2L, 20L, TIME_ID, InstructorRole.SUB)
+            );
+            given(assignmentRepository.findByTimeKeyAndTenantId(TIME_ID, TENANT_ID)).willReturn(assignments);
+
+            // when
+            List<InstructorAssignmentResponse> response = assignmentService.getInstructorsByTimeId(TIME_ID, null);
+
+            // then
+            assertThat(response).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("성공 - 상태별 조회")
+        void getInstructorsByTimeId_success_byStatus() {
+            // given
+            List<InstructorAssignment> assignments = List.of(
+                    createTestAssignment(1L, 10L, TIME_ID, InstructorRole.MAIN)
+            );
+            given(assignmentRepository.findByTimeKeyAndTenantIdAndStatus(TIME_ID, TENANT_ID, AssignmentStatus.ACTIVE))
+                    .willReturn(assignments);
+
+            // when
+            List<InstructorAssignmentResponse> response = assignmentService.getInstructorsByTimeId(
+                    TIME_ID, AssignmentStatus.ACTIVE);
+
+            // then
+            assertThat(response).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("getAssignmentsByUserId - 강사별 배정 목록 조회")
+    class GetAssignmentsByUserId {
+
+        @Test
+        @DisplayName("성공 - 페이징 조회")
+        void getAssignmentsByUserId_success() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+            List<InstructorAssignment> assignments = List.of(
+                    createTestAssignment(1L, USER_ID, 100L, InstructorRole.MAIN),
+                    createTestAssignment(2L, USER_ID, 200L, InstructorRole.SUB)
+            );
+            Page<InstructorAssignment> page = new PageImpl<>(assignments, pageable, 2);
+
+            given(assignmentRepository.findByUserKeyAndTenantId(USER_ID, TENANT_ID, pageable)).willReturn(page);
+
+            // when
+            Page<InstructorAssignmentResponse> response = assignmentService.getAssignmentsByUserId(
+                    USER_ID, null, pageable);
+
+            // then
+            assertThat(response.getContent()).hasSize(2);
+            assertThat(response.getTotalElements()).isEqualTo(2);
+        }
+    }
+
+    // ==================== 역할 변경 테스트 ====================
+
+    @Nested
+    @DisplayName("updateRole - 역할 변경")
+    class UpdateRole {
+
+        @Test
+        @DisplayName("성공 - SUB에서 MAIN으로 변경")
+        void updateRole_success_subToMain() {
+            // given
+            InstructorAssignment assignment = createTestAssignment(1L, USER_ID, TIME_ID, InstructorRole.SUB);
+            UpdateRoleRequest request = new UpdateRoleRequest(InstructorRole.MAIN, "주강사 승격");
+
+            given(assignmentRepository.findByIdAndTenantId(1L, TENANT_ID)).willReturn(Optional.of(assignment));
+            given(assignmentRepository.findActiveByTimeKeyAndRole(TIME_ID, TENANT_ID, InstructorRole.MAIN))
+                    .willReturn(Optional.empty());
+
+            // when
+            InstructorAssignmentResponse response = assignmentService.updateRole(1L, request, OPERATOR_ID);
+
+            // then
+            assertThat(response.role()).isEqualTo(InstructorRole.MAIN);
+            verify(historyRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 - 비활성 배정 수정")
+        void updateRole_fail_inactive() {
+            // given
+            InstructorAssignment assignment = createTestAssignment(1L, USER_ID, TIME_ID, InstructorRole.SUB);
+            assignment.cancel();
+            UpdateRoleRequest request = new UpdateRoleRequest(InstructorRole.MAIN, "주강사 승격");
+
+            given(assignmentRepository.findByIdAndTenantId(1L, TENANT_ID)).willReturn(Optional.of(assignment));
+
+            // when & then
+            assertThatThrownBy(() -> assignmentService.updateRole(1L, request, OPERATOR_ID))
+                    .isInstanceOf(CannotModifyInactiveAssignmentException.class);
+        }
+
+        @Test
+        @DisplayName("실패 - 주강사 중복")
+        void updateRole_fail_mainAlreadyExists() {
+            // given
+            InstructorAssignment assignment = createTestAssignment(1L, USER_ID, TIME_ID, InstructorRole.SUB);
+            InstructorAssignment existingMain = createTestAssignment(99L, 999L, TIME_ID, InstructorRole.MAIN);
+            UpdateRoleRequest request = new UpdateRoleRequest(InstructorRole.MAIN, "주강사 승격");
+
+            given(assignmentRepository.findByIdAndTenantId(1L, TENANT_ID)).willReturn(Optional.of(assignment));
+            given(assignmentRepository.findActiveByTimeKeyAndRole(TIME_ID, TENANT_ID, InstructorRole.MAIN))
+                    .willReturn(Optional.of(existingMain));
+
+            // when & then
+            assertThatThrownBy(() -> assignmentService.updateRole(1L, request, OPERATOR_ID))
+                    .isInstanceOf(MainInstructorAlreadyExistsException.class);
+        }
+    }
+
+    // ==================== 교체 테스트 ====================
+
+    @Nested
+    @DisplayName("replaceInstructor - 강사 교체")
+    class ReplaceInstructor {
+
+        @Test
+        @DisplayName("성공 - 강사 교체")
+        void replaceInstructor_success() {
+            // given
+            Long newUserId = 20L;
+            InstructorAssignment oldAssignment = createTestAssignment(1L, USER_ID, TIME_ID, InstructorRole.MAIN);
+            InstructorAssignment newAssignment = createTestAssignment(2L, newUserId, TIME_ID, InstructorRole.MAIN);
+            ReplaceInstructorRequest request = new ReplaceInstructorRequest(newUserId, InstructorRole.MAIN, "교체 사유");
+
+            given(assignmentRepository.findByIdAndTenantId(1L, TENANT_ID)).willReturn(Optional.of(oldAssignment));
+            given(assignmentRepository.existsByTimeKeyAndUserKeyAndTenantIdAndStatus(
+                    TIME_ID, newUserId, TENANT_ID, AssignmentStatus.ACTIVE)).willReturn(false);
+            given(assignmentRepository.save(any())).willReturn(newAssignment);
+
+            // when
+            InstructorAssignmentResponse response = assignmentService.replaceInstructor(1L, request, OPERATOR_ID);
+
+            // then
+            assertThat(response.userId()).isEqualTo(newUserId);
+            assertThat(oldAssignment.getStatus()).isEqualTo(AssignmentStatus.REPLACED);
+        }
+
+        @Test
+        @DisplayName("실패 - 새 강사 중복 배정")
+        void replaceInstructor_fail_newUserAlreadyAssigned() {
+            // given
+            Long newUserId = 20L;
+            InstructorAssignment oldAssignment = createTestAssignment(1L, USER_ID, TIME_ID, InstructorRole.MAIN);
+            ReplaceInstructorRequest request = new ReplaceInstructorRequest(newUserId, InstructorRole.MAIN, "교체 사유");
+
+            given(assignmentRepository.findByIdAndTenantId(1L, TENANT_ID)).willReturn(Optional.of(oldAssignment));
+            given(assignmentRepository.existsByTimeKeyAndUserKeyAndTenantIdAndStatus(
+                    TIME_ID, newUserId, TENANT_ID, AssignmentStatus.ACTIVE)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> assignmentService.replaceInstructor(1L, request, OPERATOR_ID))
+                    .isInstanceOf(InstructorAlreadyAssignedException.class);
+        }
+    }
+
+    // ==================== 취소 테스트 ====================
+
+    @Nested
+    @DisplayName("cancelAssignment - 배정 취소")
+    class CancelAssignment {
+
+        @Test
+        @DisplayName("성공 - 배정 취소")
+        void cancelAssignment_success() {
+            // given
+            InstructorAssignment assignment = createTestAssignment(1L, USER_ID, TIME_ID, InstructorRole.MAIN);
+            CancelAssignmentRequest request = new CancelAssignmentRequest("취소 사유");
+
+            given(assignmentRepository.findByIdAndTenantId(1L, TENANT_ID)).willReturn(Optional.of(assignment));
+
+            // when
+            assignmentService.cancelAssignment(1L, request, OPERATOR_ID);
+
+            // then
+            assertThat(assignment.getStatus()).isEqualTo(AssignmentStatus.CANCELLED);
+            verify(historyRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 - 비활성 배정 취소")
+        void cancelAssignment_fail_inactive() {
+            // given
+            InstructorAssignment assignment = createTestAssignment(1L, USER_ID, TIME_ID, InstructorRole.MAIN);
+            assignment.cancel();
+            CancelAssignmentRequest request = new CancelAssignmentRequest("취소 사유");
+
+            given(assignmentRepository.findByIdAndTenantId(1L, TENANT_ID)).willReturn(Optional.of(assignment));
+
+            // when & then
+            assertThatThrownBy(() -> assignmentService.cancelAssignment(1L, request, OPERATOR_ID))
+                    .isInstanceOf(CannotModifyInactiveAssignmentException.class);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

IIS(Instructor Information System) 모듈에 강사 배정 CRUD API를 구현

## Related Issue

- Closes #59

## Changes

- Service Interface/Implementation 추가 (배정, 조회, 역할 변경, 교체, 취소)
- Controller 8개 API 엔드포인트 구현
- TS 모듈 연동용 메서드 추가 (`existsMainInstructor`, `getInstructorsByTimeIds`)
- Repository에 Bulk 조회 쿼리 추가 (N+1 방지)
- Service/Controller 테스트 코드 작성

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

### API 엔드포인트
| Method | Endpoint | 설명 |
|--------|----------|------|
| POST | `/api/times/{timeId}/instructors` | 강사 배정 |
| GET | `/api/times/{timeId}/instructors` | 차수별 강사 목록 |
| GET | `/api/instructor-assignments/{id}` | 배정 단건 조회 |
| PUT | `/api/instructor-assignments/{id}` | 역할 변경 |
| POST | `/api/instructor-assignments/{id}/replace` | 강사 교체 |
| DELETE | `/api/instructor-assignments/{id}` | 배정 취소 |
| GET | `/api/users/{userId}/instructor-assignments` | 강사별 배정 목록 |
| GET | `/api/users/me/instructor-assignments` | 내 배정 목록 |