### PR TITLE
[Fix] Content 생성 시 createdBy 필드 설정 추가 (#88)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/content/controller/ContentController.java
+++ b/src/main/java/com/mzc/lp/domain/content/controller/ContentController.java
@@ -45,7 +45,8 @@ public class ContentController {
             @AuthenticationPrincipal UserPrincipal principal
     ) {
         Long tenantId = TenantContext.getCurrentTenantId();
-        ContentResponse response = contentService.uploadFile(file, folderId, tenantId);
+        Long userId = principal.id();
+        ContentResponse response = contentService.uploadFile(file, folderId, tenantId, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 
@@ -56,7 +57,8 @@ public class ContentController {
             @AuthenticationPrincipal UserPrincipal principal
     ) {
         Long tenantId = TenantContext.getCurrentTenantId();
-        ContentResponse response = contentService.createExternalLink(request, tenantId);
+        Long userId = principal.id();
+        ContentResponse response = contentService.createExternalLink(request, tenantId, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/mzc/lp/domain/content/service/ContentService.java
+++ b/src/main/java/com/mzc/lp/domain/content/service/ContentService.java
@@ -16,12 +16,12 @@ public interface ContentService {
     /**
      * 파일 업로드 및 Content 생성
      */
-    ContentResponse uploadFile(MultipartFile file, Long folderId, Long tenantId);
+    ContentResponse uploadFile(MultipartFile file, Long folderId, Long tenantId, Long userId);
 
     /**
      * 외부 링크 등록
      */
-    ContentResponse createExternalLink(CreateExternalLinkRequest request, Long tenantId);
+    ContentResponse createExternalLink(CreateExternalLinkRequest request, Long tenantId, Long userId);
 
     /**
      * 콘텐츠 목록 조회

--- a/src/main/java/com/mzc/lp/domain/content/service/ContentServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/content/service/ContentServiceImpl.java
@@ -56,7 +56,7 @@ public class ContentServiceImpl implements ContentService {
 
     @Override
     @Transactional
-    public ContentResponse uploadFile(MultipartFile file, Long folderId, Long tenantId) {
+    public ContentResponse uploadFile(MultipartFile file, Long folderId, Long tenantId, Long userId) {
         String originalFileName = StringUtils.cleanPath(file.getOriginalFilename());
         String extension = fileStorageService.getFileExtension(originalFileName);
 
@@ -73,7 +73,8 @@ public class ContentServiceImpl implements ContentService {
                 storedFileName,
                 contentType,
                 file.getSize(),
-                filePath
+                filePath,
+                userId
         );
 
         // 썸네일 자동 생성
@@ -89,11 +90,11 @@ public class ContentServiceImpl implements ContentService {
 
     @Override
     @Transactional
-    public ContentResponse createExternalLink(CreateExternalLinkRequest request, Long tenantId) {
+    public ContentResponse createExternalLink(CreateExternalLinkRequest request, Long tenantId, Long userId) {
         String url = request.url();
         validateExternalUrl(url);
 
-        Content content = Content.createExternalLink(request.name(), url);
+        Content content = Content.createExternalLink(request.name(), url, userId);
         Content savedContent = contentRepository.save(content);
 
         log.info("External link created: id={}, name={}, url={}",


### PR DESCRIPTION
## Summary

콘텐츠 업로드 및 외부 링크 생성 시 `createdBy`가 `null`로 저장되던 버그 수정

## Related Issue

- Closes #88

## Changes

- `ContentController`: `principal`에서 `userId` 추출하여 서비스로 전달
- `ContentService`: `uploadFile`, `createExternalLink` 메서드에 `userId` 파라미터 추가
- `ContentServiceImpl`: `Content` 팩토리 메서드 호출 시 `userId` 전달

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

이 수정으로 DESIGNER의 archive/restore 기능이 정상 동작함
(본인 소유 콘텐츠 검증에 `createdBy` 필드 사용)