### PR TITLE
Feat: JwtAuthenticationFilter에 CourseRole 권한 로드 추가

### DIFF
--- a/src/main/java/com/mzc/lp/common/security/UserPrincipal.java
+++ b/src/main/java/com/mzc/lp/common/security/UserPrincipal.java
@@ -1,7 +1,15 @@
 package com.mzc.lp.common.security;
 
+import java.util.Set;
+
 public record UserPrincipal(
         Long id,
         String email,
-        String role
-) {}
+        String role,
+        Set<String> courseRoles  // DESIGNER, OWNER, INSTRUCTOR
+) {
+    // 하위 호환성을 위한 생성자
+    public UserPrincipal(Long id, String email, String role) {
+        this(id, email, role, Set.of());
+    }
+}


### PR DESCRIPTION
## Summary
- JwtAuthenticationFilter에서 DB의 CourseRole(DESIGNER, OWNER, INSTRUCTOR) 조회 후 Spring Security authorities에 추가
- UserPrincipal에 courseRoles 필드 추가

## 변경 내용
- `UserPrincipal`: courseRoles 필드 추가 (하위 호환성 유지)
- `JwtAuthenticationFilter`: UserCourseRoleRepository 주입, DB 조회 후 권한 추가

## 해결된 문제
- `@PreAuthorize("hasRole('DESIGNER')")` 등의 권한 체크가 정상 동작
- 기존에는 JWT의 시스템 역할(USER, OPERATOR 등)만 로드되어 CourseRole 기반 API 접근 불가

## Test plan
- [x] UserControllerTest 통과
- [x] CourseControllerTest 통과
- [x] CourseItemControllerTest 통과
- [x] 전체 테스트 373/375 통과 (실패 2건은 기존 IIS 테스트 이슈)