### PR TITLE
feat: TS 강사 배정 관리 API 구현 (#51)

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -54,6 +54,8 @@ public enum ErrorCode {
     CAPACITY_EXCEEDED(HttpStatus.CONFLICT, "TS003", "Capacity exceeded"),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "TS004", "Invalid date range"),
     LOCATION_REQUIRED(HttpStatus.BAD_REQUEST, "TS005", "Location info required for OFFLINE/BLENDED"),
+    COURSE_TIME_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST, "TS006", "CourseTime is not modifiable in current status"),
+    CANNOT_DELETE_MAIN_INSTRUCTOR(HttpStatus.BAD_REQUEST, "TS007", "Cannot delete main instructor while course is ongoing"),
 
     // Enrollment (SIS)
     ENROLLMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "SIS001", "Enrollment not found"),

--- a/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
+++ b/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
@@ -3,7 +3,6 @@ package com.mzc.lp.domain.iis.controller;
 import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.common.security.UserPrincipal;
 import com.mzc.lp.domain.iis.constant.AssignmentStatus;
-import com.mzc.lp.domain.iis.dto.request.AssignInstructorRequest;
 import com.mzc.lp.domain.iis.dto.request.CancelAssignmentRequest;
 import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
 import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
@@ -30,30 +29,8 @@ public class InstructorAssignmentController {
 
     private final InstructorAssignmentService assignmentService;
 
-    // ========== 차수 기준 API ==========
-
-    @PostMapping("/api/times/{timeId}/instructors")
-    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
-    public ResponseEntity<ApiResponse<InstructorAssignmentResponse>> assignInstructor(
-            @PathVariable Long timeId,
-            @AuthenticationPrincipal UserPrincipal principal,
-            @Valid @RequestBody AssignInstructorRequest request
-    ) {
-        InstructorAssignmentResponse response = assignmentService.assignInstructor(
-                timeId, request, principal.id());
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
-    }
-
-    @GetMapping("/api/times/{timeId}/instructors")
-    public ResponseEntity<ApiResponse<List<InstructorAssignmentResponse>>> getInstructorsByTimeId(
-            @PathVariable Long timeId,
-            @RequestParam(required = false) AssignmentStatus status
-    ) {
-        List<InstructorAssignmentResponse> response = assignmentService.getInstructorsByTimeId(timeId, status);
-        return ResponseEntity.ok(ApiResponse.success(response));
-    }
-
     // ========== 배정 단건 API ==========
+    // 차수 기준 API는 CourseTimeInstructorController에서 처리 (차수 상태 검증 포함)
 
     @GetMapping("/api/instructor-assignments/{id}")
     public ResponseEntity<ApiResponse<InstructorAssignmentResponse>> getAssignment(

--- a/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentService.java
+++ b/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentService.java
@@ -1,0 +1,34 @@
+package com.mzc.lp.domain.iis.service;
+
+import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.dto.request.AssignInstructorRequest;
+import com.mzc.lp.domain.iis.dto.request.CancelAssignmentRequest;
+import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
+import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
+import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
+
+import java.util.List;
+import java.util.Map;
+
+public interface InstructorAssignmentService {
+
+    // ===== Command =====
+
+    InstructorAssignmentResponse assignInstructor(Long timeId, AssignInstructorRequest request, Long operatorId);
+
+    InstructorAssignmentResponse updateRole(Long assignmentId, UpdateRoleRequest request, Long operatorId);
+
+    InstructorAssignmentResponse replaceInstructor(Long assignmentId, ReplaceInstructorRequest request, Long operatorId);
+
+    void cancelAssignment(Long assignmentId, CancelAssignmentRequest request, Long operatorId);
+
+    // ===== Query =====
+
+    List<InstructorAssignmentResponse> getInstructorsByTimeId(Long timeId, AssignmentStatus status);
+
+    // ===== TS 연동용 =====
+
+    boolean existsMainInstructor(Long timeId);
+
+    Map<Long, List<InstructorAssignmentResponse>> getInstructorsByTimeIds(List<Long> timeIds);
+}

--- a/src/main/java/com/mzc/lp/domain/student/controller/EnrollmentController.java
+++ b/src/main/java/com/mzc/lp/domain/student/controller/EnrollmentController.java
@@ -39,7 +39,7 @@ public class EnrollmentController {
     /**
      * 수강 신청
      */
-    @PostMapping("/api/ts/course-times/{courseTimeId}/enrollments")
+    @PostMapping("/api/times/{courseTimeId}/enrollments")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<EnrollmentDetailResponse>> enroll(
             @PathVariable Long courseTimeId,
@@ -52,7 +52,7 @@ public class EnrollmentController {
     /**
      * 강제 배정 (필수 교육)
      */
-    @PostMapping("/api/ts/course-times/{courseTimeId}/enrollments/force")
+    @PostMapping("/api/times/{courseTimeId}/enrollments/force")
     @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<ForceEnrollResultResponse>> forceEnroll(
             @PathVariable Long courseTimeId,
@@ -66,7 +66,7 @@ public class EnrollmentController {
     /**
      * 차수별 수강생 목록 조회
      */
-    @GetMapping("/api/ts/course-times/{courseTimeId}/enrollments")
+    @GetMapping("/api/times/{courseTimeId}/enrollments")
     @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<Page<EnrollmentResponse>>> getEnrollmentsByCourseTime(
             @PathVariable Long courseTimeId,
@@ -179,7 +179,7 @@ public class EnrollmentController {
     /**
      * 차수별 수강 통계 조회
      */
-    @GetMapping("/api/ts/course-times/{courseTimeId}/enrollments/stats")
+    @GetMapping("/api/times/{courseTimeId}/enrollments/stats")
     @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<CourseTimeEnrollmentStatsResponse>> getCourseTimeStats(
             @PathVariable Long courseTimeId

--- a/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeController.java
+++ b/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeController.java
@@ -23,7 +23,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/ts/course-times")
+@RequestMapping("/api/times")
 @RequiredArgsConstructor
 @Validated
 public class CourseTimeController {

--- a/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeInstructorController.java
+++ b/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeInstructorController.java
@@ -1,0 +1,150 @@
+package com.mzc.lp.domain.ts.controller;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.dto.request.AssignInstructorRequest;
+import com.mzc.lp.domain.iis.dto.request.CancelAssignmentRequest;
+import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
+import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
+import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
+import com.mzc.lp.domain.iis.service.InstructorAssignmentService;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.ts.exception.CourseTimeNotFoundException;
+import com.mzc.lp.domain.ts.exception.CourseTimeNotModifiableException;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/ts/course-times/{timeId}/instructors")
+@RequiredArgsConstructor
+@Validated
+public class CourseTimeInstructorController {
+
+    private final CourseTimeRepository courseTimeRepository;
+    private final InstructorAssignmentService instructorAssignmentService;
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<InstructorAssignmentResponse>> assignInstructor(
+            @PathVariable Long timeId,
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody AssignInstructorRequest request
+    ) {
+        log.info("Assigning instructor to course time: timeId={}, userId={}", timeId, request.userId());
+
+        CourseTime courseTime = getCourseTimeOrThrow(timeId);
+        validateModifiable(courseTime);
+
+        InstructorAssignmentResponse response = instructorAssignmentService.assignInstructor(
+                timeId, request, principal.id()
+        );
+
+        log.info("Instructor assigned: timeId={}, assignmentId={}", timeId, response.id());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<InstructorAssignmentResponse>>> getInstructors(
+            @PathVariable Long timeId,
+            @RequestParam(required = false) AssignmentStatus status
+    ) {
+        log.debug("Getting instructors for course time: timeId={}, status={}", timeId, status);
+
+        getCourseTimeOrThrow(timeId);
+
+        List<InstructorAssignmentResponse> response = instructorAssignmentService.getInstructorsByTimeId(timeId, status);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PutMapping("/{assignmentId}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<InstructorAssignmentResponse>> updateRole(
+            @PathVariable Long timeId,
+            @PathVariable Long assignmentId,
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody UpdateRoleRequest request
+    ) {
+        log.info("Updating instructor role: timeId={}, assignmentId={}, newRole={}",
+                timeId, assignmentId, request.role());
+
+        CourseTime courseTime = getCourseTimeOrThrow(timeId);
+        validateModifiable(courseTime);
+
+        InstructorAssignmentResponse response = instructorAssignmentService.updateRole(
+                assignmentId, request, principal.id()
+        );
+
+        log.info("Instructor role updated: assignmentId={}", assignmentId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/{assignmentId}/replace")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<InstructorAssignmentResponse>> replaceInstructor(
+            @PathVariable Long timeId,
+            @PathVariable Long assignmentId,
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody ReplaceInstructorRequest request
+    ) {
+        log.info("Replacing instructor: timeId={}, assignmentId={}, newUserId={}",
+                timeId, assignmentId, request.newUserId());
+
+        CourseTime courseTime = getCourseTimeOrThrow(timeId);
+        validateModifiable(courseTime);
+
+        InstructorAssignmentResponse response = instructorAssignmentService.replaceInstructor(
+                assignmentId, request, principal.id()
+        );
+
+        log.info("Instructor replaced: oldAssignmentId={}, newAssignmentId={}", assignmentId, response.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/{assignmentId}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> cancelAssignment(
+            @PathVariable Long timeId,
+            @PathVariable Long assignmentId,
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody(required = false) CancelAssignmentRequest request
+    ) {
+        log.info("Cancelling instructor assignment: timeId={}, assignmentId={}", timeId, assignmentId);
+
+        CourseTime courseTime = getCourseTimeOrThrow(timeId);
+        validateModifiable(courseTime);
+
+        CancelAssignmentRequest cancelRequest = request != null ? request : new CancelAssignmentRequest(null);
+        instructorAssignmentService.cancelAssignment(assignmentId, cancelRequest, principal.id());
+
+        log.info("Instructor assignment cancelled: assignmentId={}", assignmentId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ========== Private Methods ==========
+
+    private CourseTime getCourseTimeOrThrow(Long timeId) {
+        return courseTimeRepository.findByIdAndTenantId(timeId, TenantContext.getCurrentTenantId())
+                .orElseThrow(() -> new CourseTimeNotFoundException(timeId));
+    }
+
+    private void validateModifiable(CourseTime courseTime) {
+        if (courseTime.isClosed() || courseTime.isArchived()) {
+            throw new CourseTimeNotModifiableException(courseTime.getId(), courseTime.getStatus());
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeInstructorController.java
+++ b/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeInstructorController.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/ts/course-times/{timeId}/instructors")
+@RequestMapping("/api/times/{timeId}/instructors")
 @RequiredArgsConstructor
 @Validated
 public class CourseTimeInstructorController {

--- a/src/main/java/com/mzc/lp/domain/ts/exception/CannotDeleteMainInstructorException.java
+++ b/src/main/java/com/mzc/lp/domain/ts/exception/CannotDeleteMainInstructorException.java
@@ -1,0 +1,12 @@
+package com.mzc.lp.domain.ts.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class CannotDeleteMainInstructorException extends BusinessException {
+
+    public CannotDeleteMainInstructorException(Long assignmentId) {
+        super(ErrorCode.CANNOT_DELETE_MAIN_INSTRUCTOR,
+                String.format("Cannot delete main instructor (assignmentId=%d) while course is ongoing", assignmentId));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/exception/CourseTimeNotModifiableException.java
+++ b/src/main/java/com/mzc/lp/domain/ts/exception/CourseTimeNotModifiableException.java
@@ -1,0 +1,13 @@
+package com.mzc.lp.domain.ts.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+
+public class CourseTimeNotModifiableException extends BusinessException {
+
+    public CourseTimeNotModifiableException(Long courseTimeId, CourseTimeStatus status) {
+        super(ErrorCode.COURSE_TIME_NOT_MODIFIABLE,
+                String.format("CourseTime (id=%d) is not modifiable in %s status", courseTimeId, status));
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/ts/controller/CourseTimeControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/ts/controller/CourseTimeControllerTest.java
@@ -2,6 +2,7 @@ package com.mzc.lp.domain.ts.controller;
 import com.mzc.lp.common.support.TenantTestSupport;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.domain.iis.service.InstructorAssignmentService;
 import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
 import com.mzc.lp.domain.ts.constant.DeliveryType;
 import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
@@ -58,6 +60,9 @@ class CourseTimeControllerTest extends TenantTestSupport {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
+
+    @MockitoBean
+    private InstructorAssignmentService instructorAssignmentService;
 
     @BeforeEach
     void setUp() {
@@ -158,7 +163,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
     // ==================== 차수 생성 테스트 ====================
 
     @Nested
-    @DisplayName("POST /api/ts/course-times - 차수 생성")
+    @DisplayName("POST /api/times - 차수 생성")
     class CreateCourseTime {
 
         @Test
@@ -170,7 +175,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             CreateCourseTimeRequest request = createValidRequest();
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times")
+            mockMvc.perform(post("/api/times")
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -193,7 +198,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             CreateCourseTimeRequest request = createOfflineRequest();
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times")
+            mockMvc.perform(post("/api/times")
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -222,7 +227,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             );
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times")
+            mockMvc.perform(post("/api/times")
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -248,7 +253,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             );
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times")
+            mockMvc.perform(post("/api/times")
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -267,7 +272,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             CreateCourseTimeRequest request = createValidRequest();
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times")
+            mockMvc.perform(post("/api/times")
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -282,7 +287,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             CreateCourseTimeRequest request = createValidRequest();
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times")
+            mockMvc.perform(post("/api/times")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andDo(print())
@@ -293,7 +298,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
     // ==================== 차수 목록 조회 테스트 ====================
 
     @Nested
-    @DisplayName("GET /api/ts/course-times - 차수 목록 조회")
+    @DisplayName("GET /api/times - 차수 목록 조회")
     class GetCourseTimes {
 
         @Test
@@ -306,7 +311,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(get("/api/ts/course-times")
+            mockMvc.perform(get("/api/times")
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isOk())
@@ -327,7 +332,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(get("/api/ts/course-times")
+            mockMvc.perform(get("/api/times")
                             .header("Authorization", "Bearer " + accessToken)
                             .param("status", "RECRUITING"))
                     .andDo(print())
@@ -340,7 +345,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
     // ==================== 차수 상세 조회 테스트 ====================
 
     @Nested
-    @DisplayName("GET /api/ts/course-times/{id} - 차수 상세 조회")
+    @DisplayName("GET /api/times/{id} - 차수 상세 조회")
     class GetCourseTime {
 
         @Test
@@ -352,7 +357,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(get("/api/ts/course-times/{id}", courseTime.getId())
+            mockMvc.perform(get("/api/times/{id}", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isOk())
@@ -369,7 +374,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(get("/api/ts/course-times/{id}", 99999L)
+            mockMvc.perform(get("/api/times/{id}", 99999L)
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isNotFound())
@@ -381,7 +386,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
     // ==================== 차수 수정 테스트 ====================
 
     @Nested
-    @DisplayName("PATCH /api/ts/course-times/{id} - 차수 수정")
+    @DisplayName("PATCH /api/times/{id} - 차수 수정")
     class UpdateCourseTime {
 
         @Test
@@ -403,7 +408,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             );
 
             // when & then
-            mockMvc.perform(patch("/api/ts/course-times/{id}", courseTime.getId())
+            mockMvc.perform(patch("/api/times/{id}", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -431,7 +436,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             );
 
             // when & then
-            mockMvc.perform(patch("/api/ts/course-times/{id}", courseTime.getId())
+            mockMvc.perform(patch("/api/times/{id}", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -454,7 +459,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             );
 
             // when & then
-            mockMvc.perform(patch("/api/ts/course-times/{id}", courseTime.getId())
+            mockMvc.perform(patch("/api/times/{id}", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -466,7 +471,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
     // ==================== 차수 삭제 테스트 ====================
 
     @Nested
-    @DisplayName("DELETE /api/ts/course-times/{id} - 차수 삭제")
+    @DisplayName("DELETE /api/times/{id} - 차수 삭제")
     class DeleteCourseTime {
 
         @Test
@@ -478,13 +483,13 @@ class CourseTimeControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(delete("/api/ts/course-times/{id}", courseTime.getId())
+            mockMvc.perform(delete("/api/times/{id}", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isNoContent());
 
             // 삭제 확인
-            mockMvc.perform(get("/api/ts/course-times/{id}", courseTime.getId())
+            mockMvc.perform(get("/api/times/{id}", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken))
                     .andExpect(status().isNotFound());
         }
@@ -500,7 +505,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(delete("/api/ts/course-times/{id}", courseTime.getId())
+            mockMvc.perform(delete("/api/times/{id}", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isBadRequest())
@@ -512,7 +517,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
     // ==================== 상태 전이 테스트 ====================
 
     @Nested
-    @DisplayName("POST /api/ts/course-times/{id}/open - 모집 시작")
+    @DisplayName("POST /api/times/{id}/open - 모집 시작")
     class OpenCourseTime {
 
         @Test
@@ -524,7 +529,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times/{id}/open", courseTime.getId())
+            mockMvc.perform(post("/api/times/{id}/open", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isOk())
@@ -543,7 +548,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times/{id}/open", courseTime.getId())
+            mockMvc.perform(post("/api/times/{id}/open", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isBadRequest())
@@ -552,7 +557,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
     }
 
     @Nested
-    @DisplayName("POST /api/ts/course-times/{id}/start - 학습 시작")
+    @DisplayName("POST /api/times/{id}/start - 학습 시작")
     class StartCourseTime {
 
         @Test
@@ -566,7 +571,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times/{id}/start", courseTime.getId())
+            mockMvc.perform(post("/api/times/{id}/start", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isOk())
@@ -576,7 +581,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
     }
 
     @Nested
-    @DisplayName("POST /api/ts/course-times/{id}/close - 학습 종료")
+    @DisplayName("POST /api/times/{id}/close - 학습 종료")
     class CloseCourseTime {
 
         @Test
@@ -591,7 +596,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times/{id}/close", courseTime.getId())
+            mockMvc.perform(post("/api/times/{id}/close", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isOk())
@@ -601,7 +606,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
     }
 
     @Nested
-    @DisplayName("POST /api/ts/course-times/{id}/archive - 아카이브")
+    @DisplayName("POST /api/times/{id}/archive - 아카이브")
     class ArchiveCourseTime {
 
         @Test
@@ -617,7 +622,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times/{id}/archive", courseTime.getId())
+            mockMvc.perform(post("/api/times/{id}/archive", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isOk())
@@ -629,7 +634,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
     // ==================== Public API 테스트 ====================
 
     @Nested
-    @DisplayName("GET /api/ts/course-times/{id}/capacity - 정원 조회")
+    @DisplayName("GET /api/times/{id}/capacity - 정원 조회")
     class GetCapacity {
 
         @Test
@@ -641,7 +646,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(get("/api/ts/course-times/{id}/capacity", courseTime.getId())
+            mockMvc.perform(get("/api/times/{id}/capacity", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isOk())
@@ -679,7 +684,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(get("/api/ts/course-times/{id}/capacity", courseTime.getId())
+            mockMvc.perform(get("/api/times/{id}/capacity", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isOk())
@@ -697,7 +702,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(get("/api/ts/course-times/{id}/capacity", 99999L)
+            mockMvc.perform(get("/api/times/{id}/capacity", 99999L)
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isNotFound())
@@ -706,7 +711,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
     }
 
     @Nested
-    @DisplayName("GET /api/ts/course-times/{id}/price - 가격 조회")
+    @DisplayName("GET /api/times/{id}/price - 가격 조회")
     class GetPrice {
 
         @Test
@@ -718,7 +723,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(get("/api/ts/course-times/{id}/price", courseTime.getId())
+            mockMvc.perform(get("/api/times/{id}/price", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isOk())
@@ -754,7 +759,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(get("/api/ts/course-times/{id}/price", courseTime.getId())
+            mockMvc.perform(get("/api/times/{id}/price", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isOk())

--- a/src/test/java/com/mzc/lp/domain/ts/controller/CourseTimeInstructorControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/ts/controller/CourseTimeInstructorControllerTest.java
@@ -1,0 +1,563 @@
+package com.mzc.lp.domain.ts.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.constant.InstructorRole;
+import com.mzc.lp.domain.iis.dto.request.AssignInstructorRequest;
+import com.mzc.lp.domain.iis.dto.request.CancelAssignmentRequest;
+import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
+import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
+import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
+import com.mzc.lp.domain.iis.service.InstructorAssignmentService;
+import com.mzc.lp.domain.ts.constant.DeliveryType;
+import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CourseTimeInstructorControllerTest extends TenantTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CourseTimeRepository courseTimeRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private UserCourseRoleRepository userCourseRoleRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @MockitoBean
+    private InstructorAssignmentService instructorAssignmentService;
+
+    @BeforeEach
+    void setUp() {
+        courseTimeRepository.deleteAll();
+        userCourseRoleRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ========== Helper Methods ==========
+
+    private User createOperatorUser() {
+        User user = User.create("operator@example.com", "운영자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.OPERATOR);
+        return userRepository.save(user);
+    }
+
+    private User createNormalUser() {
+        User user = User.create("user@example.com", "일반사용자", passwordEncoder.encode("Password123!"));
+        return userRepository.save(user);
+    }
+
+    private String loginAndGetAccessToken(String email, String password) throws Exception {
+        LoginRequest request = new LoginRequest(email, password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("data").get("accessToken").asText();
+    }
+
+    private CourseTime createTestCourseTime() {
+        CourseTime courseTime = CourseTime.create(
+                "테스트 차수",
+                DeliveryType.ONLINE,
+                LocalDate.now(),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(30),
+                30,
+                5,
+                EnrollmentMethod.FIRST_COME,
+                80,
+                new BigDecimal("100000"),
+                false,
+                null,
+                true,
+                1L
+        );
+        return courseTimeRepository.save(courseTime);
+    }
+
+    private CourseTime createOngoingCourseTime() {
+        CourseTime courseTime = createTestCourseTime();
+        courseTime.open();
+        courseTime.startClass();
+        return courseTimeRepository.save(courseTime);
+    }
+
+    private CourseTime createClosedCourseTime() {
+        CourseTime courseTime = createOngoingCourseTime();
+        courseTime.close();
+        return courseTimeRepository.save(courseTime);
+    }
+
+    private InstructorAssignmentResponse createMockResponse(Long id, Long userId, Long timeId, InstructorRole role) {
+        return new InstructorAssignmentResponse(
+                id,
+                userId,
+                timeId,
+                role,
+                AssignmentStatus.ACTIVE,
+                Instant.now(),
+                null,
+                1L,
+                Instant.now()
+        );
+    }
+
+    // ==================== 강사 배정 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/ts/course-times/{timeId}/instructors - 강사 배정")
+    class AssignInstructor {
+
+        @Test
+        @DisplayName("성공 - DRAFT 상태 차수에 강사 배정")
+        void assignInstructor_success_draft() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createTestCourseTime();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            AssignInstructorRequest request = new AssignInstructorRequest(100L, InstructorRole.MAIN);
+            InstructorAssignmentResponse mockResponse = createMockResponse(1L, 100L, courseTime.getId(), InstructorRole.MAIN);
+
+            given(instructorAssignmentService.assignInstructor(eq(courseTime.getId()), any(), any()))
+                    .willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.id").value(1))
+                    .andExpect(jsonPath("$.data.userId").value(100))
+                    .andExpect(jsonPath("$.data.role").value("MAIN"));
+        }
+
+        @Test
+        @DisplayName("성공 - RECRUITING 상태 차수에 강사 배정")
+        void assignInstructor_success_recruiting() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createTestCourseTime();
+            courseTime.open();
+            courseTimeRepository.save(courseTime);
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            AssignInstructorRequest request = new AssignInstructorRequest(100L, InstructorRole.SUB);
+            InstructorAssignmentResponse mockResponse = createMockResponse(1L, 100L, courseTime.getId(), InstructorRole.SUB);
+
+            given(instructorAssignmentService.assignInstructor(eq(courseTime.getId()), any(), any()))
+                    .willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.role").value("SUB"));
+        }
+
+        @Test
+        @DisplayName("성공 - ONGOING 상태 차수에 강사 배정")
+        void assignInstructor_success_ongoing() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createOngoingCourseTime();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            AssignInstructorRequest request = new AssignInstructorRequest(100L, InstructorRole.ASSISTANT);
+            InstructorAssignmentResponse mockResponse = createMockResponse(1L, 100L, courseTime.getId(), InstructorRole.ASSISTANT);
+
+            given(instructorAssignmentService.assignInstructor(eq(courseTime.getId()), any(), any()))
+                    .willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true));
+        }
+
+        @Test
+        @DisplayName("실패 - CLOSED 상태 차수에 강사 배정")
+        void assignInstructor_fail_closed() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createClosedCourseTime();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            AssignInstructorRequest request = new AssignInstructorRequest(100L, InstructorRole.MAIN);
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("TS006"));
+        }
+
+        @Test
+        @DisplayName("실패 - ARCHIVED 상태 차수에 강사 배정")
+        void assignInstructor_fail_archived() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createClosedCourseTime();
+            courseTime.archive();
+            courseTimeRepository.save(courseTime);
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            AssignInstructorRequest request = new AssignInstructorRequest(100L, InstructorRole.MAIN);
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("TS006"));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 차수")
+        void assignInstructor_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            AssignInstructorRequest request = new AssignInstructorRequest(100L, InstructorRole.MAIN);
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors", 99999L)
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error.code").value("TS001"));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 강사 배정 시도")
+        void assignInstructor_fail_userRole() throws Exception {
+            // given
+            createNormalUser();
+            CourseTime courseTime = createTestCourseTime();
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            AssignInstructorRequest request = new AssignInstructorRequest(100L, InstructorRole.MAIN);
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 강사 목록 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/ts/course-times/{timeId}/instructors - 강사 목록 조회")
+    class GetInstructors {
+
+        @Test
+        @DisplayName("성공 - 전체 강사 목록 조회")
+        void getInstructors_success_all() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createTestCourseTime();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            List<InstructorAssignmentResponse> mockResponses = List.of(
+                    createMockResponse(1L, 100L, courseTime.getId(), InstructorRole.MAIN),
+                    createMockResponse(2L, 101L, courseTime.getId(), InstructorRole.SUB)
+            );
+
+            given(instructorAssignmentService.getInstructorsByTimeId(eq(courseTime.getId()), eq(null)))
+                    .willReturn(mockResponses);
+
+            // when & then
+            mockMvc.perform(get("/api/ts/course-times/{timeId}/instructors", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(2));
+        }
+
+        @Test
+        @DisplayName("성공 - ACTIVE 상태 강사만 조회")
+        void getInstructors_success_filterByStatus() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createTestCourseTime();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            List<InstructorAssignmentResponse> mockResponses = List.of(
+                    createMockResponse(1L, 100L, courseTime.getId(), InstructorRole.MAIN)
+            );
+
+            given(instructorAssignmentService.getInstructorsByTimeId(eq(courseTime.getId()), eq(AssignmentStatus.ACTIVE)))
+                    .willReturn(mockResponses);
+
+            // when & then
+            mockMvc.perform(get("/api/ts/course-times/{timeId}/instructors", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("status", "ACTIVE"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.length()").value(1));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 차수")
+        void getInstructors_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/ts/course-times/{timeId}/instructors", 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error.code").value("TS001"));
+        }
+    }
+
+    // ==================== 강사 역할 수정 테스트 ====================
+
+    @Nested
+    @DisplayName("PUT /api/ts/course-times/{timeId}/instructors/{assignmentId} - 역할 수정")
+    class UpdateRole {
+
+        @Test
+        @DisplayName("성공 - 역할 수정")
+        void updateRole_success() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createTestCourseTime();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            UpdateRoleRequest request = new UpdateRoleRequest(InstructorRole.SUB, "역할 변경 사유");
+            InstructorAssignmentResponse mockResponse = createMockResponse(1L, 100L, courseTime.getId(), InstructorRole.SUB);
+
+            given(instructorAssignmentService.updateRole(eq(1L), any(), any()))
+                    .willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(put("/api/ts/course-times/{timeId}/instructors/{assignmentId}", courseTime.getId(), 1L)
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.role").value("SUB"));
+        }
+
+        @Test
+        @DisplayName("실패 - CLOSED 상태 차수")
+        void updateRole_fail_closed() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createClosedCourseTime();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            UpdateRoleRequest request = new UpdateRoleRequest(InstructorRole.SUB, null);
+
+            // when & then
+            mockMvc.perform(put("/api/ts/course-times/{timeId}/instructors/{assignmentId}", courseTime.getId(), 1L)
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error.code").value("TS006"));
+        }
+    }
+
+    // ==================== 강사 교체 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/ts/course-times/{timeId}/instructors/{assignmentId}/replace - 강사 교체")
+    class ReplaceInstructor {
+
+        @Test
+        @DisplayName("성공 - 강사 교체")
+        void replaceInstructor_success() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createOngoingCourseTime();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            ReplaceInstructorRequest request = new ReplaceInstructorRequest(200L, InstructorRole.MAIN, "강사 교체 사유");
+            InstructorAssignmentResponse mockResponse = createMockResponse(2L, 200L, courseTime.getId(), InstructorRole.MAIN);
+
+            given(instructorAssignmentService.replaceInstructor(eq(1L), any(), any()))
+                    .willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors/{assignmentId}/replace", courseTime.getId(), 1L)
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.id").value(2))
+                    .andExpect(jsonPath("$.data.userId").value(200));
+        }
+
+        @Test
+        @DisplayName("실패 - CLOSED 상태 차수")
+        void replaceInstructor_fail_closed() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createClosedCourseTime();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            ReplaceInstructorRequest request = new ReplaceInstructorRequest(200L, InstructorRole.MAIN, null);
+
+            // when & then
+            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors/{assignmentId}/replace", courseTime.getId(), 1L)
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error.code").value("TS006"));
+        }
+    }
+
+    // ==================== 배정 취소 테스트 ====================
+
+    @Nested
+    @DisplayName("DELETE /api/ts/course-times/{timeId}/instructors/{assignmentId} - 배정 취소")
+    class CancelAssignment {
+
+        @Test
+        @DisplayName("성공 - 배정 취소")
+        void cancelAssignment_success() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createTestCourseTime();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            CancelAssignmentRequest request = new CancelAssignmentRequest("배정 취소 사유");
+
+            doNothing().when(instructorAssignmentService).cancelAssignment(eq(1L), any(), any());
+
+            // when & then
+            mockMvc.perform(delete("/api/ts/course-times/{timeId}/instructors/{assignmentId}", courseTime.getId(), 1L)
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("성공 - Request Body 없이 배정 취소")
+        void cancelAssignment_success_noBody() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createTestCourseTime();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            doNothing().when(instructorAssignmentService).cancelAssignment(eq(1L), any(), any());
+
+            // when & then
+            mockMvc.perform(delete("/api/ts/course-times/{timeId}/instructors/{assignmentId}", courseTime.getId(), 1L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("실패 - CLOSED 상태 차수")
+        void cancelAssignment_fail_closed() throws Exception {
+            // given
+            createOperatorUser();
+            CourseTime courseTime = createClosedCourseTime();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(delete("/api/ts/course-times/{timeId}/instructors/{assignmentId}", courseTime.getId(), 1L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error.code").value("TS006"));
+        }
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/ts/controller/CourseTimeInstructorControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/ts/controller/CourseTimeInstructorControllerTest.java
@@ -158,7 +158,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
     // ==================== 강사 배정 테스트 ====================
 
     @Nested
-    @DisplayName("POST /api/ts/course-times/{timeId}/instructors - 강사 배정")
+    @DisplayName("POST /api/times/{timeId}/instructors - 강사 배정")
     class AssignInstructor {
 
         @Test
@@ -176,7 +176,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
                     .willReturn(mockResponse);
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors", courseTime.getId())
+            mockMvc.perform(post("/api/times/{timeId}/instructors", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -205,7 +205,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
                     .willReturn(mockResponse);
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors", courseTime.getId())
+            mockMvc.perform(post("/api/times/{timeId}/instructors", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -230,7 +230,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
                     .willReturn(mockResponse);
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors", courseTime.getId())
+            mockMvc.perform(post("/api/times/{timeId}/instructors", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -250,7 +250,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             AssignInstructorRequest request = new AssignInstructorRequest(100L, InstructorRole.MAIN);
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors", courseTime.getId())
+            mockMvc.perform(post("/api/times/{timeId}/instructors", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -273,7 +273,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             AssignInstructorRequest request = new AssignInstructorRequest(100L, InstructorRole.MAIN);
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors", courseTime.getId())
+            mockMvc.perform(post("/api/times/{timeId}/instructors", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -293,7 +293,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             AssignInstructorRequest request = new AssignInstructorRequest(100L, InstructorRole.MAIN);
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors", 99999L)
+            mockMvc.perform(post("/api/times/{timeId}/instructors", 99999L)
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -313,7 +313,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             AssignInstructorRequest request = new AssignInstructorRequest(100L, InstructorRole.MAIN);
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors", courseTime.getId())
+            mockMvc.perform(post("/api/times/{timeId}/instructors", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -325,7 +325,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
     // ==================== 강사 목록 조회 테스트 ====================
 
     @Nested
-    @DisplayName("GET /api/ts/course-times/{timeId}/instructors - 강사 목록 조회")
+    @DisplayName("GET /api/times/{timeId}/instructors - 강사 목록 조회")
     class GetInstructors {
 
         @Test
@@ -345,7 +345,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
                     .willReturn(mockResponses);
 
             // when & then
-            mockMvc.perform(get("/api/ts/course-times/{timeId}/instructors", courseTime.getId())
+            mockMvc.perform(get("/api/times/{timeId}/instructors", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isOk())
@@ -370,7 +370,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
                     .willReturn(mockResponses);
 
             // when & then
-            mockMvc.perform(get("/api/ts/course-times/{timeId}/instructors", courseTime.getId())
+            mockMvc.perform(get("/api/times/{timeId}/instructors", courseTime.getId())
                             .header("Authorization", "Bearer " + accessToken)
                             .param("status", "ACTIVE"))
                     .andDo(print())
@@ -387,7 +387,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(get("/api/ts/course-times/{timeId}/instructors", 99999L)
+            mockMvc.perform(get("/api/times/{timeId}/instructors", 99999L)
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isNotFound())
@@ -398,7 +398,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
     // ==================== 강사 역할 수정 테스트 ====================
 
     @Nested
-    @DisplayName("PUT /api/ts/course-times/{timeId}/instructors/{assignmentId} - 역할 수정")
+    @DisplayName("PUT /api/times/{timeId}/instructors/{assignmentId} - 역할 수정")
     class UpdateRole {
 
         @Test
@@ -416,7 +416,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
                     .willReturn(mockResponse);
 
             // when & then
-            mockMvc.perform(put("/api/ts/course-times/{timeId}/instructors/{assignmentId}", courseTime.getId(), 1L)
+            mockMvc.perform(put("/api/times/{timeId}/instructors/{assignmentId}", courseTime.getId(), 1L)
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -437,7 +437,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             UpdateRoleRequest request = new UpdateRoleRequest(InstructorRole.SUB, null);
 
             // when & then
-            mockMvc.perform(put("/api/ts/course-times/{timeId}/instructors/{assignmentId}", courseTime.getId(), 1L)
+            mockMvc.perform(put("/api/times/{timeId}/instructors/{assignmentId}", courseTime.getId(), 1L)
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -450,7 +450,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
     // ==================== 강사 교체 테스트 ====================
 
     @Nested
-    @DisplayName("POST /api/ts/course-times/{timeId}/instructors/{assignmentId}/replace - 강사 교체")
+    @DisplayName("POST /api/times/{timeId}/instructors/{assignmentId}/replace - 강사 교체")
     class ReplaceInstructor {
 
         @Test
@@ -468,7 +468,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
                     .willReturn(mockResponse);
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors/{assignmentId}/replace", courseTime.getId(), 1L)
+            mockMvc.perform(post("/api/times/{timeId}/instructors/{assignmentId}/replace", courseTime.getId(), 1L)
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -490,7 +490,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             ReplaceInstructorRequest request = new ReplaceInstructorRequest(200L, InstructorRole.MAIN, null);
 
             // when & then
-            mockMvc.perform(post("/api/ts/course-times/{timeId}/instructors/{assignmentId}/replace", courseTime.getId(), 1L)
+            mockMvc.perform(post("/api/times/{timeId}/instructors/{assignmentId}/replace", courseTime.getId(), 1L)
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -503,7 +503,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
     // ==================== 배정 취소 테스트 ====================
 
     @Nested
-    @DisplayName("DELETE /api/ts/course-times/{timeId}/instructors/{assignmentId} - 배정 취소")
+    @DisplayName("DELETE /api/times/{timeId}/instructors/{assignmentId} - 배정 취소")
     class CancelAssignment {
 
         @Test
@@ -519,7 +519,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             doNothing().when(instructorAssignmentService).cancelAssignment(eq(1L), any(), any());
 
             // when & then
-            mockMvc.perform(delete("/api/ts/course-times/{timeId}/instructors/{assignmentId}", courseTime.getId(), 1L)
+            mockMvc.perform(delete("/api/times/{timeId}/instructors/{assignmentId}", courseTime.getId(), 1L)
                             .header("Authorization", "Bearer " + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -538,7 +538,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             doNothing().when(instructorAssignmentService).cancelAssignment(eq(1L), any(), any());
 
             // when & then
-            mockMvc.perform(delete("/api/ts/course-times/{timeId}/instructors/{assignmentId}", courseTime.getId(), 1L)
+            mockMvc.perform(delete("/api/times/{timeId}/instructors/{assignmentId}", courseTime.getId(), 1L)
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isNoContent());
@@ -553,7 +553,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
             // when & then
-            mockMvc.perform(delete("/api/ts/course-times/{timeId}/instructors/{assignmentId}", courseTime.getId(), 1L)
+            mockMvc.perform(delete("/api/times/{timeId}/instructors/{assignmentId}", courseTime.getId(), 1L)
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isBadRequest())


### PR DESCRIPTION
## Summary

TS 모듈에서 차수(CourseTime)별 강사 배정 관리 API를 구현하고, IIS 모듈과의 연동을 완료했습니다.
운영자가 차수에 강사를 배정/수정/교체/해제할 수 있는 관리자용 API를 제공합니다.

## Related Issue

- Closes #51

## Changes

### 1. TS 강사 배정 관리 API 구현 (Phase 1)
- `CourseTimeInstructorController` 신규 생성 (`/api/times/{timeId}/instructors`)
- `CourseTimeNotModifiableException` 예외 추가 (CLOSED/ARCHIVED 상태 수정 방지)
- 차수 상태 검증 후 IIS Service에 위임하는 아키텍처 적용

### 2. API 경로 컨벤션 통일
- `/api/ts/course-times` → `/api/times` 경로 변경
- Student API도 동일하게 `/api/times/{timeId}/students` 경로 사용

### 3. IIS 연동 및 통합 테스트 전환 (Phase 2)
- `CourseTimeInstructorControllerTest`에서 `@MockitoBean` 제거
- 실제 `InstructorAssignmentService` 사용하는 통합 테스트로 변경
- `InstructorAssignmentController`에서 중복 API 엔드포인트 제거
- DB 상태 검증 추가로 테스트 품질 향상

## API Endpoints

| Method | Endpoint | 설명 |
|--------|----------|------|
| POST | `/api/times/{timeId}/instructors` | 강사 배정 |
| GET | `/api/times/{timeId}/instructors` | 강사 목록 조회 |
| PUT | `/api/times/{timeId}/instructors/{id}` | 역할 수정 |
| POST | `/api/times/{timeId}/instructors/{id}/replace` | 강사 교체 |
| DELETE | `/api/times/{timeId}/instructors/{id}` | 배정 취소 |

## Type of Change

- [x] Feat: 새로운 기능
- [x] Refactor: 리팩토링
- [x] Test: 테스트 추가/수정

## Test Plan

### 단위 테스트 (./gradlew test)
- [x] CourseTimeInstructorControllerTest - 19개 테스트 통과
- [x] InstructorAssignmentControllerTest - 7개 테스트 통과
- [x] 전체 테스트 스위트 통과 (394 tests)

### API 통합 테스트 (실제 서버)
| API | 테스트 케이스 | 결과 |
|-----|-------------|------|
| `POST /api/times/{timeId}/instructors` | 강사 배정 성공 | ✅ 201 |
| `GET /api/times/{timeId}/instructors` | 강사 목록 조회 | ✅ 200 |
| `PUT /api/times/{timeId}/instructors/{id}` | 역할 수정 | ✅ 200 |
| `DELETE /api/times/{timeId}/instructors/{id}` | 배정 취소 | ✅ 204 |
| `POST /api/times/{timeId}/instructors` | CLOSED 상태 거부 | ✅ 400 (TS006) |
| `POST /api/times/{timeId}/instructors` | 중복 배정 거부 | ✅ 409 (IIS002) |
| `POST /api/times/{timeId}/instructors` | MAIN 강사 중복 거부 | ✅ 409 (IIS003) |

### DB 검증
- [x] `iis_instructor_assignments` 테이블 데이터 정상 저장/변경 확인
- [x] 상태 전환 (ACTIVE → CANCELLED, REPLACED) 정상 동작

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (dev-logs/backend/ts/phase5.md)

## Additional Notes

### 아키텍처 결정
- **TS Controller**: 차수 존재 및 상태 검증 담당
- **IIS Service**: 배정 비즈니스 로직 처리 (중복 검증, 이력 관리)
- **IIS Controller**: 배정 단건 API 및 사용자 기준 조회 API 제공

### 비즈니스 규칙
- CLOSED, ARCHIVED 상태 차수는 강사 정보 변경 불가
- 동일 차수에 동일 사용자 중복 배정 불가 
- 동일 차수에 MAIN 강사 중복 불가