### PR TITLE
feat: 차수 오픈 시 MAIN 강사 필수 검증 추가 (#89)

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -59,6 +59,7 @@ public enum ErrorCode {
     LOCATION_REQUIRED(HttpStatus.BAD_REQUEST, "TS005", "Location info required for OFFLINE/BLENDED"),
     COURSE_TIME_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST, "TS006", "CourseTime is not modifiable in current status"),
     CANNOT_DELETE_MAIN_INSTRUCTOR(HttpStatus.BAD_REQUEST, "TS007", "Cannot delete main instructor while course is ongoing"),
+    MAIN_INSTRUCTOR_REQUIRED(HttpStatus.BAD_REQUEST, "TS008", "Main instructor required for opening course time"),
 
     // Enrollment (SIS)
     ENROLLMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "SIS001", "Enrollment not found"),

--- a/src/main/java/com/mzc/lp/domain/ts/exception/MainInstructorRequiredException.java
+++ b/src/main/java/com/mzc/lp/domain/ts/exception/MainInstructorRequiredException.java
@@ -1,0 +1,16 @@
+package com.mzc.lp.domain.ts.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class MainInstructorRequiredException extends BusinessException {
+
+    public MainInstructorRequiredException() {
+        super(ErrorCode.MAIN_INSTRUCTOR_REQUIRED);
+    }
+
+    public MainInstructorRequiredException(Long courseTimeId) {
+        super(ErrorCode.MAIN_INSTRUCTOR_REQUIRED,
+                String.format("Main instructor required for course time: %d", courseTimeId));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeServiceImpl.java
@@ -10,11 +10,13 @@ import com.mzc.lp.domain.ts.dto.response.CourseTimeDetailResponse;
 import com.mzc.lp.domain.ts.dto.response.CourseTimeResponse;
 import com.mzc.lp.domain.ts.dto.response.PriceResponse;
 import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.iis.service.InstructorAssignmentService;
 import com.mzc.lp.domain.ts.exception.CapacityExceededException;
 import com.mzc.lp.domain.ts.exception.CourseTimeNotFoundException;
 import com.mzc.lp.domain.ts.exception.InvalidDateRangeException;
 import com.mzc.lp.domain.ts.exception.InvalidStatusTransitionException;
 import com.mzc.lp.domain.ts.exception.LocationRequiredException;
+import com.mzc.lp.domain.ts.exception.MainInstructorRequiredException;
 import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +34,7 @@ import java.util.List;
 public class CourseTimeServiceImpl implements CourseTimeService {
 
     private final CourseTimeRepository courseTimeRepository;
+    private final InstructorAssignmentService instructorAssignmentService;
 
     @Override
     public CourseTime getCourseTimeEntity(Long id) {
@@ -208,6 +211,11 @@ public class CourseTimeServiceImpl implements CourseTimeService {
         if (courseTime.requiresLocationInfo() &&
                 (courseTime.getLocationInfo() == null || courseTime.getLocationInfo().isBlank())) {
             throw new LocationRequiredException();
+        }
+
+        // MAIN 강사 필수 검증 (R-IIS-01, R-TS-OPEN)
+        if (!instructorAssignmentService.existsMainInstructor(id)) {
+            throw new MainInstructorRequiredException(id);
         }
 
         courseTime.open();


### PR DESCRIPTION
## Summary

차수를 RECRUITING 상태로 오픈할 때 MAIN 강사가 최소 1명 배정되어 있는지 검증하는 로직을 추가합니다.
MAIN 강사 없이 차수가 오픈되면 수강생 관리에 문제가 발생할 수 있어, 사전에 검증하여 운영 실수를 방지합니다.

## Related Issue

- Closes #89

## Changes

### 1. ErrorCode 추가
- `MAIN_INSTRUCTOR_REQUIRED(HttpStatus.BAD_REQUEST, "TS008", "Main instructor required for opening course time")`

### 2. Exception 클래스 생성
- `MainInstructorRequiredException` - `LocationRequiredException` 패턴 준수
- 기본 생성자 및 `courseTimeId` 파라미터 생성자 제공

### 3. Service 로직 수정
- `CourseTimeServiceImpl`에 `InstructorAssignmentService` 의존성 주입
- `openCourseTime()` 메서드에 MAIN 강사 검증 로직 추가

### 4. 테스트 추가
- `openCourseTime_success()` - Mock 설정 추가
- `openCourseTime_fail_noMainInstructor()` - MAIN 강사 미배정 시 TS008 에러 반환 테스트

## Type of Change

- [x] Feat: 새로운 기능

## Test Plan

### 단위 테스트 (./gradlew test)
- [x] CourseTimeControllerTest - 전체 테스트 통과
- [x] 전체 테스트 스위트 통과

### 테스트 케이스

| 테스트 | 설명 | 예상 결과 |
|--------|------|----------|
| `openCourseTime_success` | MAIN 강사 배정 후 오픈 | ✅ 200 OK, status=RECRUITING |
| `openCourseTime_fail_noMainInstructor` | MAIN 강사 미배정 상태에서 오픈 | ✅ 400 Bad Request, TS008 |
| `openCourseTime_fail_alreadyRecruiting` | 이미 RECRUITING 상태에서 오픈 시도 | ✅ 400 Bad Request, TS002 |

### 수동 테스트 (API)

```bash
# 1. MAIN 강사 없이 오픈 시도 → 실패 (TS008)
POST /api/times/{timeId}/open

# 2. MAIN 강사 배정
POST /api/times/{timeId}/instructors
{ "userId": 1, "role": "MAIN" }

# 3. 오픈 재시도 → 성공
POST /api/times/{timeId}/open
```

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### 비즈니스 규칙
- **R-IIS-01**: 차수당 MAIN 강사는 반드시 1명 이상
- **R-TS-OPEN**: DRAFT → RECRUITING 전이 시 MAIN 강사 필수

### 검증 순서 (openCourseTime)
1. 차수 존재 여부 검증 → TS001
2. 상태 전이 가능 여부 검증 (DRAFT만 허용) → TS002
3. 장소 정보 검증 (OFFLINE/BLENDED) → TS005
4. **MAIN 강사 검증 (신규)** → TS008
5. 상태 전환 실행