### PR TITLE
feat : 배정 이력 조회 API 구현 (#92)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,4 +55,5 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    environment 'JWT_SECRET', 'mzc-lp-test-jwt-secret-key-that-is-at-least-256-bits-long-for-hmac-sha256'
 }

--- a/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
+++ b/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
@@ -2,10 +2,12 @@ package com.mzc.lp.domain.iis.controller;
 
 import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.iis.constant.AssignmentAction;
 import com.mzc.lp.domain.iis.constant.AssignmentStatus;
 import com.mzc.lp.domain.iis.dto.request.CancelAssignmentRequest;
 import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
 import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
+import com.mzc.lp.domain.iis.dto.response.AssignmentHistoryResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
 import com.mzc.lp.domain.iis.service.InstructorAssignmentService;
 import jakarta.validation.Valid;
@@ -73,6 +75,17 @@ public class InstructorAssignmentController {
                 request != null ? request : new CancelAssignmentRequest(null),
                 principal.id());
         return ResponseEntity.noContent().build();
+    }
+
+    // ========== 이력 조회 API ==========
+
+    @GetMapping("/api/instructor-assignments/{id}/histories")
+    public ResponseEntity<ApiResponse<List<AssignmentHistoryResponse>>> getAssignmentHistories(
+            @PathVariable Long id,
+            @RequestParam(required = false) AssignmentAction action
+    ) {
+        List<AssignmentHistoryResponse> response = assignmentService.getAssignmentHistories(id, action);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // ========== 사용자 기준 API ==========

--- a/src/main/java/com/mzc/lp/domain/iis/repository/AssignmentHistoryRepository.java
+++ b/src/main/java/com/mzc/lp/domain/iis/repository/AssignmentHistoryRepository.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.iis.repository;
 
+import com.mzc.lp.domain.iis.constant.AssignmentAction;
 import com.mzc.lp.domain.iis.entity.AssignmentHistory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,6 +11,8 @@ import java.util.List;
 public interface AssignmentHistoryRepository extends JpaRepository<AssignmentHistory, Long> {
 
     List<AssignmentHistory> findByAssignmentIdOrderByChangedAtDesc(Long assignmentId);
+
+    List<AssignmentHistory> findByAssignmentIdAndActionOrderByChangedAtDesc(Long assignmentId, AssignmentAction action);
 
     Page<AssignmentHistory> findByAssignmentId(Long assignmentId, Pageable pageable);
 }

--- a/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentService.java
+++ b/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentService.java
@@ -1,10 +1,12 @@
 package com.mzc.lp.domain.iis.service;
 
+import com.mzc.lp.domain.iis.constant.AssignmentAction;
 import com.mzc.lp.domain.iis.constant.AssignmentStatus;
 import com.mzc.lp.domain.iis.dto.request.AssignInstructorRequest;
 import com.mzc.lp.domain.iis.dto.request.CancelAssignmentRequest;
 import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
 import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
+import com.mzc.lp.domain.iis.dto.response.AssignmentHistoryResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -47,4 +49,14 @@ public interface InstructorAssignmentService {
      * 반환: Key=timeId, Value=강사목록
      */
     Map<Long, List<InstructorAssignmentResponse>> getInstructorsByTimeIds(List<Long> timeIds);
+
+    // ========== 이력 조회 ==========
+
+    /**
+     * 특정 배정의 변경 이력 조회
+     * @param assignmentId 배정 ID
+     * @param action 액션 타입 필터 (null이면 전체 조회)
+     * @return 이력 목록 (최신순 정렬)
+     */
+    List<AssignmentHistoryResponse> getAssignmentHistories(Long assignmentId, AssignmentAction action);
 }

--- a/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentServiceImpl.java
@@ -1,12 +1,14 @@
 package com.mzc.lp.domain.iis.service;
 
 import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.domain.iis.constant.AssignmentAction;
 import com.mzc.lp.domain.iis.constant.AssignmentStatus;
 import com.mzc.lp.domain.iis.constant.InstructorRole;
 import com.mzc.lp.domain.iis.dto.request.AssignInstructorRequest;
 import com.mzc.lp.domain.iis.dto.request.CancelAssignmentRequest;
 import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
 import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
+import com.mzc.lp.domain.iis.dto.response.AssignmentHistoryResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
 import com.mzc.lp.domain.iis.entity.AssignmentHistory;
 import com.mzc.lp.domain.iis.entity.InstructorAssignment;
@@ -245,6 +247,27 @@ public class InstructorAssignmentServiceImpl implements InstructorAssignmentServ
                                 Collectors.toList()
                         )
                 ));
+    }
+
+    // ========== 이력 조회 ==========
+
+    @Override
+    public List<AssignmentHistoryResponse> getAssignmentHistories(Long assignmentId, AssignmentAction action) {
+        log.debug("Getting assignment histories: assignmentId={}, action={}", assignmentId, action);
+
+        // 배정 존재 여부 확인
+        findAssignmentById(assignmentId);
+
+        List<AssignmentHistory> histories;
+        if (action != null) {
+            histories = historyRepository.findByAssignmentIdAndActionOrderByChangedAtDesc(assignmentId, action);
+        } else {
+            histories = historyRepository.findByAssignmentIdOrderByChangedAtDesc(assignmentId);
+        }
+
+        return histories.stream()
+                .map(AssignmentHistoryResponse::from)
+                .toList();
     }
 
     // ========== Private Methods ==========


### PR DESCRIPTION
## Summary

강사 배정(InstructorAssignment)의 변경 이력을 조회하는 API를 구현했습니다.
액션 타입(ASSIGN, ROLE_CHANGE, REPLACE, CANCEL)별 필터링을 지원합니다.

## Related Issue

- Closes #92

## Changes

- AssignmentHistoryRepository에 액션 필터링 조회 메서드 추가
- InstructorAssignmentService에 이력 조회 메서드 추가
- GET /api/instructor-assignments/{id}/histories 엔드포인트 구현
- action 쿼리 파라미터로 액션 타입별 필터링 지원
- Service/Controller 테스트 코드 추가 (6개)
- build.gradle에 테스트용 JWT_SECRET 환경변수 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [x] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### API 사용 예시
GET /api/instructor-assignments/1/histories GET /api/instructor-assignments/1/histories?action=ROLE_CHANGE