### PR TITLE
refactor: CourseTimeInstructorController에서 Repository 직접 참조 제거

### DIFF
--- a/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeInstructorController.java
+++ b/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeInstructorController.java
@@ -1,6 +1,5 @@
 package com.mzc.lp.domain.ts.controller;
 
-import com.mzc.lp.common.context.TenantContext;
 import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.common.security.UserPrincipal;
 import com.mzc.lp.domain.iis.constant.AssignmentStatus;
@@ -11,9 +10,8 @@ import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
 import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
 import com.mzc.lp.domain.iis.service.InstructorAssignmentService;
 import com.mzc.lp.domain.ts.entity.CourseTime;
-import com.mzc.lp.domain.ts.exception.CourseTimeNotFoundException;
 import com.mzc.lp.domain.ts.exception.CourseTimeNotModifiableException;
-import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import com.mzc.lp.domain.ts.service.CourseTimeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +31,7 @@ import java.util.List;
 @Validated
 public class CourseTimeInstructorController {
 
-    private final CourseTimeRepository courseTimeRepository;
+    private final CourseTimeService courseTimeService;
     private final InstructorAssignmentService instructorAssignmentService;
 
     @PostMapping
@@ -138,8 +136,7 @@ public class CourseTimeInstructorController {
     // ========== Private Methods ==========
 
     private CourseTime getCourseTimeOrThrow(Long timeId) {
-        return courseTimeRepository.findByIdAndTenantId(timeId, TenantContext.getCurrentTenantId())
-                .orElseThrow(() -> new CourseTimeNotFoundException(timeId));
+        return courseTimeService.getCourseTimeEntity(timeId);
     }
 
     private void validateModifiable(CourseTime courseTime) {

--- a/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeService.java
+++ b/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeService.java
@@ -7,10 +7,14 @@ import com.mzc.lp.domain.ts.dto.response.CapacityResponse;
 import com.mzc.lp.domain.ts.dto.response.CourseTimeDetailResponse;
 import com.mzc.lp.domain.ts.dto.response.CourseTimeResponse;
 import com.mzc.lp.domain.ts.dto.response.PriceResponse;
+import com.mzc.lp.domain.ts.entity.CourseTime;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CourseTimeService {
+
+    // Entity 조회 (다른 Controller에서 상태 검증용)
+    CourseTime getCourseTimeEntity(Long id);
 
     // CRUD
     CourseTimeDetailResponse createCourseTime(CreateCourseTimeRequest request, Long createdBy);

--- a/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeServiceImpl.java
@@ -34,6 +34,12 @@ public class CourseTimeServiceImpl implements CourseTimeService {
     private final CourseTimeRepository courseTimeRepository;
 
     @Override
+    public CourseTime getCourseTimeEntity(Long id) {
+        return courseTimeRepository.findByIdAndTenantId(id, TenantContext.getCurrentTenantId())
+                .orElseThrow(() -> new CourseTimeNotFoundException(id));
+    }
+
+    @Override
     @Transactional
     public CourseTimeDetailResponse createCourseTime(CreateCourseTimeRequest request, Long createdBy) {
         log.info("Creating course time: title={}", request.title());


### PR DESCRIPTION
## Summary

Controller에서 Repository를 직접 참조하던 컨벤션 위반을 수정하여 레이어 분리 원칙을 준수하도록 개선했습니다.

## Related Issue

- N/A (컨벤션 준수 리팩토링)

## Changes

- `CourseTimeInstructorController`에서 `CourseTimeRepository` 직접 참조 제거
- `CourseTimeService`에 `getCourseTimeEntity(Long id)` 메서드 추가
- Controller → Service → Repository 레이어 분리 원칙 준수

## Type of Change

- [x] Refactor: 리팩토링

## Test Plan

### 단위 테스트 (./gradlew test)
- [x] CourseTimeInstructorControllerTest - 전체 테스트 통과
- [x] 전체 테스트 통과

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### 변경 전
```java
// Controller에서 Repository 직접 참조 (컨벤션 위반)
private final CourseTimeRepository courseTimeRepository;

private CourseTime getCourseTimeOrThrow(Long timeId) {
    return courseTimeRepository.findByIdAndTenantId(timeId, TenantContext.getCurrentTenantId())
            .orElseThrow(() -> new CourseTimeNotFoundException(timeId));
}
변경 후
// Controller에서 Service 참조 (컨벤션 준수)
private final CourseTimeService courseTimeService;

private CourseTime getCourseTimeOrThrow(Long timeId) {
    return courseTimeService.getCourseTimeEntity(timeId);
}