### PR TITLE
feat : TS - 차수 복제 API (#91)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeController.java
+++ b/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeController.java
@@ -3,6 +3,7 @@ package com.mzc.lp.domain.ts.controller;
 import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.common.security.UserPrincipal;
 import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+import com.mzc.lp.domain.ts.dto.request.CloneCourseTimeRequest;
 import com.mzc.lp.domain.ts.dto.request.CreateCourseTimeRequest;
 import com.mzc.lp.domain.ts.dto.request.UpdateCourseTimeRequest;
 import com.mzc.lp.domain.ts.dto.response.CapacityResponse;
@@ -75,6 +76,17 @@ public class CourseTimeController {
     ) {
         courseTimeService.deleteCourseTime(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{id}/clone")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseTimeDetailResponse>> cloneCourseTime(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody CloneCourseTimeRequest request
+    ) {
+        CourseTimeDetailResponse response = courseTimeService.cloneCourseTime(id, request, principal.id());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 
     // ========== 상태 전이 API ==========

--- a/src/main/java/com/mzc/lp/domain/ts/dto/request/CloneCourseTimeRequest.java
+++ b/src/main/java/com/mzc/lp/domain/ts/dto/request/CloneCourseTimeRequest.java
@@ -1,0 +1,26 @@
+package com.mzc.lp.domain.ts.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record CloneCourseTimeRequest(
+        @NotBlank(message = "제목은 필수입니다")
+        @Size(max = 200, message = "제목은 200자 이하여야 합니다")
+        String title,
+
+        @NotNull(message = "모집 시작일은 필수입니다")
+        LocalDate enrollStartDate,
+
+        @NotNull(message = "모집 종료일은 필수입니다")
+        LocalDate enrollEndDate,
+
+        @NotNull(message = "학습 시작일은 필수입니다")
+        LocalDate classStartDate,
+
+        @NotNull(message = "학습 종료일은 필수입니다")
+        LocalDate classEndDate
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/ts/entity/CourseTime.java
+++ b/src/main/java/com/mzc/lp/domain/ts/entity/CourseTime.java
@@ -92,6 +92,44 @@ public class CourseTime extends TenantEntity {
     private Long createdBy;
 
     // 정적 팩토리 메서드
+    public static CourseTime cloneFrom(
+            CourseTime source,
+            String newTitle,
+            LocalDate enrollStartDate,
+            LocalDate enrollEndDate,
+            LocalDate classStartDate,
+            LocalDate classEndDate,
+            Long createdBy
+    ) {
+        CourseTime courseTime = new CourseTime();
+        // 복제 대상 필드
+        courseTime.deliveryType = source.deliveryType;
+        courseTime.capacity = source.capacity;
+        courseTime.maxWaitingCount = source.maxWaitingCount;
+        courseTime.enrollmentMethod = source.enrollmentMethod;
+        courseTime.minProgressForCompletion = source.minProgressForCompletion;
+        courseTime.price = source.price;
+        courseTime.free = source.free;
+        courseTime.locationInfo = source.locationInfo;
+        courseTime.allowLateEnrollment = source.allowLateEnrollment;
+        courseTime.cmCourseId = source.cmCourseId;
+        courseTime.cmCourseVersionId = source.cmCourseVersionId;
+
+        // 새로 지정하는 필드
+        courseTime.title = newTitle;
+        courseTime.enrollStartDate = enrollStartDate;
+        courseTime.enrollEndDate = enrollEndDate;
+        courseTime.classStartDate = classStartDate;
+        courseTime.classEndDate = classEndDate;
+        courseTime.createdBy = createdBy;
+
+        // 고정 값
+        courseTime.status = CourseTimeStatus.DRAFT;
+        courseTime.currentEnrollment = 0;
+
+        return courseTime;
+    }
+
     public static CourseTime create(
             String title,
             DeliveryType deliveryType,

--- a/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeService.java
+++ b/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeService.java
@@ -1,6 +1,7 @@
 package com.mzc.lp.domain.ts.service;
 
 import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+import com.mzc.lp.domain.ts.dto.request.CloneCourseTimeRequest;
 import com.mzc.lp.domain.ts.dto.request.CreateCourseTimeRequest;
 import com.mzc.lp.domain.ts.dto.request.UpdateCourseTimeRequest;
 import com.mzc.lp.domain.ts.dto.response.CapacityResponse;
@@ -18,6 +19,8 @@ public interface CourseTimeService {
 
     // CRUD
     CourseTimeDetailResponse createCourseTime(CreateCourseTimeRequest request, Long createdBy);
+
+    CourseTimeDetailResponse cloneCourseTime(Long sourceId, CloneCourseTimeRequest request, Long createdBy);
 
     Page<CourseTimeResponse> getCourseTimes(CourseTimeStatus status, Long cmCourseId, Pageable pageable);
 


### PR DESCRIPTION
## Summary

기존 차수 설정을 복사하여 새 차수를 생성하는 복제 API 구현
- 복제된 차수는 DRAFT 상태로 생성되며, 일정(제목, 날짜)만 새로 지정
- validateDateRange() 메서드를 파라미터 기반으로 리팩토링하여 재사용성 향상

## Related Issue

- Closes #91

## Changes

- `CloneCourseTimeRequest.java` 신규 생성 - 복제 요청 DTO
- `CourseTime.java` - cloneFrom() 정적 팩토리 메서드 추가
- `CourseTimeService.java` - cloneCourseTime() 인터페이스 추가
- `CourseTimeServiceImpl.java` - cloneCourseTime() 구현 + validateDateRange() 리팩토링
- `CourseTimeController.java` - POST /api/times/{id}/clone 엔드포인트 추가
- `CourseTimeControllerTest.java` - 복제 API 테스트 6개 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Test Plan

- [x] DRAFT 상태 원본 복제 성공 테스트
- [x] ONGOING 상태 원본 복제 성공 테스트 (R-CLONE-01)
- [x] 원본 미존재 시 404 반환 테스트
- [x] 날짜 유효성 검증 실패 시 400 반환 테스트
- [x] 필수 필드 누락 시 400 반환 테스트
- [x] 권한 없는 사용자(USER) 접근 시 403 반환 테스트

## Additional Notes

**Business Rules 준수:**
| 규칙 | 설명 | 구현 |
|------|------|------|
| R-CLONE-01 | 원본 상태 무관 복제 가능 | ✅ |
| R-CLONE-02 | 복제된 차수는 DRAFT로 생성 | ✅ |
| R-CLONE-03 | 강사 배정은 복제하지 않음 | ✅ |
| R-CLONE-04 | 날짜 검증은 기존 로직과 동일 | ✅ |
| R-CLONE-05 | createdBy = API 호출자 | ✅ |