### PR TITLE
feat: JWT tenantId 추출 및 수강 권한 체크 구현

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -66,6 +66,7 @@ public enum ErrorCode {
     CANNOT_CANCEL_COMPLETED(HttpStatus.BAD_REQUEST, "SIS003", "Cannot cancel completed enrollment"),
     ENROLLMENT_PERIOD_CLOSED(HttpStatus.BAD_REQUEST, "SIS004", "Enrollment period is closed"),
     INVALID_PROGRESS_VALUE(HttpStatus.BAD_REQUEST, "SIS005", "Progress value must be between 0 and 100"),
+    UNAUTHORIZED_ENROLLMENT_ACCESS(HttpStatus.FORBIDDEN, "SIS006", "Not authorized to access this enrollment"),
 
     // Auth
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "Unauthorized"),

--- a/src/main/java/com/mzc/lp/domain/student/controller/EnrollmentController.java
+++ b/src/main/java/com/mzc/lp/domain/student/controller/EnrollmentController.java
@@ -101,7 +101,8 @@ public class EnrollmentController {
             @Valid @RequestBody UpdateProgressRequest request,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        EnrollmentResponse response = enrollmentService.updateProgress(enrollmentId, request, principal.id());
+        boolean isAdmin = hasAdminRole(principal);
+        EnrollmentResponse response = enrollmentService.updateProgress(enrollmentId, request, principal.id(), isAdmin);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -140,7 +141,8 @@ public class EnrollmentController {
             @PathVariable Long enrollmentId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        enrollmentService.cancelEnrollment(enrollmentId, principal.id());
+        boolean isAdmin = hasAdminRole(principal);
+        enrollmentService.cancelEnrollment(enrollmentId, principal.id(), isAdmin);
         return ResponseEntity.noContent().build();
     }
 
@@ -198,5 +200,15 @@ public class EnrollmentController {
     ) {
         UserEnrollmentStatsResponse response = enrollmentStatsService.getUserStats(userId);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // ========== Helper Methods ==========
+
+    /**
+     * 관리자 역할 여부 확인 (OPERATOR, TENANT_ADMIN)
+     */
+    private boolean hasAdminRole(UserPrincipal principal) {
+        String role = principal.role();
+        return "OPERATOR".equals(role) || "TENANT_ADMIN".equals(role);
     }
 }

--- a/src/main/java/com/mzc/lp/domain/student/exception/UnauthorizedEnrollmentAccessException.java
+++ b/src/main/java/com/mzc/lp/domain/student/exception/UnauthorizedEnrollmentAccessException.java
@@ -1,0 +1,16 @@
+package com.mzc.lp.domain.student.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class UnauthorizedEnrollmentAccessException extends BusinessException {
+
+    public UnauthorizedEnrollmentAccessException() {
+        super(ErrorCode.UNAUTHORIZED_ENROLLMENT_ACCESS);
+    }
+
+    public UnauthorizedEnrollmentAccessException(Long enrollmentId, Long userId) {
+        super(ErrorCode.UNAUTHORIZED_ENROLLMENT_ACCESS,
+                "User " + userId + " is not authorized to access enrollment " + enrollmentId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/student/service/EnrollmentService.java
+++ b/src/main/java/com/mzc/lp/domain/student/service/EnrollmentService.java
@@ -32,7 +32,7 @@ public interface EnrollmentService {
     Page<EnrollmentResponse> getEnrollmentsByUser(Long userId, EnrollmentStatus status, Pageable pageable);
 
     // 진도율 업데이트
-    EnrollmentResponse updateProgress(Long enrollmentId, UpdateProgressRequest request, Long userId);
+    EnrollmentResponse updateProgress(Long enrollmentId, UpdateProgressRequest request, Long userId, boolean isAdmin);
 
     // 수료 처리
     EnrollmentDetailResponse completeEnrollment(Long enrollmentId, CompleteEnrollmentRequest request);
@@ -41,5 +41,5 @@ public interface EnrollmentService {
     EnrollmentDetailResponse updateStatus(Long enrollmentId, UpdateEnrollmentStatusRequest request);
 
     // 수강 취소
-    void cancelEnrollment(Long enrollmentId, Long userId);
+    void cancelEnrollment(Long enrollmentId, Long userId, boolean isAdmin);
 }

--- a/src/main/java/com/mzc/lp/domain/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/AuthServiceImpl.java
@@ -77,11 +77,12 @@ public class AuthServiceImpl implements AuthService {
             throw new InvalidCredentialsException();
         }
 
-        // 토큰 생성
+        // 토큰 생성 (tenantId 포함)
         String accessToken = jwtProvider.createAccessToken(
                 user.getId(),
                 user.getEmail(),
-                user.getRole().name()
+                user.getRole().name(),
+                user.getTenantId()
         );
         String refreshToken = jwtProvider.createRefreshToken(user.getId());
 
@@ -122,11 +123,12 @@ public class AuthServiceImpl implements AuthService {
         // 기존 Refresh Token 무효화
         storedToken.revoke();
 
-        // 새 토큰 생성
+        // 새 토큰 생성 (tenantId 포함)
         String newAccessToken = jwtProvider.createAccessToken(
                 user.getId(),
                 user.getEmail(),
-                user.getRole().name()
+                user.getRole().name(),
+                user.getTenantId()
         );
         String newRefreshToken = jwtProvider.createRefreshToken(user.getId());
 

--- a/src/test/java/com/mzc/lp/domain/student/controller/EnrollmentControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/student/controller/EnrollmentControllerTest.java
@@ -1,0 +1,532 @@
+package com.mzc.lp.domain.student.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.student.dto.request.ForceEnrollRequest;
+import com.mzc.lp.domain.student.dto.request.UpdateProgressRequest;
+import com.mzc.lp.domain.student.entity.Enrollment;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.ts.constant.DeliveryType;
+import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class EnrollmentControllerTest extends TenantTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private EnrollmentRepository enrollmentRepository;
+
+    @Autowired
+    private CourseTimeRepository courseTimeRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        enrollmentRepository.deleteAll();
+        courseTimeRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ========== Helper Methods ==========
+
+    private User createOperatorUser() {
+        User user = User.create("operator@example.com", "운영자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.OPERATOR);
+        return userRepository.save(user);
+    }
+
+    private User createNormalUser() {
+        User user = User.create("user@example.com", "일반사용자", passwordEncoder.encode("Password123!"));
+        return userRepository.save(user);
+    }
+
+    private User createNormalUser(String email, String name) {
+        User user = User.create(email, name, passwordEncoder.encode("Password123!"));
+        return userRepository.save(user);
+    }
+
+    private String loginAndGetAccessToken(String email, String password) throws Exception {
+        LoginRequest request = new LoginRequest(email, password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("data").get("accessToken").asText();
+    }
+
+    private CourseTime createRecruitingCourseTime() {
+        CourseTime courseTime = CourseTime.create(
+                "테스트 차수",
+                DeliveryType.ONLINE,
+                LocalDate.now().minusDays(1),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(30),
+                30,
+                5,
+                EnrollmentMethod.FIRST_COME,
+                80,
+                new BigDecimal("100000"),
+                false,
+                null,
+                true,
+                1L
+        );
+        courseTime.open();
+        return courseTimeRepository.save(courseTime);
+    }
+
+    private CourseTime createDraftCourseTime() {
+        CourseTime courseTime = CourseTime.create(
+                "Draft 차수",
+                DeliveryType.ONLINE,
+                LocalDate.now(),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(30),
+                30,
+                5,
+                EnrollmentMethod.FIRST_COME,
+                80,
+                new BigDecimal("100000"),
+                false,
+                null,
+                true,
+                1L
+        );
+        return courseTimeRepository.save(courseTime);
+    }
+
+    private Enrollment createEnrollment(Long userId, Long courseTimeId) {
+        Enrollment enrollment = Enrollment.createVoluntary(userId, courseTimeId);
+        return enrollmentRepository.save(enrollment);
+    }
+
+    // ==================== 수강 신청 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/times/{courseTimeId}/enrollments - 수강 신청")
+    class Enroll {
+
+        @Test
+        @DisplayName("성공 - 인증된 사용자가 수강 신청")
+        void enroll_success() throws Exception {
+            // given
+            User user = createNormalUser();
+            CourseTime courseTime = createRecruitingCourseTime();
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(post("/api/times/{courseTimeId}/enrollments", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.userId").value(user.getId()))
+                    .andExpect(jsonPath("$.data.courseTimeId").value(courseTime.getId()))
+                    .andExpect(jsonPath("$.data.status").value("ENROLLED"));
+        }
+
+        @Test
+        @DisplayName("실패 - 중복 수강 신청")
+        void enroll_fail_alreadyEnrolled() throws Exception {
+            // given
+            User user = createNormalUser();
+            CourseTime courseTime = createRecruitingCourseTime();
+            createEnrollment(user.getId(), courseTime.getId());
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(post("/api/times/{courseTimeId}/enrollments", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("SIS002"));
+        }
+
+        @Test
+        @DisplayName("실패 - 모집 기간이 아닌 차수")
+        void enroll_fail_notRecruiting() throws Exception {
+            // given
+            createNormalUser();
+            CourseTime courseTime = createDraftCourseTime();
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(post("/api/times/{courseTimeId}/enrollments", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("SIS004"));
+        }
+
+        @Test
+        @DisplayName("실패 - 인증 없이 접근")
+        void enroll_fail_unauthorized() throws Exception {
+            // given
+            CourseTime courseTime = createRecruitingCourseTime();
+
+            // when & then
+            mockMvc.perform(post("/api/times/{courseTimeId}/enrollments", courseTime.getId()))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 내 수강 목록 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/users/me/enrollments - 내 수강 목록 조회")
+    class GetMyEnrollments {
+
+        @Test
+        @DisplayName("성공 - 내 수강 목록 조회")
+        void getMyEnrollments_success() throws Exception {
+            // given
+            User user = createNormalUser();
+            CourseTime courseTime1 = createRecruitingCourseTime();
+            CourseTime courseTime2 = createRecruitingCourseTime();
+            createEnrollment(user.getId(), courseTime1.getId());
+            createEnrollment(user.getId(), courseTime2.getId());
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/users/me/enrollments")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.totalElements").value(2));
+        }
+
+        @Test
+        @DisplayName("성공 - 상태 필터링 (ENROLLED)")
+        void getMyEnrollments_success_filterByStatus() throws Exception {
+            // given
+            User user = createNormalUser();
+            CourseTime courseTime1 = createRecruitingCourseTime();
+            CourseTime courseTime2 = createRecruitingCourseTime();
+            Enrollment enrollment1 = createEnrollment(user.getId(), courseTime1.getId());
+            Enrollment enrollment2 = createEnrollment(user.getId(), courseTime2.getId());
+            enrollment2.complete(90);
+            enrollmentRepository.save(enrollment2);
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/users/me/enrollments")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("status", "ENROLLED"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.totalElements").value(1));
+        }
+
+        @Test
+        @DisplayName("성공 - 수강 내역 없음")
+        void getMyEnrollments_success_empty() throws Exception {
+            // given
+            createNormalUser();
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/users/me/enrollments")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.totalElements").value(0));
+        }
+
+        @Test
+        @DisplayName("성공 - 페이징")
+        void getMyEnrollments_success_paging() throws Exception {
+            // given
+            User user = createNormalUser();
+            for (int i = 0; i < 5; i++) {
+                CourseTime courseTime = createRecruitingCourseTime();
+                createEnrollment(user.getId(), courseTime.getId());
+            }
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/users/me/enrollments")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("page", "0")
+                            .param("size", "2"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.content.length()").value(2))
+                    .andExpect(jsonPath("$.data.totalElements").value(5))
+                    .andExpect(jsonPath("$.data.totalPages").value(3));
+        }
+
+        @Test
+        @DisplayName("실패 - 인증 없이 접근")
+        void getMyEnrollments_fail_unauthorized() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/users/me/enrollments"))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 사용자별 수강 이력 조회 테스트 (관리자) ====================
+
+    @Nested
+    @DisplayName("GET /api/users/{userId}/enrollments - 사용자별 수강 이력 조회")
+    class GetEnrollmentsByUser {
+
+        @Test
+        @DisplayName("성공 - OPERATOR가 사용자 수강 이력 조회")
+        void getEnrollmentsByUser_success() throws Exception {
+            // given
+            createOperatorUser();
+            User targetUser = createNormalUser("target@example.com", "대상사용자");
+            CourseTime courseTime = createRecruitingCourseTime();
+            createEnrollment(targetUser.getId(), courseTime.getId());
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/users/{userId}/enrollments", targetUser.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.totalElements").value(1));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 타인 수강 이력 조회")
+        void getEnrollmentsByUser_fail_userRole() throws Exception {
+            // given
+            createNormalUser();
+            User targetUser = createNormalUser("target@example.com", "대상사용자");
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/users/{userId}/enrollments", targetUser.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 수강 상세 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/enrollments/{enrollmentId} - 수강 상세 조회")
+    class GetEnrollment {
+
+        @Test
+        @DisplayName("성공 - 본인 수강 상세 조회")
+        void getEnrollment_success() throws Exception {
+            // given
+            User user = createNormalUser();
+            CourseTime courseTime = createRecruitingCourseTime();
+            Enrollment enrollment = createEnrollment(user.getId(), courseTime.getId());
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/enrollments/{enrollmentId}", enrollment.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.id").value(enrollment.getId()))
+                    .andExpect(jsonPath("$.data.userId").value(user.getId()))
+                    .andExpect(jsonPath("$.data.status").value("ENROLLED"));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 수강")
+        void getEnrollment_fail_notFound() throws Exception {
+            // given
+            createNormalUser();
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/enrollments/{enrollmentId}", 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("SIS001"));
+        }
+    }
+
+    // ==================== 진도율 업데이트 테스트 ====================
+
+    @Nested
+    @DisplayName("PATCH /api/enrollments/{enrollmentId}/progress - 진도율 업데이트")
+    class UpdateProgress {
+
+        @Test
+        @DisplayName("성공 - 진도율 업데이트")
+        void updateProgress_success() throws Exception {
+            // given
+            User user = createNormalUser();
+            CourseTime courseTime = createRecruitingCourseTime();
+            Enrollment enrollment = createEnrollment(user.getId(), courseTime.getId());
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+            UpdateProgressRequest request = new UpdateProgressRequest(50);
+
+            // when & then
+            mockMvc.perform(patch("/api/enrollments/{enrollmentId}/progress", enrollment.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.progressPercent").value(50));
+        }
+    }
+
+    // ==================== 강제 배정 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/times/{courseTimeId}/enrollments/force - 강제 배정")
+    class ForceEnroll {
+
+        @Test
+        @DisplayName("성공 - OPERATOR가 강제 배정")
+        void forceEnroll_success() throws Exception {
+            // given
+            createOperatorUser();
+            User user1 = createNormalUser("user1@example.com", "사용자1");
+            User user2 = createNormalUser("user2@example.com", "사용자2");
+            CourseTime courseTime = createRecruitingCourseTime();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            ForceEnrollRequest request = new ForceEnrollRequest(
+                    List.of(user1.getId(), user2.getId()),
+                    "필수 교육"
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/times/{courseTimeId}/enrollments/force", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.successCount").value(2))
+                    .andExpect(jsonPath("$.data.failCount").value(0));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 강제 배정")
+        void forceEnroll_fail_userRole() throws Exception {
+            // given
+            createNormalUser();
+            User targetUser = createNormalUser("target@example.com", "대상사용자");
+            CourseTime courseTime = createRecruitingCourseTime();
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+            ForceEnrollRequest request = new ForceEnrollRequest(
+                    List.of(targetUser.getId()),
+                    "강제 배정 시도"
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/times/{courseTimeId}/enrollments/force", courseTime.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 수강 취소 테스트 ====================
+
+    @Nested
+    @DisplayName("DELETE /api/enrollments/{enrollmentId} - 수강 취소")
+    class CancelEnrollment {
+
+        @Test
+        @DisplayName("성공 - 수강 취소")
+        void cancelEnrollment_success() throws Exception {
+            // given
+            User user = createNormalUser();
+            CourseTime courseTime = createRecruitingCourseTime();
+            Enrollment enrollment = createEnrollment(user.getId(), courseTime.getId());
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(delete("/api/enrollments/{enrollmentId}", enrollment.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("실패 - 수료 상태에서 취소")
+        void cancelEnrollment_fail_completed() throws Exception {
+            // given
+            User user = createNormalUser();
+            CourseTime courseTime = createRecruitingCourseTime();
+            Enrollment enrollment = createEnrollment(user.getId(), courseTime.getId());
+            enrollment.complete(90);
+            enrollmentRepository.save(enrollment);
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(delete("/api/enrollments/{enrollmentId}", enrollment.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("SIS003"));
+        }
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/student/service/EnrollmentServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/student/service/EnrollmentServiceTest.java
@@ -265,8 +265,8 @@ class EnrollmentServiceTest extends TenantTestSupport {
             given(enrollmentRepository.findByIdAndTenantId(enrollmentId, TENANT_ID))
                     .willReturn(Optional.of(enrollment));
 
-            // when
-            EnrollmentResponse response = enrollmentService.updateProgress(enrollmentId, request, userId);
+            // when (본인의 수강이므로 isAdmin=false)
+            EnrollmentResponse response = enrollmentService.updateProgress(enrollmentId, request, userId, false);
 
             // then
             assertThat(response.progressPercent()).isEqualTo(50);
@@ -283,7 +283,7 @@ class EnrollmentServiceTest extends TenantTestSupport {
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> enrollmentService.updateProgress(enrollmentId, request, 1L))
+            assertThatThrownBy(() -> enrollmentService.updateProgress(enrollmentId, request, 1L, false))
                     .isInstanceOf(EnrollmentNotFoundException.class);
         }
     }
@@ -334,8 +334,8 @@ class EnrollmentServiceTest extends TenantTestSupport {
             given(enrollmentRepository.findByIdAndTenantId(enrollmentId, TENANT_ID))
                     .willReturn(Optional.of(enrollment));
 
-            // when
-            enrollmentService.cancelEnrollment(enrollmentId, userId);
+            // when (본인의 수강 취소이므로 isAdmin=false)
+            enrollmentService.cancelEnrollment(enrollmentId, userId, false);
 
             // then
             assertThat(enrollment.isDropped()).isTrue();
@@ -354,7 +354,7 @@ class EnrollmentServiceTest extends TenantTestSupport {
                     .willReturn(Optional.of(enrollment));
 
             // when & then
-            assertThatThrownBy(() -> enrollmentService.cancelEnrollment(enrollmentId, userId))
+            assertThatThrownBy(() -> enrollmentService.cancelEnrollment(enrollmentId, userId, false))
                     .isInstanceOf(CannotCancelCompletedException.class);
 
             verify(courseTimeService, never()).releaseSeat(any());


### PR DESCRIPTION
## Summary
- JWT 토큰에서 tenantId를 추출하여 TenantContext에 설정하는 로직 구현
- 수강(Enrollment) 진도율 업데이트 및 취소 시 본인/관리자 권한 검증 추가
- 권한 없는 접근에 대한 예외 처리 추가 (SIS006)

## Changes

### 1. JWT tenantId 추출 (TenantFilter)
- `TenantFilter`에 `JwtProvider` 주입
- Authorization 헤더에서 JWT 토큰 파싱 후 tenantId 클레임 추출
- 추출된 tenantId를 `TenantContext`에 설정

### 2. AuthService 토큰 생성 수정
- `login()`, `refresh()` 시 JWT 토큰에 tenantId 포함

### 3. 수강 권한 체크 구현
- `updateProgress()`: 본인 또는 관리자만 진도율 수정 가능
- `cancelEnrollment()`: 본인 또는 관리자만 수강 취소 가능
- `UnauthorizedEnrollmentAccessException` 예외 클래스 추가
- `ErrorCode.SIS006` 추가

### 4. Controller 수정
- `hasAdminRole()` 헬퍼 메서드 추가 (OPERATOR, TENANT_ADMIN 체크)

## Files Changed
| File | Description |
|------|-------------|
| `TenantFilter.java` | JWT에서 tenantId 추출 로직 구현 |
| `AuthServiceImpl.java` | 토큰 생성 시 tenantId 포함 |
| `EnrollmentService.java` | isAdmin 파라미터 추가 |
| `EnrollmentServiceImpl.java` | 권한 체크 로직 구현 |
| `EnrollmentController.java` | hasAdminRole() 헬퍼 추가 |
| `ErrorCode.java` | SIS006 에러코드 추가 |
| `UnauthorizedEnrollmentAccessException.java` | 새 예외 클래스 |
| `EnrollmentServiceTest.java` | 테스트 코드 업데이트 |

## Test Plan
- [x] 로그인 후 JWT 토큰에 tenantId 클레임 포함 확인
- [x] 본인 수강 진도율 업데이트 성공
- [x] 타인 수강 진도율 업데이트 시 403 Forbidden
- [x] 관리자(OPERATOR/TENANT_ADMIN)의 타인 수강 진도율 업데이트 성공
- [x] 본인 수강 취소 성공
- [x] 타인 수강 취소 시 403 Forbidden
- [x] 관리자의 타인 수강 취소 성공
- [x] `EnrollmentServiceTest` 전체 통과