### PR TITLE
[Feat] Snapshot CRUD API 구현

### DIFF
--- a/src/main/java/com/mzc/lp/domain/snapshot/controller/SnapshotController.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/controller/SnapshotController.java
@@ -1,0 +1,174 @@
+package com.mzc.lp.domain.snapshot.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.snapshot.constant.SnapshotStatus;
+import com.mzc.lp.domain.snapshot.dto.request.CreateSnapshotRequest;
+import com.mzc.lp.domain.snapshot.dto.request.UpdateSnapshotRequest;
+import com.mzc.lp.domain.snapshot.dto.response.SnapshotDetailResponse;
+import com.mzc.lp.domain.snapshot.dto.response.SnapshotResponse;
+import com.mzc.lp.domain.snapshot.service.SnapshotService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class SnapshotController {
+
+    private final SnapshotService snapshotService;
+
+    /**
+     * Course(템플릿)에서 스냅샷 생성
+     * POST /api/courses/{courseId}/snapshots
+     */
+    @PostMapping("/api/courses/{courseId}/snapshots")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<SnapshotDetailResponse>> createSnapshotFromCourse(
+            @PathVariable @Positive Long courseId,
+            @RequestParam @Positive Long createdBy,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        SnapshotDetailResponse response = snapshotService.createSnapshotFromCourse(courseId, createdBy);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * Course의 스냅샷 목록 조회
+     * GET /api/courses/{courseId}/snapshots
+     */
+    @GetMapping("/api/courses/{courseId}/snapshots")
+    public ResponseEntity<ApiResponse<List<SnapshotResponse>>> getSnapshotsByCourse(
+            @PathVariable @Positive Long courseId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<SnapshotResponse> response = snapshotService.getSnapshotsByCourse(courseId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 신규 스냅샷 직접 생성
+     * POST /api/snapshots
+     */
+    @PostMapping("/api/snapshots")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<SnapshotResponse>> createSnapshot(
+            @Valid @RequestBody CreateSnapshotRequest request,
+            @RequestParam @Positive Long createdBy,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        SnapshotResponse response = snapshotService.createSnapshot(request, createdBy);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 스냅샷 목록 조회 (페이징, 상태/생성자 필터)
+     * GET /api/snapshots
+     */
+    @GetMapping("/api/snapshots")
+    public ResponseEntity<ApiResponse<Page<SnapshotResponse>>> getSnapshots(
+            @RequestParam(required = false) SnapshotStatus status,
+            @RequestParam(required = false) Long createdBy,
+            @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Page<SnapshotResponse> response = snapshotService.getSnapshots(status, createdBy, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 스냅샷 상세 조회
+     * GET /api/snapshots/{snapshotId}
+     */
+    @GetMapping("/api/snapshots/{snapshotId}")
+    public ResponseEntity<ApiResponse<SnapshotDetailResponse>> getSnapshotDetail(
+            @PathVariable @Positive Long snapshotId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        SnapshotDetailResponse response = snapshotService.getSnapshotDetail(snapshotId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 스냅샷 수정
+     * PUT /api/snapshots/{snapshotId}
+     */
+    @PutMapping("/api/snapshots/{snapshotId}")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<SnapshotResponse>> updateSnapshot(
+            @PathVariable @Positive Long snapshotId,
+            @Valid @RequestBody UpdateSnapshotRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        SnapshotResponse response = snapshotService.updateSnapshot(snapshotId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 스냅샷 삭제
+     * DELETE /api/snapshots/{snapshotId}
+     */
+    @DeleteMapping("/api/snapshots/{snapshotId}")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> deleteSnapshot(
+            @PathVariable @Positive Long snapshotId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        snapshotService.deleteSnapshot(snapshotId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 스냅샷 발행 (DRAFT → ACTIVE)
+     * POST /api/snapshots/{snapshotId}/publish
+     */
+    @PostMapping("/api/snapshots/{snapshotId}/publish")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<SnapshotResponse>> publishSnapshot(
+            @PathVariable @Positive Long snapshotId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        SnapshotResponse response = snapshotService.publishSnapshot(snapshotId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 스냅샷 완료 (ACTIVE → COMPLETED)
+     * POST /api/snapshots/{snapshotId}/complete
+     */
+    @PostMapping("/api/snapshots/{snapshotId}/complete")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<SnapshotResponse>> completeSnapshot(
+            @PathVariable @Positive Long snapshotId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        SnapshotResponse response = snapshotService.completeSnapshot(snapshotId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 스냅샷 보관 (COMPLETED → ARCHIVED)
+     * POST /api/snapshots/{snapshotId}/archive
+     */
+    @PostMapping("/api/snapshots/{snapshotId}/archive")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<SnapshotResponse>> archiveSnapshot(
+            @PathVariable @Positive Long snapshotId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        SnapshotResponse response = snapshotService.archiveSnapshot(snapshotId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/service/SnapshotService.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/service/SnapshotService.java
@@ -1,0 +1,88 @@
+package com.mzc.lp.domain.snapshot.service;
+
+import com.mzc.lp.domain.snapshot.constant.SnapshotStatus;
+import com.mzc.lp.domain.snapshot.dto.request.CreateSnapshotRequest;
+import com.mzc.lp.domain.snapshot.dto.request.UpdateSnapshotRequest;
+import com.mzc.lp.domain.snapshot.dto.response.SnapshotDetailResponse;
+import com.mzc.lp.domain.snapshot.dto.response.SnapshotResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface SnapshotService {
+
+    /**
+     * Course(템플릿)에서 스냅샷 생성 (깊은 복사)
+     * @param courseId 원본 Course ID
+     * @param createdBy 생성자 ID
+     * @return 생성된 스냅샷 상세 정보
+     */
+    SnapshotDetailResponse createSnapshotFromCourse(Long courseId, Long createdBy);
+
+    /**
+     * 신규 스냅샷 직접 생성
+     * @param request 생성 요청 DTO
+     * @param createdBy 생성자 ID
+     * @return 생성된 스냅샷 정보
+     */
+    SnapshotResponse createSnapshot(CreateSnapshotRequest request, Long createdBy);
+
+    /**
+     * 스냅샷 목록 조회 (페이징, 상태/생성자 필터)
+     * @param status 상태 필터 (optional)
+     * @param createdBy 생성자 ID 필터 (optional)
+     * @param pageable 페이징 정보
+     * @return 스냅샷 목록 페이지
+     */
+    Page<SnapshotResponse> getSnapshots(SnapshotStatus status, Long createdBy, Pageable pageable);
+
+    /**
+     * 스냅샷 상세 조회 (아이템 포함)
+     * @param snapshotId 스냅샷 ID
+     * @return 스냅샷 상세 정보
+     */
+    SnapshotDetailResponse getSnapshotDetail(Long snapshotId);
+
+    /**
+     * Course의 스냅샷 목록 조회
+     * @param courseId Course ID
+     * @return 스냅샷 목록
+     */
+    List<SnapshotResponse> getSnapshotsByCourse(Long courseId);
+
+    /**
+     * 스냅샷 수정
+     * @param snapshotId 스냅샷 ID
+     * @param request 수정 요청 DTO
+     * @return 수정된 스냅샷 정보
+     */
+    SnapshotResponse updateSnapshot(Long snapshotId, UpdateSnapshotRequest request);
+
+    /**
+     * 스냅샷 삭제
+     * @param snapshotId 스냅샷 ID
+     */
+    void deleteSnapshot(Long snapshotId);
+
+    /**
+     * 스냅샷 발행 (DRAFT → ACTIVE)
+     * @param snapshotId 스냅샷 ID
+     * @return 변경된 스냅샷 정보
+     */
+    SnapshotResponse publishSnapshot(Long snapshotId);
+
+    /**
+     * 스냅샷 완료 (ACTIVE → COMPLETED)
+     * @param snapshotId 스냅샷 ID
+     * @return 변경된 스냅샷 정보
+     */
+    SnapshotResponse completeSnapshot(Long snapshotId);
+
+    /**
+     * 스냅샷 보관 (COMPLETED → ARCHIVED)
+     * @param snapshotId 스냅샷 ID
+     * @return 변경된 스냅샷 정보
+     */
+    SnapshotResponse archiveSnapshot(Long snapshotId);
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/service/SnapshotServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/service/SnapshotServiceImpl.java
@@ -1,0 +1,271 @@
+package com.mzc.lp.domain.snapshot.service;
+
+import com.mzc.lp.domain.course.entity.Course;
+import com.mzc.lp.domain.course.entity.CourseItem;
+import com.mzc.lp.domain.course.exception.CourseNotFoundException;
+import com.mzc.lp.domain.course.repository.CourseItemRepository;
+import com.mzc.lp.domain.course.repository.CourseRepository;
+import com.mzc.lp.domain.snapshot.constant.SnapshotStatus;
+import com.mzc.lp.domain.snapshot.dto.request.CreateSnapshotRequest;
+import com.mzc.lp.domain.snapshot.dto.request.UpdateSnapshotRequest;
+import com.mzc.lp.domain.snapshot.dto.response.SnapshotDetailResponse;
+import com.mzc.lp.domain.snapshot.dto.response.SnapshotItemResponse;
+import com.mzc.lp.domain.snapshot.dto.response.SnapshotResponse;
+import com.mzc.lp.domain.snapshot.entity.CourseSnapshot;
+import com.mzc.lp.domain.snapshot.entity.SnapshotItem;
+import com.mzc.lp.domain.snapshot.entity.SnapshotLearningObject;
+import com.mzc.lp.domain.snapshot.exception.SnapshotNotFoundException;
+import com.mzc.lp.domain.snapshot.exception.SnapshotStateException;
+import com.mzc.lp.domain.snapshot.repository.CourseSnapshotRepository;
+import com.mzc.lp.domain.snapshot.repository.SnapshotItemRepository;
+import com.mzc.lp.domain.snapshot.repository.SnapshotLearningObjectRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SnapshotServiceImpl implements SnapshotService {
+
+    private final CourseSnapshotRepository snapshotRepository;
+    private final SnapshotItemRepository snapshotItemRepository;
+    private final SnapshotLearningObjectRepository snapshotLoRepository;
+    private final CourseRepository courseRepository;
+    private final CourseItemRepository courseItemRepository;
+
+    private static final Long DEFAULT_TENANT_ID = 1L;
+
+    @Override
+    @Transactional
+    public SnapshotDetailResponse createSnapshotFromCourse(Long courseId, Long createdBy) {
+        log.info("Creating snapshot from course: courseId={}, createdBy={}", courseId, createdBy);
+
+        Course course = courseRepository.findByIdAndTenantId(courseId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new CourseNotFoundException(courseId));
+
+        CourseSnapshot snapshot = CourseSnapshot.createFromCourse(course, createdBy);
+        CourseSnapshot savedSnapshot = snapshotRepository.save(snapshot);
+
+        List<CourseItem> courseItems = courseItemRepository.findByCourseIdOrderByDepthAndSortOrder(
+                courseId, DEFAULT_TENANT_ID);
+
+        copyItemsFromCourse(savedSnapshot, courseItems);
+
+        Long itemCount = snapshotRepository.countItemsBySnapshotId(savedSnapshot.getId());
+        Long totalDuration = snapshotRepository.sumDurationBySnapshotId(savedSnapshot.getId());
+
+        List<SnapshotItem> rootItems = snapshotItemRepository.findRootItemsWithLo(
+                savedSnapshot.getId(), DEFAULT_TENANT_ID);
+        List<SnapshotItemResponse> itemResponses = rootItems.stream()
+                .map(SnapshotItemResponse::fromWithChildren)
+                .toList();
+
+        log.info("Snapshot created from course: snapshotId={}, courseId={}, itemCount={}",
+                savedSnapshot.getId(), courseId, itemCount);
+
+        return SnapshotDetailResponse.from(savedSnapshot, itemResponses, itemCount, totalDuration);
+    }
+
+    @Override
+    @Transactional
+    public SnapshotResponse createSnapshot(CreateSnapshotRequest request, Long createdBy) {
+        log.info("Creating snapshot: snapshotName={}, createdBy={}", request.snapshotName(), createdBy);
+
+        CourseSnapshot snapshot = CourseSnapshot.create(
+                request.snapshotName(),
+                request.description(),
+                request.hashtags(),
+                createdBy
+        );
+
+        CourseSnapshot savedSnapshot = snapshotRepository.save(snapshot);
+        log.info("Snapshot created: snapshotId={}", savedSnapshot.getId());
+
+        return SnapshotResponse.from(savedSnapshot);
+    }
+
+    @Override
+    public Page<SnapshotResponse> getSnapshots(SnapshotStatus status, Long createdBy, Pageable pageable) {
+        log.debug("Getting snapshots: status={}, createdBy={}", status, createdBy);
+
+        Page<CourseSnapshot> snapshots;
+
+        if (status != null && createdBy != null) {
+            snapshots = snapshotRepository.findByTenantIdAndStatusAndCreatedBy(
+                    DEFAULT_TENANT_ID, status, createdBy, pageable);
+        } else if (status != null) {
+            snapshots = snapshotRepository.findByTenantIdAndStatus(
+                    DEFAULT_TENANT_ID, status, pageable);
+        } else if (createdBy != null) {
+            snapshots = snapshotRepository.findByTenantIdAndCreatedBy(
+                    DEFAULT_TENANT_ID, createdBy, pageable);
+        } else {
+            snapshots = snapshotRepository.findByTenantId(DEFAULT_TENANT_ID, pageable);
+        }
+
+        return snapshots.map(SnapshotResponse::from);
+    }
+
+    @Override
+    public SnapshotDetailResponse getSnapshotDetail(Long snapshotId) {
+        log.debug("Getting snapshot detail: snapshotId={}", snapshotId);
+
+        CourseSnapshot snapshot = snapshotRepository.findByIdAndTenantId(snapshotId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new SnapshotNotFoundException(snapshotId));
+
+        List<SnapshotItem> rootItems = snapshotItemRepository.findRootItemsWithLo(
+                snapshotId, DEFAULT_TENANT_ID);
+        List<SnapshotItemResponse> itemResponses = rootItems.stream()
+                .map(SnapshotItemResponse::fromWithChildren)
+                .toList();
+
+        Long itemCount = snapshotRepository.countItemsBySnapshotId(snapshotId);
+        Long totalDuration = snapshotRepository.sumDurationBySnapshotId(snapshotId);
+
+        return SnapshotDetailResponse.from(snapshot, itemResponses, itemCount, totalDuration);
+    }
+
+    @Override
+    public List<SnapshotResponse> getSnapshotsByCourse(Long courseId) {
+        log.debug("Getting snapshots by course: courseId={}", courseId);
+
+        if (!courseRepository.existsByIdAndTenantId(courseId, DEFAULT_TENANT_ID)) {
+            throw new CourseNotFoundException(courseId);
+        }
+
+        List<CourseSnapshot> snapshots = snapshotRepository.findBySourceCourseIdAndTenantId(
+                courseId, DEFAULT_TENANT_ID);
+
+        return snapshots.stream()
+                .map(SnapshotResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public SnapshotResponse updateSnapshot(Long snapshotId, UpdateSnapshotRequest request) {
+        log.info("Updating snapshot: snapshotId={}", snapshotId);
+
+        CourseSnapshot snapshot = snapshotRepository.findByIdAndTenantId(snapshotId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new SnapshotNotFoundException(snapshotId));
+
+        if (!snapshot.isModifiable()) {
+            throw new SnapshotStateException(snapshot.getStatus(), "수정");
+        }
+
+        snapshot.update(request.snapshotName(), request.description(), request.hashtags());
+
+        log.info("Snapshot updated: snapshotId={}", snapshotId);
+        return SnapshotResponse.from(snapshot);
+    }
+
+    @Override
+    @Transactional
+    public void deleteSnapshot(Long snapshotId) {
+        log.info("Deleting snapshot: snapshotId={}", snapshotId);
+
+        CourseSnapshot snapshot = snapshotRepository.findByIdAndTenantId(snapshotId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new SnapshotNotFoundException(snapshotId));
+
+        snapshotRepository.delete(snapshot);
+        log.info("Snapshot deleted: snapshotId={}", snapshotId);
+    }
+
+    @Override
+    @Transactional
+    public SnapshotResponse publishSnapshot(Long snapshotId) {
+        log.info("Publishing snapshot: snapshotId={}", snapshotId);
+
+        CourseSnapshot snapshot = snapshotRepository.findByIdAndTenantId(snapshotId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new SnapshotNotFoundException(snapshotId));
+
+        if (!snapshot.isDraft()) {
+            throw new SnapshotStateException(snapshot.getStatus(), "발행");
+        }
+
+        snapshot.publish();
+
+        log.info("Snapshot published: snapshotId={}", snapshotId);
+        return SnapshotResponse.from(snapshot);
+    }
+
+    @Override
+    @Transactional
+    public SnapshotResponse completeSnapshot(Long snapshotId) {
+        log.info("Completing snapshot: snapshotId={}", snapshotId);
+
+        CourseSnapshot snapshot = snapshotRepository.findByIdAndTenantId(snapshotId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new SnapshotNotFoundException(snapshotId));
+
+        if (!snapshot.isActive()) {
+            throw new SnapshotStateException(snapshot.getStatus(), "완료");
+        }
+
+        snapshot.complete();
+
+        log.info("Snapshot completed: snapshotId={}", snapshotId);
+        return SnapshotResponse.from(snapshot);
+    }
+
+    @Override
+    @Transactional
+    public SnapshotResponse archiveSnapshot(Long snapshotId) {
+        log.info("Archiving snapshot: snapshotId={}", snapshotId);
+
+        CourseSnapshot snapshot = snapshotRepository.findByIdAndTenantId(snapshotId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new SnapshotNotFoundException(snapshotId));
+
+        if (snapshot.getStatus() != SnapshotStatus.COMPLETED) {
+            throw new SnapshotStateException(snapshot.getStatus(), "보관");
+        }
+
+        snapshot.archive();
+
+        log.info("Snapshot archived: snapshotId={}", snapshotId);
+        return SnapshotResponse.from(snapshot);
+    }
+
+    private void copyItemsFromCourse(CourseSnapshot snapshot, List<CourseItem> courseItems) {
+        Map<Long, SnapshotItem> itemMapping = new HashMap<>();
+
+        for (CourseItem courseItem : courseItems) {
+            SnapshotLearningObject snapshotLo = null;
+
+            if (courseItem.getLearningObjectId() != null) {
+                snapshotLo = SnapshotLearningObject.create(
+                        courseItem.getLearningObjectId(),
+                        courseItem.getItemName()
+                );
+                snapshotLo = snapshotLoRepository.save(snapshotLo);
+            }
+
+            SnapshotItem parentItem = null;
+            if (courseItem.getParent() != null) {
+                parentItem = itemMapping.get(courseItem.getParent().getId());
+            }
+
+            String itemType = courseItem.isFolder() ? null : "CONTENT";
+
+            SnapshotItem snapshotItem = SnapshotItem.createFromCourseItem(
+                    snapshot,
+                    courseItem.getId(),
+                    courseItem.getItemName(),
+                    parentItem,
+                    snapshotLo,
+                    itemType
+            );
+
+            SnapshotItem savedItem = snapshotItemRepository.save(snapshotItem);
+            itemMapping.put(courseItem.getId(), savedItem);
+        }
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/snapshot/controller/SnapshotControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/snapshot/controller/SnapshotControllerTest.java
@@ -1,0 +1,757 @@
+package com.mzc.lp.domain.snapshot.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.course.constant.CourseLevel;
+import com.mzc.lp.domain.course.constant.CourseType;
+import com.mzc.lp.domain.course.entity.Course;
+import com.mzc.lp.domain.course.entity.CourseItem;
+import com.mzc.lp.domain.course.repository.CourseItemRepository;
+import com.mzc.lp.domain.course.repository.CourseRepository;
+import com.mzc.lp.domain.snapshot.constant.SnapshotStatus;
+import com.mzc.lp.domain.snapshot.dto.request.CreateSnapshotRequest;
+import com.mzc.lp.domain.snapshot.dto.request.UpdateSnapshotRequest;
+import com.mzc.lp.domain.snapshot.entity.CourseSnapshot;
+import com.mzc.lp.domain.snapshot.repository.CourseSnapshotRepository;
+import com.mzc.lp.domain.snapshot.repository.SnapshotItemRepository;
+import com.mzc.lp.domain.snapshot.repository.SnapshotLearningObjectRepository;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.dto.request.RegisterRequest;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SnapshotControllerTest extends TenantTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CourseSnapshotRepository snapshotRepository;
+
+    @Autowired
+    private SnapshotItemRepository snapshotItemRepository;
+
+    @Autowired
+    private SnapshotLearningObjectRepository snapshotLoRepository;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @Autowired
+    private CourseItemRepository courseItemRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private UserCourseRoleRepository userCourseRoleRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        snapshotItemRepository.deleteAll();
+        snapshotLoRepository.deleteAll();
+        snapshotRepository.deleteAll();
+        courseItemRepository.deleteAll();
+        courseRepository.deleteAll();
+        userCourseRoleRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ===== 헬퍼 메서드 =====
+
+    private User createOperatorUser() {
+        User user = User.create("operator@example.com", "운영자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.OPERATOR);
+        return userRepository.save(user);
+    }
+
+    private void createTestUser() throws Exception {
+        RegisterRequest request = new RegisterRequest(
+                "test@example.com",
+                "Password123!",
+                "홍길동",
+                "010-1234-5678"
+        );
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+    }
+
+    private String loginAndGetAccessToken(String email, String password) throws Exception {
+        LoginRequest request = new LoginRequest(email, password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("data").get("accessToken").asText();
+    }
+
+    private Course createTestCourse(String title) {
+        Course course = Course.create(
+                title,
+                "테스트 강의 설명",
+                CourseLevel.BEGINNER,
+                CourseType.ONLINE,
+                10,
+                1L,
+                null
+        );
+        return courseRepository.save(course);
+    }
+
+    private Course createTestCourseWithItems(String title) {
+        Course course = createTestCourse(title);
+
+        CourseItem folder = CourseItem.createFolder(course, "1장. 입문", null);
+        courseItemRepository.save(folder);
+
+        CourseItem item1 = CourseItem.createItem(course, "1-1. 소개", folder, 100L);
+        CourseItem item2 = CourseItem.createItem(course, "1-2. 설치", folder, 101L);
+        courseItemRepository.save(item1);
+        courseItemRepository.save(item2);
+
+        return course;
+    }
+
+    private CourseSnapshot createTestSnapshot(String name, Long createdBy) {
+        CourseSnapshot snapshot = CourseSnapshot.create(name, "설명", "#태그", createdBy);
+        return snapshotRepository.save(snapshot);
+    }
+
+    private CourseSnapshot createTestSnapshotWithStatus(String name, Long createdBy, SnapshotStatus status) {
+        CourseSnapshot snapshot = CourseSnapshot.create(name, "설명", "#태그", createdBy);
+        snapshotRepository.save(snapshot);
+
+        if (status == SnapshotStatus.ACTIVE) {
+            snapshot.publish();
+        } else if (status == SnapshotStatus.COMPLETED) {
+            snapshot.publish();
+            snapshot.complete();
+        } else if (status == SnapshotStatus.ARCHIVED) {
+            snapshot.publish();
+            snapshot.complete();
+            snapshot.archive();
+        }
+
+        return snapshotRepository.save(snapshot);
+    }
+
+    // ==================== Course에서 스냅샷 생성 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/courses/{courseId}/snapshots - Course에서 스냅샷 생성")
+    class CreateSnapshotFromCourse {
+
+        @Test
+        @DisplayName("성공 - OPERATOR가 Course에서 스냅샷 생성")
+        void createSnapshotFromCourse_success() throws Exception {
+            // given
+            User operator = createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourseWithItems("Spring Boot 기초");
+
+            // when & then
+            mockMvc.perform(post("/api/courses/{courseId}/snapshots", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("createdBy", operator.getId().toString()))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.snapshotName").value("Spring Boot 기초"))
+                    .andExpect(jsonPath("$.data.sourceCourseId").value(course.getId()))
+                    .andExpect(jsonPath("$.data.status").value("DRAFT"))
+                    .andExpect(jsonPath("$.data.version").value(1));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 Course")
+        void createSnapshotFromCourse_fail_courseNotFound() throws Exception {
+            // given
+            User operator = createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(post("/api/courses/{courseId}/snapshots", 99999L)
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("createdBy", operator.getId().toString()))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM001"));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 생성 시도")
+        void createSnapshotFromCourse_fail_userRole() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken("test@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+
+            // when & then
+            mockMvc.perform(post("/api/courses/{courseId}/snapshots", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("createdBy", "1"))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 신규 스냅샷 직접 생성 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/snapshots - 신규 스냅샷 직접 생성")
+    class CreateSnapshot {
+
+        @Test
+        @DisplayName("성공 - OPERATOR가 스냅샷 직접 생성")
+        void createSnapshot_success() throws Exception {
+            // given
+            User operator = createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CreateSnapshotRequest request = new CreateSnapshotRequest(
+                    "새 강의",
+                    "강의 설명입니다.",
+                    "#spring #java"
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("createdBy", operator.getId().toString())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.snapshotName").value("새 강의"))
+                    .andExpect(jsonPath("$.data.description").value("강의 설명입니다."))
+                    .andExpect(jsonPath("$.data.hashtags").value("#spring #java"))
+                    .andExpect(jsonPath("$.data.status").value("DRAFT"))
+                    .andExpect(jsonPath("$.data.sourceCourseId").isEmpty());
+        }
+
+        @Test
+        @DisplayName("실패 - 스냅샷 이름 누락")
+        void createSnapshot_fail_missingName() throws Exception {
+            // given
+            User operator = createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CreateSnapshotRequest request = new CreateSnapshotRequest(
+                    null,
+                    "설명만 있음",
+                    "#태그"
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("createdBy", operator.getId().toString())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 생성 시도")
+        void createSnapshot_fail_userRole() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken("test@example.com", "Password123!");
+            CreateSnapshotRequest request = new CreateSnapshotRequest(
+                    "테스트 강의",
+                    null,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("createdBy", "1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 스냅샷 목록 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/snapshots - 스냅샷 목록 조회")
+    class GetSnapshots {
+
+        @Test
+        @DisplayName("성공 - 전체 스냅샷 목록 조회")
+        void getSnapshots_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            createTestSnapshot("스냅샷1", 1L);
+            createTestSnapshot("스냅샷2", 1L);
+            createTestSnapshot("스냅샷3", 2L);
+
+            // when & then
+            mockMvc.perform(get("/api/snapshots")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.totalElements").value(3));
+        }
+
+        @Test
+        @DisplayName("성공 - 상태 필터링")
+        void getSnapshots_success_statusFilter() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            createTestSnapshotWithStatus("DRAFT 스냅샷", 1L, SnapshotStatus.DRAFT);
+            createTestSnapshotWithStatus("ACTIVE 스냅샷", 1L, SnapshotStatus.ACTIVE);
+            createTestSnapshotWithStatus("COMPLETED 스냅샷", 1L, SnapshotStatus.COMPLETED);
+
+            // when & then
+            mockMvc.perform(get("/api/snapshots")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("status", "ACTIVE"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.totalElements").value(1));
+        }
+
+        @Test
+        @DisplayName("성공 - 생성자 필터링")
+        void getSnapshots_success_createdByFilter() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            createTestSnapshot("스냅샷1", 1L);
+            createTestSnapshot("스냅샷2", 1L);
+            createTestSnapshot("스냅샷3", 2L);
+
+            // when & then
+            mockMvc.perform(get("/api/snapshots")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("createdBy", "1"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.totalElements").value(2));
+        }
+
+        @Test
+        @DisplayName("성공 - 빈 결과")
+        void getSnapshots_success_empty() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/snapshots")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.totalElements").value(0));
+        }
+    }
+
+    // ==================== 스냅샷 상세 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/snapshots/{snapshotId} - 스냅샷 상세 조회")
+    class GetSnapshotDetail {
+
+        @Test
+        @DisplayName("성공 - 스냅샷 상세 조회")
+        void getSnapshotDetail_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+
+            // when & then
+            mockMvc.perform(get("/api/snapshots/{snapshotId}", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.snapshotId").value(snapshot.getId()))
+                    .andExpect(jsonPath("$.data.snapshotName").value("테스트 스냅샷"))
+                    .andExpect(jsonPath("$.data.items").isArray());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 스냅샷")
+        void getSnapshotDetail_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/snapshots/{snapshotId}", 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM006"));
+        }
+    }
+
+    // ==================== Course의 스냅샷 목록 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/courses/{courseId}/snapshots - Course의 스냅샷 목록")
+    class GetSnapshotsByCourse {
+
+        @Test
+        @DisplayName("성공 - Course의 스냅샷 목록 조회")
+        void getSnapshotsByCourse_success() throws Exception {
+            // given
+            User operator = createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Course course = createTestCourse("테스트 강의");
+
+            // Course에서 스냅샷 생성
+            mockMvc.perform(post("/api/courses/{courseId}/snapshots", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("createdBy", operator.getId().toString()))
+                    .andExpect(status().isCreated());
+
+            mockMvc.perform(post("/api/courses/{courseId}/snapshots", course.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("createdBy", operator.getId().toString()))
+                    .andExpect(status().isCreated());
+
+            // when & then
+            mockMvc.perform(get("/api/courses/{courseId}/snapshots", course.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(2));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 Course")
+        void getSnapshotsByCourse_fail_courseNotFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/courses/{courseId}/snapshots", 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM001"));
+        }
+    }
+
+    // ==================== 스냅샷 수정 테스트 ====================
+
+    @Nested
+    @DisplayName("PUT /api/snapshots/{snapshotId} - 스냅샷 수정")
+    class UpdateSnapshot {
+
+        @Test
+        @DisplayName("성공 - DRAFT 상태에서 수정")
+        void updateSnapshot_success_draft() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("원래 이름", 1L);
+            UpdateSnapshotRequest request = new UpdateSnapshotRequest(
+                    "수정된 이름",
+                    "수정된 설명",
+                    "#updated"
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/snapshots/{snapshotId}", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.snapshotName").value("수정된 이름"))
+                    .andExpect(jsonPath("$.data.description").value("수정된 설명"))
+                    .andExpect(jsonPath("$.data.hashtags").value("#updated"));
+        }
+
+        @Test
+        @DisplayName("성공 - ACTIVE 상태에서 메타데이터 수정")
+        void updateSnapshot_success_active() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshotWithStatus("원래 이름", 1L, SnapshotStatus.ACTIVE);
+            UpdateSnapshotRequest request = new UpdateSnapshotRequest(
+                    "수정된 이름",
+                    "수정된 설명",
+                    "#updated"
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/snapshots/{snapshotId}", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.snapshotName").value("수정된 이름"));
+        }
+
+        @Test
+        @DisplayName("실패 - COMPLETED 상태에서 수정 시도")
+        void updateSnapshot_fail_completed() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshotWithStatus("원래 이름", 1L, SnapshotStatus.COMPLETED);
+            UpdateSnapshotRequest request = new UpdateSnapshotRequest(
+                    "수정 시도",
+                    null,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/snapshots/{snapshotId}", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM007"));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 스냅샷")
+        void updateSnapshot_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            UpdateSnapshotRequest request = new UpdateSnapshotRequest(
+                    "수정 시도",
+                    null,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/snapshots/{snapshotId}", 99999L)
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM006"));
+        }
+    }
+
+    // ==================== 스냅샷 삭제 테스트 ====================
+
+    @Nested
+    @DisplayName("DELETE /api/snapshots/{snapshotId} - 스냅샷 삭제")
+    class DeleteSnapshot {
+
+        @Test
+        @DisplayName("성공 - 스냅샷 삭제")
+        void deleteSnapshot_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("삭제할 스냅샷", 1L);
+
+            // when & then
+            mockMvc.perform(delete("/api/snapshots/{snapshotId}", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+
+            // 삭제 확인
+            mockMvc.perform(get("/api/snapshots/{snapshotId}", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 스냅샷")
+        void deleteSnapshot_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(delete("/api/snapshots/{snapshotId}", 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM006"));
+        }
+    }
+
+    // ==================== 상태 변경 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/snapshots/{snapshotId}/publish - 스냅샷 발행")
+    class PublishSnapshot {
+
+        @Test
+        @DisplayName("성공 - DRAFT → ACTIVE 발행")
+        void publishSnapshot_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("발행할 스냅샷", 1L);
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots/{snapshotId}/publish", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+        }
+
+        @Test
+        @DisplayName("실패 - ACTIVE 상태에서 발행 시도")
+        void publishSnapshot_fail_alreadyActive() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshotWithStatus("이미 발행됨", 1L, SnapshotStatus.ACTIVE);
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots/{snapshotId}/publish", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM007"));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/snapshots/{snapshotId}/complete - 스냅샷 완료")
+    class CompleteSnapshot {
+
+        @Test
+        @DisplayName("성공 - ACTIVE → COMPLETED 완료")
+        void completeSnapshot_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshotWithStatus("완료할 스냅샷", 1L, SnapshotStatus.ACTIVE);
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots/{snapshotId}/complete", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.status").value("COMPLETED"));
+        }
+
+        @Test
+        @DisplayName("실패 - DRAFT 상태에서 완료 시도")
+        void completeSnapshot_fail_draft() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("DRAFT 스냅샷", 1L);
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots/{snapshotId}/complete", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM007"));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/snapshots/{snapshotId}/archive - 스냅샷 보관")
+    class ArchiveSnapshot {
+
+        @Test
+        @DisplayName("성공 - COMPLETED → ARCHIVED 보관")
+        void archiveSnapshot_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshotWithStatus("보관할 스냅샷", 1L, SnapshotStatus.COMPLETED);
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots/{snapshotId}/archive", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.status").value("ARCHIVED"));
+        }
+
+        @Test
+        @DisplayName("실패 - ACTIVE 상태에서 보관 시도")
+        void archiveSnapshot_fail_active() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshotWithStatus("ACTIVE 스냅샷", 1L, SnapshotStatus.ACTIVE);
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots/{snapshotId}/archive", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM007"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- SnapshotService 인터페이스 및 구현체 작성
- SnapshotController 작성 (10개 엔드포인트)
- SnapshotControllerTest 작성 (21개 테스트 케이스)
- Course → Snapshot 깊은 복사 로직 구현

## API 엔드포인트
| Method | Endpoint | 기능 |
|--------|----------|------|
| POST | `/api/courses/{courseId}/snapshots` | 템플릿에서 스냅샷 생성 |
| POST | `/api/snapshots` | 신규 스냅샷 직접 생성 |
| GET | `/api/snapshots` | 스냅샷 목록 조회 |
| GET | `/api/snapshots/{snapshotId}` | 스냅샷 상세 조회 |
| GET | `/api/courses/{courseId}/snapshots` | Course의 스냅샷 목록 |
| PUT | `/api/snapshots/{snapshotId}` | 스냅샷 수정 |
| DELETE | `/api/snapshots/{snapshotId}` | 스냅샷 삭제 |
| POST | `/api/snapshots/{snapshotId}/publish` | 발행 (DRAFT → ACTIVE) |
| POST | `/api/snapshots/{snapshotId}/complete` | 완료 (ACTIVE → COMPLETED) |
| POST | `/api/snapshots/{snapshotId}/archive` | 보관 (COMPLETED → ARCHIVED) |

## 추가된 파일
- `SnapshotService.java` - 서비스 인터페이스
- `SnapshotServiceImpl.java` - 서비스 구현체
- `SnapshotController.java` - REST 컨트롤러
- `SnapshotControllerTest.java` - 통합 테스트

## Test Plan
- [x] 전체 테스트 통과 확인 (`./gradlew test`)
- [x] SnapshotControllerTest 21개 케이스 통과
- [ ] 수동 API 테스트

Closes #80