### PR TITLE
[Feat] 콘텐츠 상태 관리 및 DESIGNER 전용 API 구현

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CT005", "File upload failed"),
     METADATA_EXTRACTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CT006", "Metadata extraction failed"),
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "CT007", "File not found on storage"),
+    UNAUTHORIZED_CONTENT_ACCESS(HttpStatus.FORBIDDEN, "CT008", "Not authorized to access this content"),
 
     // Learning Object (LO)
     LEARNING_OBJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "LO001", "Learning object not found"),

--- a/src/main/java/com/mzc/lp/domain/content/constant/ContentStatus.java
+++ b/src/main/java/com/mzc/lp/domain/content/constant/ContentStatus.java
@@ -1,0 +1,9 @@
+package com.mzc.lp.domain.content.constant;
+
+/**
+ * 콘텐츠 상태
+ */
+public enum ContentStatus {
+    ACTIVE,    // 사용 중
+    ARCHIVED   // 보관됨 (soft delete)
+}

--- a/src/main/java/com/mzc/lp/domain/content/controller/ContentController.java
+++ b/src/main/java/com/mzc/lp/domain/content/controller/ContentController.java
@@ -3,6 +3,7 @@ package com.mzc.lp.domain.content.controller;
 import com.mzc.lp.common.context.TenantContext;
 import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.content.constant.ContentStatus;
 import com.mzc.lp.domain.content.constant.ContentType;
 import com.mzc.lp.domain.content.dto.request.CreateExternalLinkRequest;
 import com.mzc.lp.domain.content.dto.request.UpdateContentRequest;
@@ -166,5 +167,46 @@ public class ContentController {
         Long tenantId = TenantContext.getCurrentTenantId();
         contentService.deleteContent(contentId, tenantId);
         return ResponseEntity.noContent().build();
+    }
+
+    // ========== DESIGNER용 API (본인 콘텐츠 관리) ==========
+
+    @GetMapping("/my")
+    @PreAuthorize("hasRole('DESIGNER')")
+    public ResponseEntity<ApiResponse<Page<ContentListResponse>>> getMyContents(
+            @RequestParam(required = false) ContentStatus status,
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        Long userId = principal.id();
+        Page<ContentListResponse> response = contentService.getMyContents(
+                tenantId, userId, status, keyword, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/{contentId}/archive")
+    @PreAuthorize("hasRole('DESIGNER')")
+    public ResponseEntity<ApiResponse<ContentResponse>> archiveContent(
+            @PathVariable Long contentId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        Long userId = principal.id();
+        ContentResponse response = contentService.archiveContent(contentId, tenantId, userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/{contentId}/restore")
+    @PreAuthorize("hasRole('DESIGNER')")
+    public ResponseEntity<ApiResponse<ContentResponse>> restoreContent(
+            @PathVariable Long contentId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        Long userId = principal.id();
+        ContentResponse response = contentService.restoreContent(contentId, tenantId, userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/content/dto/response/ContentListResponse.java
+++ b/src/main/java/com/mzc/lp/domain/content/dto/response/ContentListResponse.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.content.dto.response;
 
+import com.mzc.lp.domain.content.constant.ContentStatus;
 import com.mzc.lp.domain.content.constant.ContentType;
 import com.mzc.lp.domain.content.entity.Content;
 
@@ -10,6 +11,7 @@ public record ContentListResponse(
         Long id,
         String originalFileName,
         ContentType contentType,
+        ContentStatus status,
         Long fileSize,
         Integer duration,
         String resolution,
@@ -21,6 +23,7 @@ public record ContentListResponse(
                 content.getId(),
                 content.getOriginalFileName(),
                 content.getContentType(),
+                content.getStatus(),
                 content.getFileSize(),
                 content.getDuration(),
                 content.getResolution(),

--- a/src/main/java/com/mzc/lp/domain/content/dto/response/ContentResponse.java
+++ b/src/main/java/com/mzc/lp/domain/content/dto/response/ContentResponse.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.content.dto.response;
 
+import com.mzc.lp.domain.content.constant.ContentStatus;
 import com.mzc.lp.domain.content.constant.ContentType;
 import com.mzc.lp.domain.content.entity.Content;
 
@@ -11,6 +12,7 @@ public record ContentResponse(
         String originalFileName,
         String storedFileName,
         ContentType contentType,
+        ContentStatus status,
         Long fileSize,
         Integer duration,
         String resolution,
@@ -18,6 +20,7 @@ public record ContentResponse(
         String externalUrl,
         String filePath,
         String thumbnailPath,
+        Long createdBy,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -27,6 +30,7 @@ public record ContentResponse(
                 content.getOriginalFileName(),
                 content.getStoredFileName(),
                 content.getContentType(),
+                content.getStatus(),
                 content.getFileSize(),
                 content.getDuration(),
                 content.getResolution(),
@@ -34,6 +38,7 @@ public record ContentResponse(
                 content.getExternalUrl(),
                 content.getFilePath(),
                 content.getThumbnailPath(),
+                content.getCreatedBy(),
                 content.getCreatedAt() != null
                         ? LocalDateTime.ofInstant(content.getCreatedAt(), ZoneId.systemDefault())
                         : null,

--- a/src/main/java/com/mzc/lp/domain/content/exception/UnauthorizedContentAccessException.java
+++ b/src/main/java/com/mzc/lp/domain/content/exception/UnauthorizedContentAccessException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.content.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class UnauthorizedContentAccessException extends BusinessException {
+
+    public UnauthorizedContentAccessException() {
+        super(ErrorCode.UNAUTHORIZED_CONTENT_ACCESS);
+    }
+
+    public UnauthorizedContentAccessException(Long contentId) {
+        super(ErrorCode.UNAUTHORIZED_CONTENT_ACCESS, "Not authorized to access content: " + contentId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/content/repository/ContentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/content/repository/ContentRepository.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.content.repository;
 
+import com.mzc.lp.domain.content.constant.ContentStatus;
 import com.mzc.lp.domain.content.constant.ContentType;
 import com.mzc.lp.domain.content.entity.Content;
 import org.springframework.data.domain.Page;
@@ -32,4 +33,25 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
                                                          @Param("contentType") ContentType contentType,
                                                          @Param("keyword") String keyword,
                                                          Pageable pageable);
+
+    // createdBy 기반 조회 (DESIGNER용)
+    Page<Content> findByTenantIdAndCreatedBy(Long tenantId, Long createdBy, Pageable pageable);
+
+    Page<Content> findByTenantIdAndCreatedByAndStatus(Long tenantId, Long createdBy,
+                                                       ContentStatus status, Pageable pageable);
+
+    @Query("SELECT c FROM Content c WHERE c.tenantId = :tenantId AND c.createdBy = :createdBy " +
+           "AND LOWER(c.originalFileName) LIKE LOWER(CONCAT('%', :keyword, '%'))")
+    Page<Content> findByTenantIdAndCreatedByAndKeyword(@Param("tenantId") Long tenantId,
+                                                        @Param("createdBy") Long createdBy,
+                                                        @Param("keyword") String keyword,
+                                                        Pageable pageable);
+
+    @Query("SELECT c FROM Content c WHERE c.tenantId = :tenantId AND c.createdBy = :createdBy " +
+           "AND c.status = :status AND LOWER(c.originalFileName) LIKE LOWER(CONCAT('%', :keyword, '%'))")
+    Page<Content> findByTenantIdAndCreatedByAndStatusAndKeyword(@Param("tenantId") Long tenantId,
+                                                                 @Param("createdBy") Long createdBy,
+                                                                 @Param("status") ContentStatus status,
+                                                                 @Param("keyword") String keyword,
+                                                                 Pageable pageable);
 }

--- a/src/main/java/com/mzc/lp/domain/content/service/ContentService.java
+++ b/src/main/java/com/mzc/lp/domain/content/service/ContentService.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.content.service;
 
+import com.mzc.lp.domain.content.constant.ContentStatus;
 import com.mzc.lp.domain.content.constant.ContentType;
 import com.mzc.lp.domain.content.dto.request.CreateExternalLinkRequest;
 import com.mzc.lp.domain.content.dto.request.UpdateContentRequest;
@@ -58,4 +59,21 @@ public interface ContentService {
     ContentDownloadInfo getFileForDownload(Long contentId, Long tenantId);
 
     record ContentDownloadInfo(Resource resource, String originalFileName, String contentType) {}
+
+    // ========== DESIGNER용 API (본인 콘텐츠 관리) ==========
+
+    /**
+     * 내 콘텐츠 목록 조회 (DESIGNER용)
+     */
+    Page<ContentListResponse> getMyContents(Long tenantId, Long userId, ContentStatus status, String keyword, Pageable pageable);
+
+    /**
+     * 콘텐츠 보관 (Archive)
+     */
+    ContentResponse archiveContent(Long contentId, Long tenantId, Long userId);
+
+    /**
+     * 콘텐츠 복원 (Restore from Archive)
+     */
+    ContentResponse restoreContent(Long contentId, Long tenantId, Long userId);
 }


### PR DESCRIPTION
## Summary
- ContentStatus enum 추가 (ACTIVE/ARCHIVED)
- Content entity에 status, createdBy 필드 추가
- DESIGNER 전용 API 3개 추가
  - `GET /api/contents/my` - 내 콘텐츠 목록 조회
  - `POST /api/contents/{id}/archive` - 콘텐츠 보관
  - `POST /api/contents/{id}/restore` - 콘텐츠 복원
- 소유권 검증 로직 추가 (createdBy 기반)
- 하위 호환성을 위한 팩토리 메서드 오버로드

## ⚠️ 주의사항
**DESIGNER API 테스트를 위해서는 JwtAuthenticationFilter 수정이 필요합니다.**

현재 JwtAuthenticationFilter는 JWT 토큰의 기본 role만 로드하고, DB의 CourseRole(DESIGNER)은 로드하지 않습니다. 
따라서 security 모듈 수정이 선행되어야 DESIGNER API가 정상 동작합니다.

> security 모듈 수정이 된 후 테스트 예정

## Test plan
- [ ] JwtAuthenticationFilter에 CourseRole 로드 로직 추가 후 테스트
- [ ] DESIGNER 계정으로 `/api/contents/my` 호출
- [ ] 콘텐츠 archive/restore 동작 확인
- [ ] 타인 콘텐츠 접근 시 403 응답 확인