### PR TITLE
feat: Content 버전 관리 기능 구현 (#93)

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -45,6 +45,7 @@ public enum ErrorCode {
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "CT007", "File not found on storage"),
     UNAUTHORIZED_CONTENT_ACCESS(HttpStatus.FORBIDDEN, "CT008", "Not authorized to access this content"),
     CONTENT_VERSION_NOT_FOUND(HttpStatus.NOT_FOUND, "CT009", "Content version not found"),
+    CONTENT_IN_USE(HttpStatus.CONFLICT, "CT010", "Content is in use by learning objects and cannot be modified"),
 
     // Learning Object (LO)
     LEARNING_OBJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "LO001", "Learning object not found"),

--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     METADATA_EXTRACTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CT006", "Metadata extraction failed"),
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "CT007", "File not found on storage"),
     UNAUTHORIZED_CONTENT_ACCESS(HttpStatus.FORBIDDEN, "CT008", "Not authorized to access this content"),
+    CONTENT_VERSION_NOT_FOUND(HttpStatus.NOT_FOUND, "CT009", "Content version not found"),
 
     // Learning Object (LO)
     LEARNING_OBJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "LO001", "Learning object not found"),

--- a/src/main/java/com/mzc/lp/domain/content/constant/VersionChangeType.java
+++ b/src/main/java/com/mzc/lp/domain/content/constant/VersionChangeType.java
@@ -1,0 +1,7 @@
+package com.mzc.lp.domain.content.constant;
+
+public enum VersionChangeType {
+    FILE_UPLOAD,      // 최초 파일 업로드
+    FILE_REPLACE,     // 파일 교체
+    METADATA_UPDATE   // 메타데이터 수정
+}

--- a/src/main/java/com/mzc/lp/domain/content/controller/ContentVersionController.java
+++ b/src/main/java/com/mzc/lp/domain/content/controller/ContentVersionController.java
@@ -1,0 +1,64 @@
+package com.mzc.lp.domain.content.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.content.dto.request.RestoreVersionRequest;
+import com.mzc.lp.domain.content.dto.response.ContentResponse;
+import com.mzc.lp.domain.content.dto.response.ContentVersionResponse;
+import com.mzc.lp.domain.content.service.ContentVersionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/contents/{contentId}/versions")
+@RequiredArgsConstructor
+public class ContentVersionController {
+
+    private final ContentVersionService contentVersionService;
+
+    @GetMapping
+    @PreAuthorize("hasRole('DESIGNER')")
+    public ResponseEntity<ApiResponse<List<ContentVersionResponse>>> getVersionHistory(
+            @PathVariable Long contentId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        Long userId = principal.id();
+        List<ContentVersionResponse> response = contentVersionService.getVersionHistory(contentId, tenantId, userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{versionNumber}")
+    @PreAuthorize("hasRole('DESIGNER')")
+    public ResponseEntity<ApiResponse<ContentVersionResponse>> getVersion(
+            @PathVariable Long contentId,
+            @PathVariable Integer versionNumber,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        Long userId = principal.id();
+        ContentVersionResponse response = contentVersionService.getVersion(contentId, versionNumber, tenantId, userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/{versionNumber}/restore")
+    @PreAuthorize("hasRole('DESIGNER')")
+    public ResponseEntity<ApiResponse<ContentResponse>> restoreVersion(
+            @PathVariable Long contentId,
+            @PathVariable Integer versionNumber,
+            @RequestBody(required = false) RestoreVersionRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        Long userId = principal.id();
+        String changeSummary = request != null ? request.changeSummary() : null;
+        ContentResponse response = contentVersionService.restoreVersion(contentId, versionNumber, tenantId, userId, changeSummary);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/content/controller/ContentVersionController.java
+++ b/src/main/java/com/mzc/lp/domain/content/controller/ContentVersionController.java
@@ -23,7 +23,7 @@ public class ContentVersionController {
     private final ContentVersionService contentVersionService;
 
     @GetMapping
-    @PreAuthorize("hasRole('DESIGNER')")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<List<ContentVersionResponse>>> getVersionHistory(
             @PathVariable Long contentId,
             @AuthenticationPrincipal UserPrincipal principal
@@ -35,7 +35,7 @@ public class ContentVersionController {
     }
 
     @GetMapping("/{versionNumber}")
-    @PreAuthorize("hasRole('DESIGNER')")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<ContentVersionResponse>> getVersion(
             @PathVariable Long contentId,
             @PathVariable Integer versionNumber,
@@ -48,7 +48,7 @@ public class ContentVersionController {
     }
 
     @PostMapping("/{versionNumber}/restore")
-    @PreAuthorize("hasRole('DESIGNER')")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<ContentResponse>> restoreVersion(
             @PathVariable Long contentId,
             @PathVariable Integer versionNumber,

--- a/src/main/java/com/mzc/lp/domain/content/dto/request/RestoreVersionRequest.java
+++ b/src/main/java/com/mzc/lp/domain/content/dto/request/RestoreVersionRequest.java
@@ -1,0 +1,5 @@
+package com.mzc.lp.domain.content.dto.request;
+
+public record RestoreVersionRequest(
+        String changeSummary  // 복원 사유 (선택)
+) {}

--- a/src/main/java/com/mzc/lp/domain/content/dto/response/ContentListResponse.java
+++ b/src/main/java/com/mzc/lp/domain/content/dto/response/ContentListResponse.java
@@ -16,6 +16,7 @@ public record ContentListResponse(
         Integer duration,
         String resolution,
         String thumbnailPath,
+        Integer currentVersion,
         LocalDateTime createdAt
 ) {
     public static ContentListResponse from(Content content) {
@@ -28,6 +29,7 @@ public record ContentListResponse(
                 content.getDuration(),
                 content.getResolution(),
                 content.getThumbnailPath(),
+                content.getCurrentVersion(),
                 content.getCreatedAt() != null
                         ? LocalDateTime.ofInstant(content.getCreatedAt(), ZoneId.systemDefault())
                         : null

--- a/src/main/java/com/mzc/lp/domain/content/dto/response/ContentResponse.java
+++ b/src/main/java/com/mzc/lp/domain/content/dto/response/ContentResponse.java
@@ -21,6 +21,7 @@ public record ContentResponse(
         String filePath,
         String thumbnailPath,
         Long createdBy,
+        Integer currentVersion,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -39,6 +40,7 @@ public record ContentResponse(
                 content.getFilePath(),
                 content.getThumbnailPath(),
                 content.getCreatedBy(),
+                content.getCurrentVersion(),
                 content.getCreatedAt() != null
                         ? LocalDateTime.ofInstant(content.getCreatedAt(), ZoneId.systemDefault())
                         : null,

--- a/src/main/java/com/mzc/lp/domain/content/dto/response/ContentVersionResponse.java
+++ b/src/main/java/com/mzc/lp/domain/content/dto/response/ContentVersionResponse.java
@@ -1,0 +1,42 @@
+package com.mzc.lp.domain.content.dto.response;
+
+import com.mzc.lp.domain.content.constant.ContentType;
+import com.mzc.lp.domain.content.constant.VersionChangeType;
+import com.mzc.lp.domain.content.entity.ContentVersion;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+public record ContentVersionResponse(
+        Long id,
+        Long contentId,
+        Integer versionNumber,
+        VersionChangeType changeType,
+        String originalFileName,
+        ContentType contentType,
+        Long fileSize,
+        Integer duration,
+        String resolution,
+        String changeSummary,
+        Long createdBy,
+        LocalDateTime createdAt
+) {
+    public static ContentVersionResponse from(ContentVersion version) {
+        return new ContentVersionResponse(
+                version.getId(),
+                version.getContent().getId(),
+                version.getVersionNumber(),
+                version.getChangeType(),
+                version.getOriginalFileName(),
+                version.getContentType(),
+                version.getFileSize(),
+                version.getDuration(),
+                version.getResolution(),
+                version.getChangeSummary(),
+                version.getCreatedBy(),
+                version.getCreatedAt() != null
+                        ? LocalDateTime.ofInstant(version.getCreatedAt(), ZoneId.systemDefault())
+                        : null
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/content/entity/Content.java
+++ b/src/main/java/com/mzc/lp/domain/content/entity/Content.java
@@ -27,6 +27,9 @@ public class Content extends TenantEntity {
     @Column(name = "created_by")
     private Long createdBy;
 
+    @Column(name = "current_version")
+    private Integer currentVersion;
+
     @Column(name = "original_file_name", length = 500)
     private String originalFileName;
 
@@ -71,6 +74,7 @@ public class Content extends TenantEntity {
         Content content = new Content();
         content.status = ContentStatus.ACTIVE;
         content.createdBy = createdBy;
+        content.currentVersion = 1;
         content.originalFileName = originalFileName;
         content.storedFileName = storedFileName;
         content.contentType = contentType;
@@ -89,6 +93,7 @@ public class Content extends TenantEntity {
         Content content = new Content();
         content.status = ContentStatus.ACTIVE;
         content.createdBy = createdBy;
+        content.currentVersion = 1;
         content.originalFileName = name;
         content.contentType = ContentType.EXTERNAL_LINK;
         content.externalUrl = externalUrl;
@@ -164,5 +169,13 @@ public class Content extends TenantEntity {
 
     public boolean isArchived() {
         return this.status == ContentStatus.ARCHIVED;
+    }
+
+    // 버전 증가 메서드
+    public void incrementVersion() {
+        if (this.currentVersion == null) {
+            this.currentVersion = 1;
+        }
+        this.currentVersion++;
     }
 }

--- a/src/main/java/com/mzc/lp/domain/content/entity/ContentVersion.java
+++ b/src/main/java/com/mzc/lp/domain/content/entity/ContentVersion.java
@@ -1,0 +1,92 @@
+package com.mzc.lp.domain.content.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import com.mzc.lp.domain.content.constant.ContentType;
+import com.mzc.lp.domain.content.constant.VersionChangeType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "content_version", indexes = {
+        @Index(name = "idx_cv_content", columnList = "tenant_id, content_id"),
+        @Index(name = "idx_cv_version", columnList = "content_id, version_number")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ContentVersion extends TenantEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id", nullable = false)
+    private Content content;
+
+    @Column(name = "version_number", nullable = false)
+    private Integer versionNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "change_type", nullable = false, length = 20)
+    private VersionChangeType changeType;
+
+    // 스냅샷 데이터 (변경 전 상태 저장)
+    @Column(name = "original_file_name", length = 500)
+    private String originalFileName;
+
+    @Column(name = "stored_file_name", length = 255)
+    private String storedFileName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "content_type", nullable = false, length = 50)
+    private ContentType contentType;
+
+    @Column(name = "file_size")
+    private Long fileSize;
+
+    @Column(name = "duration")
+    private Integer duration;
+
+    @Column(name = "resolution", length = 20)
+    private String resolution;
+
+    @Column(name = "page_count")
+    private Integer pageCount;
+
+    @Column(name = "external_url", length = 2000)
+    private String externalUrl;
+
+    @Column(name = "file_path", length = 1000)
+    private String filePath;
+
+    @Column(name = "thumbnail_path", length = 1000)
+    private String thumbnailPath;
+
+    @Column(name = "created_by")
+    private Long createdBy;
+
+    @Column(name = "change_summary", length = 500)
+    private String changeSummary;
+
+    // 정적 팩토리 메서드
+    public static ContentVersion createFrom(Content content, int versionNumber,
+                                            VersionChangeType changeType,
+                                            Long createdBy, String changeSummary) {
+        ContentVersion version = new ContentVersion();
+        version.content = content;
+        version.versionNumber = versionNumber;
+        version.changeType = changeType;
+        // Content 현재 상태 스냅샷
+        version.originalFileName = content.getOriginalFileName();
+        version.storedFileName = content.getStoredFileName();
+        version.contentType = content.getContentType();
+        version.fileSize = content.getFileSize();
+        version.duration = content.getDuration();
+        version.resolution = content.getResolution();
+        version.pageCount = content.getPageCount();
+        version.externalUrl = content.getExternalUrl();
+        version.filePath = content.getFilePath();
+        version.thumbnailPath = content.getThumbnailPath();
+        version.createdBy = createdBy;
+        version.changeSummary = changeSummary;
+        return version;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/content/exception/ContentInUseException.java
+++ b/src/main/java/com/mzc/lp/domain/content/exception/ContentInUseException.java
@@ -1,0 +1,12 @@
+package com.mzc.lp.domain.content.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class ContentInUseException extends BusinessException {
+
+    public ContentInUseException(Long contentId) {
+        super(ErrorCode.CONTENT_IN_USE,
+                String.format("Content %d is in use by learning objects and cannot be modified", contentId));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/content/exception/ContentVersionNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/content/exception/ContentVersionNotFoundException.java
@@ -1,0 +1,12 @@
+package com.mzc.lp.domain.content.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class ContentVersionNotFoundException extends BusinessException {
+
+    public ContentVersionNotFoundException(Long contentId, Integer version) {
+        super(ErrorCode.CONTENT_VERSION_NOT_FOUND,
+                String.format("Version %d not found for content %d", version, contentId));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/content/repository/ContentVersionRepository.java
+++ b/src/main/java/com/mzc/lp/domain/content/repository/ContentVersionRepository.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.domain.content.repository;
+
+import com.mzc.lp.domain.content.entity.ContentVersion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ContentVersionRepository extends JpaRepository<ContentVersion, Long> {
+
+    List<ContentVersion> findByContentIdOrderByVersionNumberDesc(Long contentId);
+
+    Optional<ContentVersion> findByContentIdAndVersionNumber(Long contentId, Integer versionNumber);
+
+    @Query("SELECT MAX(v.versionNumber) FROM ContentVersion v WHERE v.content.id = :contentId")
+    Optional<Integer> findMaxVersionNumber(@Param("contentId") Long contentId);
+}

--- a/src/main/java/com/mzc/lp/domain/content/service/ContentVersionService.java
+++ b/src/main/java/com/mzc/lp/domain/content/service/ContentVersionService.java
@@ -1,0 +1,31 @@
+package com.mzc.lp.domain.content.service;
+
+import com.mzc.lp.domain.content.constant.VersionChangeType;
+import com.mzc.lp.domain.content.dto.response.ContentResponse;
+import com.mzc.lp.domain.content.dto.response.ContentVersionResponse;
+import com.mzc.lp.domain.content.entity.Content;
+
+import java.util.List;
+
+public interface ContentVersionService {
+
+    /**
+     * 버전 생성 (수정 전 호출)
+     */
+    void createVersion(Content content, VersionChangeType changeType, Long userId, String changeSummary);
+
+    /**
+     * 버전 이력 조회
+     */
+    List<ContentVersionResponse> getVersionHistory(Long contentId, Long tenantId, Long userId);
+
+    /**
+     * 특정 버전 조회
+     */
+    ContentVersionResponse getVersion(Long contentId, Integer versionNumber, Long tenantId, Long userId);
+
+    /**
+     * 버전 복원
+     */
+    ContentResponse restoreVersion(Long contentId, Integer versionNumber, Long tenantId, Long userId, String changeSummary);
+}

--- a/src/main/java/com/mzc/lp/domain/content/service/ContentVersionServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/content/service/ContentVersionServiceImpl.java
@@ -1,0 +1,106 @@
+package com.mzc.lp.domain.content.service;
+
+import com.mzc.lp.domain.content.constant.VersionChangeType;
+import com.mzc.lp.domain.content.dto.response.ContentResponse;
+import com.mzc.lp.domain.content.dto.response.ContentVersionResponse;
+import com.mzc.lp.domain.content.entity.Content;
+import com.mzc.lp.domain.content.entity.ContentVersion;
+import com.mzc.lp.domain.content.exception.ContentNotFoundException;
+import com.mzc.lp.domain.content.exception.ContentVersionNotFoundException;
+import com.mzc.lp.domain.content.exception.UnauthorizedContentAccessException;
+import com.mzc.lp.domain.content.repository.ContentRepository;
+import com.mzc.lp.domain.content.repository.ContentVersionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContentVersionServiceImpl implements ContentVersionService {
+
+    private final ContentRepository contentRepository;
+    private final ContentVersionRepository contentVersionRepository;
+
+    @Override
+    @Transactional
+    public void createVersion(Content content, VersionChangeType changeType, Long userId, String changeSummary) {
+        int nextVersion = contentVersionRepository.findMaxVersionNumber(content.getId())
+                .map(v -> v + 1)
+                .orElse(1);
+
+        ContentVersion version = ContentVersion.createFrom(content, nextVersion, changeType, userId, changeSummary);
+        contentVersionRepository.save(version);
+
+        log.info("Content version created: contentId={}, version={}, changeType={}",
+                content.getId(), nextVersion, changeType);
+    }
+
+    @Override
+    public List<ContentVersionResponse> getVersionHistory(Long contentId, Long tenantId, Long userId) {
+        Content content = findContentOrThrow(contentId, tenantId);
+        validateOwnership(content, userId);
+
+        return contentVersionRepository.findByContentIdOrderByVersionNumberDesc(contentId)
+                .stream()
+                .map(ContentVersionResponse::from)
+                .toList();
+    }
+
+    @Override
+    public ContentVersionResponse getVersion(Long contentId, Integer versionNumber, Long tenantId, Long userId) {
+        Content content = findContentOrThrow(contentId, tenantId);
+        validateOwnership(content, userId);
+
+        ContentVersion version = contentVersionRepository.findByContentIdAndVersionNumber(contentId, versionNumber)
+                .orElseThrow(() -> new ContentVersionNotFoundException(contentId, versionNumber));
+
+        return ContentVersionResponse.from(version);
+    }
+
+    @Override
+    @Transactional
+    public ContentResponse restoreVersion(Long contentId, Integer versionNumber, Long tenantId, Long userId, String changeSummary) {
+        Content content = findContentOrThrow(contentId, tenantId);
+        validateOwnership(content, userId);
+
+        ContentVersion version = contentVersionRepository.findByContentIdAndVersionNumber(contentId, versionNumber)
+                .orElseThrow(() -> new ContentVersionNotFoundException(contentId, versionNumber));
+
+        // 현재 상태 백업
+        String summary = "Before restore to v" + versionNumber;
+        if (changeSummary != null && !changeSummary.isBlank()) {
+            summary += ": " + changeSummary;
+        }
+        createVersion(content, VersionChangeType.FILE_REPLACE, userId, summary);
+
+        // 버전 복원
+        content.replaceFile(
+                version.getOriginalFileName(),
+                version.getStoredFileName(),
+                version.getFileSize(),
+                version.getFilePath()
+        );
+        content.setThumbnailPath(version.getThumbnailPath());
+        content.incrementVersion();
+
+        log.info("Content restored to version {}: contentId={}", versionNumber, contentId);
+
+        return ContentResponse.from(content);
+    }
+
+    private Content findContentOrThrow(Long contentId, Long tenantId) {
+        return contentRepository.findByIdAndTenantId(contentId, tenantId)
+                .orElseThrow(() -> new ContentNotFoundException(contentId));
+    }
+
+    private void validateOwnership(Content content, Long userId) {
+        if (content.getCreatedBy() == null || !content.getCreatedBy().equals(userId)) {
+            throw new UnauthorizedContentAccessException(content.getId());
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/learning/repository/LearningObjectRepository.java
+++ b/src/main/java/com/mzc/lp/domain/learning/repository/LearningObjectRepository.java
@@ -35,4 +35,9 @@ public interface LearningObjectRepository extends JpaRepository<LearningObject, 
                                                              @Param("folderId") Long folderId,
                                                              @Param("keyword") String keyword,
                                                              Pageable pageable);
+
+    /**
+     * 콘텐츠가 강의(LearningObject)에서 참조되고 있는지 확인
+     */
+    boolean existsByContentId(Long contentId);
 }

--- a/src/test/java/com/mzc/lp/domain/content/controller/ContentControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/content/controller/ContentControllerTest.java
@@ -7,6 +7,7 @@ import com.mzc.lp.domain.content.dto.request.CreateExternalLinkRequest;
 import com.mzc.lp.domain.content.dto.request.UpdateContentRequest;
 import com.mzc.lp.domain.content.entity.Content;
 import com.mzc.lp.domain.content.repository.ContentRepository;
+import com.mzc.lp.domain.content.repository.ContentVersionRepository;
 import com.mzc.lp.domain.user.constant.TenantRole;
 import com.mzc.lp.domain.user.dto.request.LoginRequest;
 import com.mzc.lp.domain.user.entity.User;
@@ -46,6 +47,9 @@ class ContentControllerTest extends TenantTestSupport {
     private ContentRepository contentRepository;
 
     @Autowired
+    private ContentVersionRepository contentVersionRepository;
+
+    @Autowired
     private UserRepository userRepository;
 
     @Autowired
@@ -65,9 +69,10 @@ class ContentControllerTest extends TenantTestSupport {
 
     @BeforeEach
     void setUp() {
-        // FK 제약조건: LearningObject -> Content
+        // FK 제약조건: LearningObject -> Content, ContentVersion -> Content
         learningObjectRepository.deleteAll();
         contentFolderRepository.deleteAll();
+        contentVersionRepository.deleteAll();
         contentRepository.deleteAll();
         userCourseRoleRepository.deleteAll();
         refreshTokenRepository.deleteAll();

--- a/src/test/java/com/mzc/lp/domain/content/controller/ContentVersionControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/content/controller/ContentVersionControllerTest.java
@@ -1,0 +1,314 @@
+package com.mzc.lp.domain.content.controller;
+
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.domain.content.constant.ContentType;
+import com.mzc.lp.domain.content.constant.VersionChangeType;
+import com.mzc.lp.domain.content.dto.request.RestoreVersionRequest;
+import com.mzc.lp.domain.content.entity.Content;
+import com.mzc.lp.domain.content.entity.ContentVersion;
+import com.mzc.lp.domain.content.repository.ContentRepository;
+import com.mzc.lp.domain.content.repository.ContentVersionRepository;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import com.mzc.lp.domain.learning.repository.LearningObjectRepository;
+import com.mzc.lp.domain.learning.repository.ContentFolderRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ContentVersionControllerTest extends TenantTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ContentRepository contentRepository;
+
+    @Autowired
+    private ContentVersionRepository contentVersionRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private UserCourseRoleRepository userCourseRoleRepository;
+
+    @Autowired
+    private LearningObjectRepository learningObjectRepository;
+
+    @Autowired
+    private ContentFolderRepository contentFolderRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private User designerUser;
+
+    @BeforeEach
+    void setUp() {
+        learningObjectRepository.deleteAll();
+        contentFolderRepository.deleteAll();
+        contentVersionRepository.deleteAll();
+        contentRepository.deleteAll();
+        userCourseRoleRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+
+        designerUser = createDesignerUser();
+    }
+
+    private User createDesignerUser() {
+        User user = User.create("designer@example.com", "디자이너", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.OPERATOR);
+        return userRepository.save(user);
+    }
+
+    private User createAnotherUser() {
+        User user = User.create("another@example.com", "다른유저", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.OPERATOR);
+        return userRepository.save(user);
+    }
+
+    private String loginAndGetAccessToken(String email, String password) throws Exception {
+        LoginRequest request = new LoginRequest(email, password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("data").get("accessToken").asText();
+    }
+
+    private Content createContentWithOwner(Long ownerId) {
+        Content content = Content.createFile("test.mp4", "stored.mp4", ContentType.VIDEO, 1000L, "/path/test.mp4", ownerId);
+        return contentRepository.save(content);
+    }
+
+    private ContentVersion createVersion(Content content, int versionNumber, VersionChangeType changeType) {
+        ContentVersion version = ContentVersion.createFrom(
+                content, versionNumber, changeType, content.getCreatedBy(), "Version " + versionNumber
+        );
+        return contentVersionRepository.save(version);
+    }
+
+    // ==================== 버전 이력 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/contents/{contentId}/versions - 버전 이력 조회")
+    class GetVersionHistory {
+
+        @Test
+        @DisplayName("성공 - 버전 이력 조회")
+        void getVersionHistory_success() throws Exception {
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            Content content = createContentWithOwner(designerUser.getId());
+            createVersion(content, 1, VersionChangeType.FILE_UPLOAD);
+            createVersion(content, 2, VersionChangeType.METADATA_UPDATE);
+
+            mockMvc.perform(get("/api/contents/{contentId}/versions", content.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(2))
+                    .andExpect(jsonPath("$.data[0].versionNumber").value(2))
+                    .andExpect(jsonPath("$.data[1].versionNumber").value(1));
+        }
+
+        @Test
+        @DisplayName("성공 - 버전이 없는 경우 빈 배열 반환")
+        void getVersionHistory_empty() throws Exception {
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            Content content = createContentWithOwner(designerUser.getId());
+
+            mockMvc.perform(get("/api/contents/{contentId}/versions", content.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(0));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 콘텐츠")
+        void getVersionHistory_contentNotFound() throws Exception {
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+
+            mockMvc.perform(get("/api/contents/{contentId}/versions", 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CT001"));
+        }
+
+        @Test
+        @DisplayName("실패 - 다른 사용자의 콘텐츠")
+        void getVersionHistory_unauthorized() throws Exception {
+            createAnotherUser();
+            String accessToken = loginAndGetAccessToken("another@example.com", "Password123!");
+            Content content = createContentWithOwner(designerUser.getId());
+
+            mockMvc.perform(get("/api/contents/{contentId}/versions", content.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CT008"));
+        }
+    }
+
+    // ==================== 특정 버전 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/contents/{contentId}/versions/{versionNumber} - 특정 버전 조회")
+    class GetVersion {
+
+        @Test
+        @DisplayName("성공 - 특정 버전 조회")
+        void getVersion_success() throws Exception {
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            Content content = createContentWithOwner(designerUser.getId());
+            createVersion(content, 1, VersionChangeType.FILE_UPLOAD);
+            createVersion(content, 2, VersionChangeType.FILE_REPLACE);
+
+            mockMvc.perform(get("/api/contents/{contentId}/versions/{versionNumber}", content.getId(), 1)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.versionNumber").value(1))
+                    .andExpect(jsonPath("$.data.changeType").value("FILE_UPLOAD"));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 버전")
+        void getVersion_versionNotFound() throws Exception {
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            Content content = createContentWithOwner(designerUser.getId());
+            createVersion(content, 1, VersionChangeType.FILE_UPLOAD);
+
+            mockMvc.perform(get("/api/contents/{contentId}/versions/{versionNumber}", content.getId(), 99)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CT009"));
+        }
+
+        @Test
+        @DisplayName("실패 - 다른 사용자의 콘텐츠")
+        void getVersion_unauthorized() throws Exception {
+            createAnotherUser();
+            String accessToken = loginAndGetAccessToken("another@example.com", "Password123!");
+            Content content = createContentWithOwner(designerUser.getId());
+            createVersion(content, 1, VersionChangeType.FILE_UPLOAD);
+
+            mockMvc.perform(get("/api/contents/{contentId}/versions/{versionNumber}", content.getId(), 1)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.error.code").value("CT008"));
+        }
+    }
+
+    // ==================== 버전 복원 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/contents/{contentId}/versions/{versionNumber}/restore - 버전 복원")
+    class RestoreVersion {
+
+        @Test
+        @DisplayName("성공 - 버전 복원")
+        void restoreVersion_success() throws Exception {
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            Content content = createContentWithOwner(designerUser.getId());
+            createVersion(content, 1, VersionChangeType.FILE_UPLOAD);
+
+            RestoreVersionRequest request = new RestoreVersionRequest("Restoring to version 1");
+
+            mockMvc.perform(post("/api/contents/{contentId}/versions/{versionNumber}/restore", content.getId(), 1)
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.id").value(content.getId()));
+        }
+
+        @Test
+        @DisplayName("성공 - changeSummary 없이 복원")
+        void restoreVersion_withoutSummary() throws Exception {
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            Content content = createContentWithOwner(designerUser.getId());
+            createVersion(content, 1, VersionChangeType.FILE_UPLOAD);
+
+            mockMvc.perform(post("/api/contents/{contentId}/versions/{versionNumber}/restore", content.getId(), 1)
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 버전 복원")
+        void restoreVersion_versionNotFound() throws Exception {
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            Content content = createContentWithOwner(designerUser.getId());
+
+            mockMvc.perform(post("/api/contents/{contentId}/versions/{versionNumber}/restore", content.getId(), 99)
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error.code").value("CT009"));
+        }
+
+        @Test
+        @DisplayName("실패 - 다른 사용자의 콘텐츠 복원")
+        void restoreVersion_unauthorized() throws Exception {
+            createAnotherUser();
+            String accessToken = loginAndGetAccessToken("another@example.com", "Password123!");
+            Content content = createContentWithOwner(designerUser.getId());
+            createVersion(content, 1, VersionChangeType.FILE_UPLOAD);
+
+            mockMvc.perform(post("/api/contents/{contentId}/versions/{versionNumber}/restore", content.getId(), 1)
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.error.code").value("CT008"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Content 버전 관리 기능을 구현하여 콘텐츠 변경 이력을 추적하고 이전 버전으로 복원할 수 있습니다.

## Related Issue

- Closes #93

## Changes

- `ContentVersion` 엔티티 추가 - 버전 스냅샷 저장
- `ContentVersionService` 구현 - 버전 생성, 조회, 복원 로직
- `ContentVersionController` 추가 - 버전 관리 API 엔드포인트
- `ContentServiceImpl` 수정 - 파일 업로드/교체/메타데이터 수정 시 자동 버전 기록
- 강의에 포함된 콘텐츠 수정/교체/복원 제한 기능 추가
- 버전 API 테스트 11개 추가

## Type of Change

- [x] Feat: 새로운 기능
- [x] Test: 테스트 추가/수정

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### 버전 관리 API

| Method | Endpoint | 설명 |
|--------|----------|------|
| GET | `/api/contents/{contentId}/versions` | 버전 히스토리 조회 |
| GET | `/api/contents/{contentId}/versions/{versionNumber}` | 특정 버전 조회 |
| POST | `/api/contents/{contentId}/versions/{versionNumber}/restore` | 버전 복원 |

### VersionChangeType

- `FILE_UPLOAD` - 최초 업로드
- `FILE_REPLACE` - 파일 교체
- `METADATA_UPDATE` - 메타데이터 수정