### PR TITLE
feat : 강사 정보 조회 API - User 모듈 연동 (#119)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/iis/dto/response/InstructorAssignmentResponse.java
+++ b/src/main/java/com/mzc/lp/domain/iis/dto/response/InstructorAssignmentResponse.java
@@ -3,12 +3,15 @@ package com.mzc.lp.domain.iis.dto.response;
 import com.mzc.lp.domain.iis.constant.AssignmentStatus;
 import com.mzc.lp.domain.iis.constant.InstructorRole;
 import com.mzc.lp.domain.iis.entity.InstructorAssignment;
+import com.mzc.lp.domain.user.entity.User;
 
 import java.time.Instant;
 
 public record InstructorAssignmentResponse(
         Long id,
         Long userId,
+        String userName,
+        String userEmail,
         Long timeId,
         InstructorRole role,
         AssignmentStatus status,
@@ -21,6 +24,24 @@ public record InstructorAssignmentResponse(
         return new InstructorAssignmentResponse(
                 entity.getId(),
                 entity.getUserKey(),
+                null,
+                null,
+                entity.getTimeKey(),
+                entity.getRole(),
+                entity.getStatus(),
+                entity.getAssignedAt(),
+                entity.getReplacedAt(),
+                entity.getAssignedBy(),
+                entity.getCreatedAt()
+        );
+    }
+
+    public static InstructorAssignmentResponse from(InstructorAssignment entity, User user) {
+        return new InstructorAssignmentResponse(
+                entity.getId(),
+                entity.getUserKey(),
+                user != null ? user.getName() : null,
+                user != null ? user.getEmail() : null,
                 entity.getTimeKey(),
                 entity.getRole(),
                 entity.getStatus(),


### PR DESCRIPTION
## Summary

강사 배정 API 응답에 User 정보(이름, 이메일)를 포함하여 반환하도록 개선

## Related Issue

- Closes #119

## Changes

- `InstructorAssignmentResponse`에 `userName`, `userEmail` 필드 추가
- `InstructorAssignmentServiceImpl`에 `UserRepository` 의존성 추가
- 모든 배정 조회/변경 API에서 User 정보 함께 반환
- N+1 방지를 위한 벌크 조회 헬퍼 메서드 추가 (`getUserMapByAssignments`)
- Service 테스트 코드에 `UserRepository` Mock 및 테스트 케이스 수정

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 기존 API 응답에 필드가 추가되는 형태로 하위 호환성 유지
- User가 존재하지 않는 경우 `userName`, `userEmail`은 `null` 반환