### PR TITLE
feat: Program Entity 및 승인 워크플로우 구현 (#120)

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -88,7 +88,14 @@ public enum ErrorCode {
     DUPLICATE_TENANT_CODE(HttpStatus.CONFLICT, "TN002", "Tenant code already exists"),
     DUPLICATE_SUBDOMAIN(HttpStatus.CONFLICT, "TN003", "Subdomain already exists"),
     DUPLICATE_CUSTOM_DOMAIN(HttpStatus.CONFLICT, "TN004", "Custom domain already exists"),
-    INVALID_TENANT_STATUS(HttpStatus.BAD_REQUEST, "TN005", "Invalid tenant status transition");
+    INVALID_TENANT_STATUS(HttpStatus.BAD_REQUEST, "TN005", "Invalid tenant status transition"),
+
+    // Program (PG)
+    PROGRAM_NOT_FOUND(HttpStatus.NOT_FOUND, "PG001", "Program not found"),
+    INVALID_PROGRAM_STATUS(HttpStatus.BAD_REQUEST, "PG002", "Invalid program status transition"),
+    PROGRAM_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST, "PG003", "Program is not modifiable in current status"),
+    PROGRAM_NOT_APPROVED(HttpStatus.BAD_REQUEST, "PG004", "Program is not approved"),
+    REJECTION_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "PG005", "Rejection reason is required");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/mzc/lp/domain/program/constant/ProgramLevel.java
+++ b/src/main/java/com/mzc/lp/domain/program/constant/ProgramLevel.java
@@ -1,0 +1,7 @@
+package com.mzc.lp.domain.program.constant;
+
+public enum ProgramLevel {
+    BEGINNER,       // 입문
+    INTERMEDIATE,   // 중급
+    ADVANCED        // 고급
+}

--- a/src/main/java/com/mzc/lp/domain/program/constant/ProgramStatus.java
+++ b/src/main/java/com/mzc/lp/domain/program/constant/ProgramStatus.java
@@ -1,0 +1,9 @@
+package com.mzc.lp.domain.program.constant;
+
+public enum ProgramStatus {
+    DRAFT,      // 작성 중
+    PENDING,    // 검토 대기
+    APPROVED,   // 승인됨 (운영 가능)
+    REJECTED,   // 반려됨
+    CLOSED      // 종료됨
+}

--- a/src/main/java/com/mzc/lp/domain/program/constant/ProgramType.java
+++ b/src/main/java/com/mzc/lp/domain/program/constant/ProgramType.java
@@ -1,0 +1,7 @@
+package com.mzc.lp.domain.program.constant;
+
+public enum ProgramType {
+    ONLINE,     // 온라인 (비대면)
+    OFFLINE,    // 오프라인 (대면)
+    BLENDED     // 블렌디드 (혼합)
+}

--- a/src/main/java/com/mzc/lp/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/mzc/lp/domain/program/controller/ProgramController.java
@@ -1,0 +1,192 @@
+package com.mzc.lp.domain.program.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.program.constant.ProgramStatus;
+import com.mzc.lp.domain.program.dto.request.ApproveRequest;
+import com.mzc.lp.domain.program.dto.request.CreateProgramRequest;
+import com.mzc.lp.domain.program.dto.request.RejectRequest;
+import com.mzc.lp.domain.program.dto.request.UpdateProgramRequest;
+import com.mzc.lp.domain.program.dto.response.PendingProgramResponse;
+import com.mzc.lp.domain.program.dto.response.ProgramDetailResponse;
+import com.mzc.lp.domain.program.dto.response.ProgramResponse;
+import com.mzc.lp.domain.program.service.ProgramService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+@RequestMapping("/api/programs")
+public class ProgramController {
+
+    private final ProgramService programService;
+
+    /**
+     * 프로그램(강의 개설) 생성
+     * POST /api/programs
+     */
+    @PostMapping
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<ProgramResponse>> createProgram(
+            @Valid @RequestBody CreateProgramRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        ProgramResponse response = programService.createProgram(request, principal.id());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 프로그램 목록 조회
+     * GET /api/programs
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<ProgramResponse>>> getPrograms(
+            @RequestParam(required = false) ProgramStatus status,
+            @RequestParam(required = false) Long creatorId,
+            @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Page<ProgramResponse> response = programService.getPrograms(status, creatorId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 프로그램 상세 조회
+     * GET /api/programs/{programId}
+     */
+    @GetMapping("/{programId}")
+    public ResponseEntity<ApiResponse<ProgramDetailResponse>> getProgram(
+            @PathVariable @Positive Long programId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        ProgramDetailResponse response = programService.getProgram(programId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 프로그램 수정
+     * PUT /api/programs/{programId}
+     */
+    @PutMapping("/{programId}")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<ProgramResponse>> updateProgram(
+            @PathVariable @Positive Long programId,
+            @Valid @RequestBody UpdateProgramRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        ProgramResponse response = programService.updateProgram(programId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 프로그램 삭제
+     * DELETE /api/programs/{programId}
+     */
+    @DeleteMapping("/{programId}")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> deleteProgram(
+            @PathVariable @Positive Long programId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        programService.deleteProgram(programId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 프로그램 개설 신청 (DRAFT → PENDING)
+     * POST /api/programs/{programId}/submit
+     */
+    @PostMapping("/{programId}/submit")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<ProgramResponse>> submitProgram(
+            @PathVariable @Positive Long programId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        ProgramResponse response = programService.submitProgram(programId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 검토 대기 프로그램 목록 조회 (OPERATOR용)
+     * GET /api/programs/pending
+     */
+    @GetMapping("/pending")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<Page<PendingProgramResponse>>> getPendingPrograms(
+            @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Page<PendingProgramResponse> response = programService.getPendingPrograms(pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 프로그램 승인 (PENDING → APPROVED)
+     * POST /api/programs/{programId}/approve
+     */
+    @PostMapping("/{programId}/approve")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<ProgramDetailResponse>> approveProgram(
+            @PathVariable @Positive Long programId,
+            @Valid @RequestBody(required = false) ApproveRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        ProgramDetailResponse response = programService.approveProgram(programId, request, principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 프로그램 반려 (PENDING → REJECTED)
+     * POST /api/programs/{programId}/reject
+     */
+    @PostMapping("/{programId}/reject")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<ProgramDetailResponse>> rejectProgram(
+            @PathVariable @Positive Long programId,
+            @Valid @RequestBody RejectRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        ProgramDetailResponse response = programService.rejectProgram(programId, request, principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 프로그램 종료
+     * POST /api/programs/{programId}/close
+     */
+    @PostMapping("/{programId}/close")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<ProgramResponse>> closeProgram(
+            @PathVariable @Positive Long programId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        ProgramResponse response = programService.closeProgram(programId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 스냅샷 연결
+     * POST /api/programs/{programId}/snapshot
+     */
+    @PostMapping("/{programId}/snapshot")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<ProgramResponse>> linkSnapshot(
+            @PathVariable @Positive Long programId,
+            @RequestParam @Positive Long snapshotId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        ProgramResponse response = programService.linkSnapshot(programId, snapshotId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/program/dto/request/ApproveRequest.java
+++ b/src/main/java/com/mzc/lp/domain/program/dto/request/ApproveRequest.java
@@ -1,0 +1,9 @@
+package com.mzc.lp.domain.program.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record ApproveRequest(
+        @Size(max = 500, message = "승인 코멘트는 500자 이하여야 합니다")
+        String comment
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/program/dto/request/CreateProgramRequest.java
+++ b/src/main/java/com/mzc/lp/domain/program/dto/request/CreateProgramRequest.java
@@ -1,0 +1,27 @@
+package com.mzc.lp.domain.program.dto.request;
+
+import com.mzc.lp.domain.program.constant.ProgramLevel;
+import com.mzc.lp.domain.program.constant.ProgramType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateProgramRequest(
+        @NotBlank(message = "제목은 필수입니다")
+        @Size(max = 255, message = "제목은 255자 이하여야 합니다")
+        String title,
+
+        @Size(max = 5000, message = "설명은 5000자 이하여야 합니다")
+        String description,
+
+        @Size(max = 500, message = "썸네일 URL은 500자 이하여야 합니다")
+        String thumbnailUrl,
+
+        ProgramLevel level,
+
+        ProgramType type,
+
+        Integer estimatedHours,
+
+        Long snapshotId
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/program/dto/request/RejectRequest.java
+++ b/src/main/java/com/mzc/lp/domain/program/dto/request/RejectRequest.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.program.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RejectRequest(
+        @NotBlank(message = "반려 사유는 필수입니다")
+        @Size(max = 500, message = "반려 사유는 500자 이하여야 합니다")
+        String reason
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/program/dto/request/UpdateProgramRequest.java
+++ b/src/main/java/com/mzc/lp/domain/program/dto/request/UpdateProgramRequest.java
@@ -1,0 +1,23 @@
+package com.mzc.lp.domain.program.dto.request;
+
+import com.mzc.lp.domain.program.constant.ProgramLevel;
+import com.mzc.lp.domain.program.constant.ProgramType;
+import jakarta.validation.constraints.Size;
+
+public record UpdateProgramRequest(
+        @Size(max = 255, message = "제목은 255자 이하여야 합니다")
+        String title,
+
+        @Size(max = 5000, message = "설명은 5000자 이하여야 합니다")
+        String description,
+
+        @Size(max = 500, message = "썸네일 URL은 500자 이하여야 합니다")
+        String thumbnailUrl,
+
+        ProgramLevel level,
+
+        ProgramType type,
+
+        Integer estimatedHours
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/program/dto/response/PendingProgramResponse.java
+++ b/src/main/java/com/mzc/lp/domain/program/dto/response/PendingProgramResponse.java
@@ -1,0 +1,31 @@
+package com.mzc.lp.domain.program.dto.response;
+
+import com.mzc.lp.domain.program.constant.ProgramLevel;
+import com.mzc.lp.domain.program.constant.ProgramType;
+import com.mzc.lp.domain.program.entity.Program;
+
+import java.time.Instant;
+
+public record PendingProgramResponse(
+        Long id,
+        String title,
+        String thumbnailUrl,
+        ProgramLevel level,
+        ProgramType type,
+        Long creatorId,
+        Instant submittedAt,
+        Long snapshotId
+) {
+    public static PendingProgramResponse from(Program program) {
+        return new PendingProgramResponse(
+                program.getId(),
+                program.getTitle(),
+                program.getThumbnailUrl(),
+                program.getLevel(),
+                program.getType(),
+                program.getCreatorId(),
+                program.getSubmittedAt(),
+                program.getSnapshot() != null ? program.getSnapshot().getId() : null
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/program/dto/response/ProgramDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/program/dto/response/ProgramDetailResponse.java
@@ -1,0 +1,57 @@
+package com.mzc.lp.domain.program.dto.response;
+
+import com.mzc.lp.domain.program.constant.ProgramLevel;
+import com.mzc.lp.domain.program.constant.ProgramStatus;
+import com.mzc.lp.domain.program.constant.ProgramType;
+import com.mzc.lp.domain.program.entity.Program;
+
+import java.time.Instant;
+
+public record ProgramDetailResponse(
+        Long id,
+        String title,
+        String description,
+        String thumbnailUrl,
+        ProgramLevel level,
+        ProgramType type,
+        Integer estimatedHours,
+        ProgramStatus status,
+        Long creatorId,
+        Long snapshotId,
+        String snapshotName,
+        // 승인 정보
+        Long approvedBy,
+        Instant approvedAt,
+        String approvalComment,
+        // 반려 정보
+        String rejectionReason,
+        Instant rejectedAt,
+        // 제출 정보
+        Instant submittedAt,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static ProgramDetailResponse from(Program program) {
+        return new ProgramDetailResponse(
+                program.getId(),
+                program.getTitle(),
+                program.getDescription(),
+                program.getThumbnailUrl(),
+                program.getLevel(),
+                program.getType(),
+                program.getEstimatedHours(),
+                program.getStatus(),
+                program.getCreatorId(),
+                program.getSnapshot() != null ? program.getSnapshot().getId() : null,
+                program.getSnapshot() != null ? program.getSnapshot().getSnapshotName() : null,
+                program.getApprovedBy(),
+                program.getApprovedAt(),
+                program.getApprovalComment(),
+                program.getRejectionReason(),
+                program.getRejectedAt(),
+                program.getSubmittedAt(),
+                program.getCreatedAt(),
+                program.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/program/dto/response/ProgramResponse.java
+++ b/src/main/java/com/mzc/lp/domain/program/dto/response/ProgramResponse.java
@@ -1,0 +1,40 @@
+package com.mzc.lp.domain.program.dto.response;
+
+import com.mzc.lp.domain.program.constant.ProgramLevel;
+import com.mzc.lp.domain.program.constant.ProgramStatus;
+import com.mzc.lp.domain.program.constant.ProgramType;
+import com.mzc.lp.domain.program.entity.Program;
+
+import java.time.Instant;
+
+public record ProgramResponse(
+        Long id,
+        String title,
+        String description,
+        String thumbnailUrl,
+        ProgramLevel level,
+        ProgramType type,
+        Integer estimatedHours,
+        ProgramStatus status,
+        Long creatorId,
+        Long snapshotId,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static ProgramResponse from(Program program) {
+        return new ProgramResponse(
+                program.getId(),
+                program.getTitle(),
+                program.getDescription(),
+                program.getThumbnailUrl(),
+                program.getLevel(),
+                program.getType(),
+                program.getEstimatedHours(),
+                program.getStatus(),
+                program.getCreatorId(),
+                program.getSnapshot() != null ? program.getSnapshot().getId() : null,
+                program.getCreatedAt(),
+                program.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/program/entity/Program.java
+++ b/src/main/java/com/mzc/lp/domain/program/entity/Program.java
@@ -1,0 +1,215 @@
+package com.mzc.lp.domain.program.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import com.mzc.lp.domain.program.constant.ProgramLevel;
+import com.mzc.lp.domain.program.constant.ProgramStatus;
+import com.mzc.lp.domain.program.constant.ProgramType;
+import com.mzc.lp.domain.program.exception.ProgramNotModifiableException;
+import com.mzc.lp.domain.program.exception.ProgramStatusException;
+import com.mzc.lp.domain.snapshot.entity.CourseSnapshot;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "cm_programs", indexes = {
+        @Index(name = "idx_program_tenant", columnList = "tenant_id"),
+        @Index(name = "idx_program_status", columnList = "status"),
+        @Index(name = "idx_program_creator", columnList = "creator_id"),
+        @Index(name = "idx_program_snapshot", columnList = "snapshot_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Program extends TenantEntity {
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "thumbnail_url", length = 500)
+    private String thumbnailUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private ProgramLevel level;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private ProgramType type;
+
+    @Column(name = "estimated_hours")
+    private Integer estimatedHours;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "snapshot_id")
+    private CourseSnapshot snapshot;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ProgramStatus status;
+
+    @Column(name = "creator_id", nullable = false)
+    private Long creatorId;
+
+    // 승인 정보
+    @Column(name = "approved_by")
+    private Long approvedBy;
+
+    @Column(name = "approved_at")
+    private Instant approvedAt;
+
+    @Column(name = "approval_comment", length = 500)
+    private String approvalComment;
+
+    // 반려 정보
+    @Column(name = "rejection_reason", length = 500)
+    private String rejectionReason;
+
+    @Column(name = "rejected_at")
+    private Instant rejectedAt;
+
+    // 제출 정보
+    @Column(name = "submitted_at")
+    private Instant submittedAt;
+
+    // ===== 정적 팩토리 메서드 =====
+    public static Program create(String title, Long creatorId) {
+        Program program = new Program();
+        program.title = title;
+        program.creatorId = creatorId;
+        program.status = ProgramStatus.DRAFT;
+        return program;
+    }
+
+    public static Program create(String title, String description, String thumbnailUrl,
+                                  ProgramLevel level, ProgramType type, Integer estimatedHours,
+                                  Long creatorId) {
+        Program program = new Program();
+        program.title = title;
+        program.description = description;
+        program.thumbnailUrl = thumbnailUrl;
+        program.level = level;
+        program.type = type;
+        program.estimatedHours = estimatedHours;
+        program.creatorId = creatorId;
+        program.status = ProgramStatus.DRAFT;
+        return program;
+    }
+
+    // ===== 비즈니스 메서드 =====
+    public void update(String title, String description, String thumbnailUrl,
+                       ProgramLevel level, ProgramType type, Integer estimatedHours) {
+        validateModifiable();
+        if (title != null) {
+            validateTitle(title);
+            this.title = title;
+        }
+        this.description = description;
+        this.thumbnailUrl = thumbnailUrl;
+        this.level = level;
+        this.type = type;
+        this.estimatedHours = estimatedHours;
+    }
+
+    public void linkSnapshot(CourseSnapshot snapshot) {
+        validateModifiable();
+        this.snapshot = snapshot;
+    }
+
+    public void submit() {
+        if (this.status != ProgramStatus.DRAFT && this.status != ProgramStatus.REJECTED) {
+            throw new ProgramStatusException(this.status, "제출");
+        }
+        this.status = ProgramStatus.PENDING;
+        this.submittedAt = Instant.now();
+        // 반려 정보 초기화 (재제출 시)
+        this.rejectionReason = null;
+        this.rejectedAt = null;
+    }
+
+    public void approve(Long operatorId, String comment) {
+        if (this.status != ProgramStatus.PENDING) {
+            throw new ProgramStatusException(this.status, "승인");
+        }
+        this.status = ProgramStatus.APPROVED;
+        this.approvedBy = operatorId;
+        this.approvedAt = Instant.now();
+        this.approvalComment = comment;
+    }
+
+    public void reject(Long operatorId, String reason) {
+        if (this.status != ProgramStatus.PENDING) {
+            throw new ProgramStatusException(this.status, "반려");
+        }
+        validateRejectionReason(reason);
+        this.status = ProgramStatus.REJECTED;
+        this.rejectionReason = reason;
+        this.rejectedAt = Instant.now();
+    }
+
+    public void close() {
+        if (this.status != ProgramStatus.APPROVED && this.status != ProgramStatus.DRAFT) {
+            throw new ProgramStatusException(this.status, "종료");
+        }
+        this.status = ProgramStatus.CLOSED;
+    }
+
+    // ===== 상태 확인 메서드 =====
+    public boolean isDraft() {
+        return this.status == ProgramStatus.DRAFT;
+    }
+
+    public boolean isPending() {
+        return this.status == ProgramStatus.PENDING;
+    }
+
+    public boolean isApproved() {
+        return this.status == ProgramStatus.APPROVED;
+    }
+
+    public boolean isRejected() {
+        return this.status == ProgramStatus.REJECTED;
+    }
+
+    public boolean isClosed() {
+        return this.status == ProgramStatus.CLOSED;
+    }
+
+    public boolean isModifiable() {
+        return this.status == ProgramStatus.DRAFT || this.status == ProgramStatus.REJECTED;
+    }
+
+    public boolean canCreateTime() {
+        return this.status == ProgramStatus.APPROVED;
+    }
+
+    // ===== Private 검증 메서드 =====
+    private void validateModifiable() {
+        if (!isModifiable()) {
+            throw new ProgramNotModifiableException(this.status);
+        }
+    }
+
+    private void validateTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("제목은 필수입니다");
+        }
+        if (title.length() > 255) {
+            throw new IllegalArgumentException("제목은 255자 이하여야 합니다");
+        }
+    }
+
+    private void validateRejectionReason(String reason) {
+        if (reason == null || reason.isBlank()) {
+            throw new IllegalArgumentException("반려 사유는 필수입니다");
+        }
+        if (reason.length() > 500) {
+            throw new IllegalArgumentException("반려 사유는 500자 이하여야 합니다");
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/program/exception/ProgramNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/program/exception/ProgramNotFoundException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.program.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class ProgramNotFoundException extends BusinessException {
+
+    public ProgramNotFoundException() {
+        super(ErrorCode.PROGRAM_NOT_FOUND);
+    }
+
+    public ProgramNotFoundException(Long programId) {
+        super(ErrorCode.PROGRAM_NOT_FOUND, "프로그램을 찾을 수 없습니다. ID: " + programId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/program/exception/ProgramNotModifiableException.java
+++ b/src/main/java/com/mzc/lp/domain/program/exception/ProgramNotModifiableException.java
@@ -1,0 +1,13 @@
+package com.mzc.lp.domain.program.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.domain.program.constant.ProgramStatus;
+
+public class ProgramNotModifiableException extends BusinessException {
+
+    public ProgramNotModifiableException(ProgramStatus currentStatus) {
+        super(ErrorCode.PROGRAM_NOT_MODIFIABLE,
+                String.format("현재 상태(%s)에서는 수정할 수 없습니다", currentStatus));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/program/exception/ProgramStatusException.java
+++ b/src/main/java/com/mzc/lp/domain/program/exception/ProgramStatusException.java
@@ -1,0 +1,13 @@
+package com.mzc.lp.domain.program.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.domain.program.constant.ProgramStatus;
+
+public class ProgramStatusException extends BusinessException {
+
+    public ProgramStatusException(ProgramStatus currentStatus, String action) {
+        super(ErrorCode.INVALID_PROGRAM_STATUS,
+                String.format("현재 상태(%s)에서는 '%s' 작업을 수행할 수 없습니다", currentStatus, action));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/program/repository/ProgramRepository.java
+++ b/src/main/java/com/mzc/lp/domain/program/repository/ProgramRepository.java
@@ -1,0 +1,37 @@
+package com.mzc.lp.domain.program.repository;
+
+import com.mzc.lp.domain.program.constant.ProgramStatus;
+import com.mzc.lp.domain.program.entity.Program;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ProgramRepository extends JpaRepository<Program, Long> {
+
+    Optional<Program> findByIdAndTenantId(Long id, Long tenantId);
+
+    Page<Program> findByTenantId(Long tenantId, Pageable pageable);
+
+    Page<Program> findByTenantIdAndStatus(Long tenantId, ProgramStatus status, Pageable pageable);
+
+    Page<Program> findByTenantIdAndCreatorId(Long tenantId, Long creatorId, Pageable pageable);
+
+    Page<Program> findByTenantIdAndStatusAndCreatorId(Long tenantId, ProgramStatus status, Long creatorId, Pageable pageable);
+
+    @Query("SELECT p FROM Program p WHERE p.tenantId = :tenantId AND p.status = 'PENDING' ORDER BY p.submittedAt ASC")
+    Page<Program> findPendingPrograms(@Param("tenantId") Long tenantId, Pageable pageable);
+
+    @Query("SELECT COUNT(p) FROM Program p WHERE p.tenantId = :tenantId AND p.status = 'PENDING'")
+    long countPendingPrograms(@Param("tenantId") Long tenantId);
+
+    @Query("SELECT p FROM Program p LEFT JOIN FETCH p.snapshot WHERE p.id = :id AND p.tenantId = :tenantId")
+    Optional<Program> findByIdWithSnapshot(@Param("id") Long id, @Param("tenantId") Long tenantId);
+
+    boolean existsByIdAndTenantId(Long id, Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/program/service/ProgramService.java
+++ b/src/main/java/com/mzc/lp/domain/program/service/ProgramService.java
@@ -1,0 +1,40 @@
+package com.mzc.lp.domain.program.service;
+
+import com.mzc.lp.domain.program.constant.ProgramStatus;
+import com.mzc.lp.domain.program.dto.request.ApproveRequest;
+import com.mzc.lp.domain.program.dto.request.CreateProgramRequest;
+import com.mzc.lp.domain.program.dto.request.RejectRequest;
+import com.mzc.lp.domain.program.dto.request.UpdateProgramRequest;
+import com.mzc.lp.domain.program.dto.response.PendingProgramResponse;
+import com.mzc.lp.domain.program.dto.response.ProgramDetailResponse;
+import com.mzc.lp.domain.program.dto.response.ProgramResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ProgramService {
+
+    // CRUD
+    ProgramResponse createProgram(CreateProgramRequest request, Long creatorId);
+
+    ProgramDetailResponse getProgram(Long programId);
+
+    Page<ProgramResponse> getPrograms(ProgramStatus status, Long creatorId, Pageable pageable);
+
+    ProgramResponse updateProgram(Long programId, UpdateProgramRequest request);
+
+    void deleteProgram(Long programId);
+
+    // 워크플로우
+    ProgramResponse submitProgram(Long programId);
+
+    Page<PendingProgramResponse> getPendingPrograms(Pageable pageable);
+
+    ProgramDetailResponse approveProgram(Long programId, ApproveRequest request, Long operatorId);
+
+    ProgramDetailResponse rejectProgram(Long programId, RejectRequest request, Long operatorId);
+
+    ProgramResponse closeProgram(Long programId);
+
+    // Snapshot 연결
+    ProgramResponse linkSnapshot(Long programId, Long snapshotId);
+}

--- a/src/main/java/com/mzc/lp/domain/program/service/ProgramServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/program/service/ProgramServiceImpl.java
@@ -1,0 +1,211 @@
+package com.mzc.lp.domain.program.service;
+
+import com.mzc.lp.domain.program.constant.ProgramStatus;
+import com.mzc.lp.domain.program.dto.request.ApproveRequest;
+import com.mzc.lp.domain.program.dto.request.CreateProgramRequest;
+import com.mzc.lp.domain.program.dto.request.RejectRequest;
+import com.mzc.lp.domain.program.dto.request.UpdateProgramRequest;
+import com.mzc.lp.domain.program.dto.response.PendingProgramResponse;
+import com.mzc.lp.domain.program.dto.response.ProgramDetailResponse;
+import com.mzc.lp.domain.program.dto.response.ProgramResponse;
+import com.mzc.lp.domain.program.entity.Program;
+import com.mzc.lp.domain.program.exception.ProgramNotFoundException;
+import com.mzc.lp.domain.program.repository.ProgramRepository;
+import com.mzc.lp.domain.snapshot.entity.CourseSnapshot;
+import com.mzc.lp.domain.snapshot.exception.SnapshotNotFoundException;
+import com.mzc.lp.domain.snapshot.repository.CourseSnapshotRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProgramServiceImpl implements ProgramService {
+
+    private static final Long DEFAULT_TENANT_ID = 1L;
+
+    private final ProgramRepository programRepository;
+    private final CourseSnapshotRepository snapshotRepository;
+
+    @Override
+    @Transactional
+    public ProgramResponse createProgram(CreateProgramRequest request, Long creatorId) {
+        log.info("Creating program: title={}, creatorId={}", request.title(), creatorId);
+
+        Program program = Program.create(
+                request.title(),
+                request.description(),
+                request.thumbnailUrl(),
+                request.level(),
+                request.type(),
+                request.estimatedHours(),
+                creatorId
+        );
+
+        // Snapshot 연결 (선택)
+        if (request.snapshotId() != null) {
+            CourseSnapshot snapshot = snapshotRepository.findByIdAndTenantId(request.snapshotId(), DEFAULT_TENANT_ID)
+                    .orElseThrow(() -> new SnapshotNotFoundException(request.snapshotId()));
+            program.linkSnapshot(snapshot);
+        }
+
+        Program savedProgram = programRepository.save(program);
+        log.info("Program created: id={}", savedProgram.getId());
+
+        return ProgramResponse.from(savedProgram);
+    }
+
+    @Override
+    public ProgramDetailResponse getProgram(Long programId) {
+        log.debug("Getting program: id={}", programId);
+
+        Program program = programRepository.findByIdWithSnapshot(programId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new ProgramNotFoundException(programId));
+
+        return ProgramDetailResponse.from(program);
+    }
+
+    @Override
+    public Page<ProgramResponse> getPrograms(ProgramStatus status, Long creatorId, Pageable pageable) {
+        log.debug("Getting programs: status={}, creatorId={}", status, creatorId);
+
+        Page<Program> programs;
+
+        if (status != null && creatorId != null) {
+            programs = programRepository.findByTenantIdAndStatusAndCreatorId(DEFAULT_TENANT_ID, status, creatorId, pageable);
+        } else if (status != null) {
+            programs = programRepository.findByTenantIdAndStatus(DEFAULT_TENANT_ID, status, pageable);
+        } else if (creatorId != null) {
+            programs = programRepository.findByTenantIdAndCreatorId(DEFAULT_TENANT_ID, creatorId, pageable);
+        } else {
+            programs = programRepository.findByTenantId(DEFAULT_TENANT_ID, pageable);
+        }
+
+        return programs.map(ProgramResponse::from);
+    }
+
+    @Override
+    @Transactional
+    public ProgramResponse updateProgram(Long programId, UpdateProgramRequest request) {
+        log.info("Updating program: id={}", programId);
+
+        Program program = programRepository.findByIdAndTenantId(programId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new ProgramNotFoundException(programId));
+
+        program.update(
+                request.title(),
+                request.description(),
+                request.thumbnailUrl(),
+                request.level(),
+                request.type(),
+                request.estimatedHours()
+        );
+
+        log.info("Program updated: id={}", programId);
+        return ProgramResponse.from(program);
+    }
+
+    @Override
+    @Transactional
+    public void deleteProgram(Long programId) {
+        log.info("Deleting program: id={}", programId);
+
+        Program program = programRepository.findByIdAndTenantId(programId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new ProgramNotFoundException(programId));
+
+        // DRAFT 상태에서만 삭제 가능
+        if (!program.isDraft()) {
+            program.close();
+            log.info("Program closed instead of deleted: id={}", programId);
+        } else {
+            programRepository.delete(program);
+            log.info("Program deleted: id={}", programId);
+        }
+    }
+
+    @Override
+    @Transactional
+    public ProgramResponse submitProgram(Long programId) {
+        log.info("Submitting program: id={}", programId);
+
+        Program program = programRepository.findByIdAndTenantId(programId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new ProgramNotFoundException(programId));
+
+        program.submit();
+
+        log.info("Program submitted: id={}, status={}", programId, program.getStatus());
+        return ProgramResponse.from(program);
+    }
+
+    @Override
+    public Page<PendingProgramResponse> getPendingPrograms(Pageable pageable) {
+        log.debug("Getting pending programs");
+
+        Page<Program> pendingPrograms = programRepository.findPendingPrograms(DEFAULT_TENANT_ID, pageable);
+        return pendingPrograms.map(PendingProgramResponse::from);
+    }
+
+    @Override
+    @Transactional
+    public ProgramDetailResponse approveProgram(Long programId, ApproveRequest request, Long operatorId) {
+        log.info("Approving program: id={}, operatorId={}", programId, operatorId);
+
+        Program program = programRepository.findByIdWithSnapshot(programId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new ProgramNotFoundException(programId));
+
+        program.approve(operatorId, request != null ? request.comment() : null);
+
+        log.info("Program approved: id={}, approvedBy={}", programId, operatorId);
+        return ProgramDetailResponse.from(program);
+    }
+
+    @Override
+    @Transactional
+    public ProgramDetailResponse rejectProgram(Long programId, RejectRequest request, Long operatorId) {
+        log.info("Rejecting program: id={}, operatorId={}", programId, operatorId);
+
+        Program program = programRepository.findByIdWithSnapshot(programId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new ProgramNotFoundException(programId));
+
+        program.reject(operatorId, request.reason());
+
+        log.info("Program rejected: id={}, reason={}", programId, request.reason());
+        return ProgramDetailResponse.from(program);
+    }
+
+    @Override
+    @Transactional
+    public ProgramResponse closeProgram(Long programId) {
+        log.info("Closing program: id={}", programId);
+
+        Program program = programRepository.findByIdAndTenantId(programId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new ProgramNotFoundException(programId));
+
+        program.close();
+
+        log.info("Program closed: id={}", programId);
+        return ProgramResponse.from(program);
+    }
+
+    @Override
+    @Transactional
+    public ProgramResponse linkSnapshot(Long programId, Long snapshotId) {
+        log.info("Linking snapshot to program: programId={}, snapshotId={}", programId, snapshotId);
+
+        Program program = programRepository.findByIdAndTenantId(programId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new ProgramNotFoundException(programId));
+
+        CourseSnapshot snapshot = snapshotRepository.findByIdAndTenantId(snapshotId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new SnapshotNotFoundException(snapshotId));
+
+        program.linkSnapshot(snapshot);
+
+        log.info("Snapshot linked to program: programId={}, snapshotId={}", programId, snapshotId);
+        return ProgramResponse.from(program);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/entity/CourseTime.java
+++ b/src/main/java/com/mzc/lp/domain/ts/entity/CourseTime.java
@@ -1,6 +1,7 @@
 package com.mzc.lp.domain.ts.entity;
 
 import com.mzc.lp.common.entity.TenantEntity;
+import com.mzc.lp.domain.program.entity.Program;
 import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
 import com.mzc.lp.domain.ts.constant.DeliveryType;
 import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
@@ -15,16 +16,24 @@ import java.time.LocalDate;
 @Entity
 @Table(name = "course_times", indexes = {
         @Index(name = "idx_course_times_status", columnList = "tenant_id, status"),
-        @Index(name = "idx_course_times_course", columnList = "tenant_id, cm_course_id")
+        @Index(name = "idx_course_times_course", columnList = "tenant_id, cm_course_id"),
+        @Index(name = "idx_course_times_program", columnList = "tenant_id, program_id")
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CourseTime extends TenantEntity {
 
-    // CM 연결 (CM 구현 전까지 nullable)
+    // Program 연결 (승인된 프로그램과 연결)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "program_id")
+    private Program program;
+
+    // CM 연결 (deprecated - Program을 통해 Snapshot으로 연결됨)
+    @Deprecated
     @Column(name = "cm_course_id")
     private Long cmCourseId;
 
+    @Deprecated
     @Column(name = "cm_course_version_id")
     private Long cmCourseVersionId;
 
@@ -170,6 +179,17 @@ public class CourseTime extends TenantEntity {
 
     // 비즈니스 메서드
 
+    /**
+     * 승인된 Program과 연결
+     */
+    public void linkProgram(Program program) {
+        this.program = program;
+    }
+
+    /**
+     * @deprecated Program을 통해 Snapshot으로 연결하세요
+     */
+    @Deprecated
     public void linkCourse(Long cmCourseId, Long cmCourseVersionId) {
         this.cmCourseId = cmCourseId;
         this.cmCourseVersionId = cmCourseVersionId;

--- a/src/main/java/com/mzc/lp/domain/user/constant/TenantRole.java
+++ b/src/main/java/com/mzc/lp/domain/user/constant/TenantRole.java
@@ -4,5 +4,6 @@ public enum TenantRole {
     SYSTEM_ADMIN,   // 시스템 최고 관리자 (테넌트 관리)
     TENANT_ADMIN,   // 테넌트 최고 관리자
     OPERATOR,       // 운영자 (강의 검토, 차수 생성, 역할 부여)
+    DESIGNER,       // 설계자 (강의 개설 신청)
     USER            // 일반 사용자 (수강)
 }

--- a/src/test/java/com/mzc/lp/domain/program/controller/ProgramControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/program/controller/ProgramControllerTest.java
@@ -1,0 +1,739 @@
+package com.mzc.lp.domain.program.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.program.constant.ProgramLevel;
+import com.mzc.lp.domain.program.constant.ProgramStatus;
+import com.mzc.lp.domain.program.constant.ProgramType;
+import com.mzc.lp.domain.program.dto.request.ApproveRequest;
+import com.mzc.lp.domain.program.dto.request.CreateProgramRequest;
+import com.mzc.lp.domain.program.dto.request.RejectRequest;
+import com.mzc.lp.domain.program.dto.request.UpdateProgramRequest;
+import com.mzc.lp.domain.program.entity.Program;
+import com.mzc.lp.domain.program.repository.ProgramRepository;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ProgramControllerTest extends TenantTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ProgramRepository programRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private UserCourseRoleRepository userCourseRoleRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        programRepository.deleteAll();
+        userCourseRoleRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ===== 헬퍼 메서드 =====
+
+    private User createDesignerUser() {
+        User user = User.create("designer@example.com", "설계자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.DESIGNER);
+        return userRepository.save(user);
+    }
+
+    private User createOperatorUser() {
+        User user = User.create("operator@example.com", "운영자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.OPERATOR);
+        return userRepository.save(user);
+    }
+
+    private User createRegularUser() {
+        User user = User.create("user@example.com", "일반사용자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.USER);
+        return userRepository.save(user);
+    }
+
+    private String loginAndGetAccessToken(String email, String password) throws Exception {
+        LoginRequest request = new LoginRequest(email, password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("data").get("accessToken").asText();
+    }
+
+    private Program createTestProgram(String title, Long creatorId) {
+        Program program = Program.create(
+                title,
+                "테스트 프로그램 설명",
+                null,
+                ProgramLevel.BEGINNER,
+                ProgramType.ONLINE,
+                10,
+                creatorId
+        );
+        return programRepository.save(program);
+    }
+
+    private Program createTestProgramWithStatus(String title, Long creatorId, ProgramStatus status) {
+        Program program = createTestProgram(title, creatorId);
+
+        if (status == ProgramStatus.PENDING) {
+            program.submit();
+        } else if (status == ProgramStatus.APPROVED) {
+            program.submit();
+            program.approve(1L, "승인합니다");
+        } else if (status == ProgramStatus.REJECTED) {
+            program.submit();
+            program.reject(1L, "반려 사유");
+        } else if (status == ProgramStatus.CLOSED) {
+            program.submit();
+            program.approve(1L, "승인합니다");
+            program.close();
+        }
+
+        return programRepository.save(program);
+    }
+
+    // ==================== 프로그램 생성 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/programs - 프로그램 생성")
+    class CreateProgram {
+
+        @Test
+        @DisplayName("성공 - DESIGNER가 프로그램 생성")
+        void createProgram_success() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            CreateProgramRequest request = new CreateProgramRequest(
+                    "Spring Boot 기초",
+                    "Spring Boot 기초 강의입니다.",
+                    null,
+                    ProgramLevel.BEGINNER,
+                    ProgramType.ONLINE,
+                    20,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/programs")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.title").value("Spring Boot 기초"))
+                    .andExpect(jsonPath("$.data.status").value("DRAFT"))
+                    .andExpect(jsonPath("$.data.creatorId").value(designer.getId()));
+        }
+
+        @Test
+        @DisplayName("성공 - OPERATOR가 프로그램 생성")
+        void createProgram_success_operator() throws Exception {
+            // given
+            User operator = createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CreateProgramRequest request = new CreateProgramRequest(
+                    "Java 심화",
+                    "Java 심화 강의입니다.",
+                    null,
+                    ProgramLevel.ADVANCED,
+                    ProgramType.BLENDED,
+                    30,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/programs")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.title").value("Java 심화"))
+                    .andExpect(jsonPath("$.data.level").value("ADVANCED"))
+                    .andExpect(jsonPath("$.data.type").value("BLENDED"));
+        }
+
+        @Test
+        @DisplayName("실패 - 제목 누락")
+        void createProgram_fail_missingTitle() throws Exception {
+            // given
+            createDesignerUser();
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            CreateProgramRequest request = new CreateProgramRequest(
+                    null,
+                    "설명만 있음",
+                    null,
+                    ProgramLevel.BEGINNER,
+                    ProgramType.ONLINE,
+                    10,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/programs")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 생성 시도")
+        void createProgram_fail_userRole() throws Exception {
+            // given
+            createRegularUser();
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+            CreateProgramRequest request = new CreateProgramRequest(
+                    "테스트 프로그램",
+                    "설명",
+                    null,
+                    ProgramLevel.BEGINNER,
+                    ProgramType.ONLINE,
+                    10,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/programs")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 프로그램 목록 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/programs - 프로그램 목록 조회")
+    class GetPrograms {
+
+        @Test
+        @DisplayName("성공 - 전체 프로그램 목록 조회")
+        void getPrograms_success() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            createTestProgram("프로그램1", designer.getId());
+            createTestProgram("프로그램2", designer.getId());
+            createTestProgram("프로그램3", designer.getId());
+
+            // when & then
+            mockMvc.perform(get("/api/programs")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.totalElements").value(3));
+        }
+
+        @Test
+        @DisplayName("성공 - 상태 필터링")
+        void getPrograms_success_statusFilter() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            createTestProgramWithStatus("DRAFT 프로그램", designer.getId(), ProgramStatus.DRAFT);
+            createTestProgramWithStatus("PENDING 프로그램", designer.getId(), ProgramStatus.PENDING);
+            createTestProgramWithStatus("APPROVED 프로그램", designer.getId(), ProgramStatus.APPROVED);
+
+            // when & then
+            mockMvc.perform(get("/api/programs")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("status", "PENDING"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.totalElements").value(1));
+        }
+
+        @Test
+        @DisplayName("성공 - 생성자 필터링")
+        void getPrograms_success_creatorFilter() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            User operator = createOperatorUser();
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            createTestProgram("디자이너 프로그램1", designer.getId());
+            createTestProgram("디자이너 프로그램2", designer.getId());
+            createTestProgram("운영자 프로그램", operator.getId());
+
+            // when & then
+            mockMvc.perform(get("/api/programs")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("creatorId", designer.getId().toString()))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.totalElements").value(2));
+        }
+    }
+
+    // ==================== 프로그램 상세 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/programs/{programId} - 프로그램 상세 조회")
+    class GetProgramDetail {
+
+        @Test
+        @DisplayName("성공 - 프로그램 상세 조회")
+        void getProgramDetail_success() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            Program program = createTestProgram("테스트 프로그램", designer.getId());
+
+            // when & then
+            mockMvc.perform(get("/api/programs/{programId}", program.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.id").value(program.getId()))
+                    .andExpect(jsonPath("$.data.title").value("테스트 프로그램"));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 프로그램")
+        void getProgramDetail_fail_notFound() throws Exception {
+            // given
+            createDesignerUser();
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/programs/{programId}", 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("PG001"));
+        }
+    }
+
+    // ==================== 프로그램 수정 테스트 ====================
+
+    @Nested
+    @DisplayName("PUT /api/programs/{programId} - 프로그램 수정")
+    class UpdateProgram {
+
+        @Test
+        @DisplayName("성공 - DRAFT 상태에서 수정")
+        void updateProgram_success_draft() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            Program program = createTestProgram("원래 제목", designer.getId());
+            UpdateProgramRequest request = new UpdateProgramRequest(
+                    "수정된 제목",
+                    "수정된 설명",
+                    null,
+                    ProgramLevel.INTERMEDIATE,
+                    ProgramType.OFFLINE,
+                    15
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/programs/{programId}", program.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.title").value("수정된 제목"))
+                    .andExpect(jsonPath("$.data.level").value("INTERMEDIATE"))
+                    .andExpect(jsonPath("$.data.type").value("OFFLINE"));
+        }
+
+        @Test
+        @DisplayName("실패 - APPROVED 상태에서 수정 시도")
+        void updateProgram_fail_approved() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            Program program = createTestProgramWithStatus("승인된 프로그램", designer.getId(), ProgramStatus.APPROVED);
+            UpdateProgramRequest request = new UpdateProgramRequest(
+                    "수정 시도",
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/programs/{programId}", program.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("PG003"));
+        }
+    }
+
+    // ==================== 프로그램 삭제 테스트 ====================
+
+    @Nested
+    @DisplayName("DELETE /api/programs/{programId} - 프로그램 삭제")
+    class DeleteProgram {
+
+        @Test
+        @DisplayName("성공 - DRAFT 상태 프로그램 삭제")
+        void deleteProgram_success() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            Program program = createTestProgram("삭제할 프로그램", designer.getId());
+
+            // when & then
+            mockMvc.perform(delete("/api/programs/{programId}", program.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+
+            // 삭제 확인
+            mockMvc.perform(get("/api/programs/{programId}", program.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 프로그램")
+        void deleteProgram_fail_notFound() throws Exception {
+            // given
+            createDesignerUser();
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(delete("/api/programs/{programId}", 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("PG001"));
+        }
+    }
+
+    // ==================== 프로그램 제출 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/programs/{programId}/submit - 프로그램 제출")
+    class SubmitProgram {
+
+        @Test
+        @DisplayName("성공 - DRAFT → PENDING 제출")
+        void submitProgram_success() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            Program program = createTestProgram("제출할 프로그램", designer.getId());
+
+            // when & then
+            mockMvc.perform(post("/api/programs/{programId}/submit", program.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.status").value("PENDING"));
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 PENDING 상태에서 제출 시도")
+        void submitProgram_fail_alreadyPending() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            Program program = createTestProgramWithStatus("이미 제출됨", designer.getId(), ProgramStatus.PENDING);
+
+            // when & then
+            mockMvc.perform(post("/api/programs/{programId}/submit", program.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("PG002"));
+        }
+    }
+
+    // ==================== 검토 대기 목록 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/programs/pending - 검토 대기 목록 조회")
+    class GetPendingPrograms {
+
+        @Test
+        @DisplayName("성공 - OPERATOR가 검토 대기 목록 조회")
+        void getPendingPrograms_success() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            User operator = createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            createTestProgramWithStatus("PENDING 프로그램1", designer.getId(), ProgramStatus.PENDING);
+            createTestProgramWithStatus("PENDING 프로그램2", designer.getId(), ProgramStatus.PENDING);
+            createTestProgramWithStatus("DRAFT 프로그램", designer.getId(), ProgramStatus.DRAFT);
+
+            // when & then
+            mockMvc.perform(get("/api/programs/pending")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.totalElements").value(2));
+        }
+
+        @Test
+        @DisplayName("실패 - DESIGNER는 검토 대기 목록 접근 불가")
+        void getPendingPrograms_fail_designerRole() throws Exception {
+            // given
+            createDesignerUser();
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/programs/pending")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 프로그램 승인 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/programs/{programId}/approve - 프로그램 승인")
+    class ApproveProgram {
+
+        @Test
+        @DisplayName("성공 - PENDING → APPROVED 승인")
+        void approveProgram_success() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Program program = createTestProgramWithStatus("승인 대기 프로그램", designer.getId(), ProgramStatus.PENDING);
+            ApproveRequest request = new ApproveRequest("잘 작성되었습니다.");
+
+            // when & then
+            mockMvc.perform(post("/api/programs/{programId}/approve", program.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.status").value("APPROVED"))
+                    .andExpect(jsonPath("$.data.approvalComment").value("잘 작성되었습니다."));
+        }
+
+        @Test
+        @DisplayName("성공 - 코멘트 없이 승인")
+        void approveProgram_success_noComment() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Program program = createTestProgramWithStatus("승인 대기 프로그램", designer.getId(), ProgramStatus.PENDING);
+
+            // when & then
+            mockMvc.perform(post("/api/programs/{programId}/approve", program.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.status").value("APPROVED"));
+        }
+
+        @Test
+        @DisplayName("실패 - DRAFT 상태에서 승인 시도")
+        void approveProgram_fail_draft() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Program program = createTestProgram("DRAFT 프로그램", designer.getId());
+
+            // when & then
+            mockMvc.perform(post("/api/programs/{programId}/approve", program.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("PG002"));
+        }
+
+        @Test
+        @DisplayName("실패 - DESIGNER는 승인 불가")
+        void approveProgram_fail_designerRole() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+            Program program = createTestProgramWithStatus("승인 대기 프로그램", designer.getId(), ProgramStatus.PENDING);
+
+            // when & then
+            mockMvc.perform(post("/api/programs/{programId}/approve", program.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 프로그램 반려 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/programs/{programId}/reject - 프로그램 반려")
+    class RejectProgram {
+
+        @Test
+        @DisplayName("성공 - PENDING → REJECTED 반려")
+        void rejectProgram_success() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Program program = createTestProgramWithStatus("반려 대기 프로그램", designer.getId(), ProgramStatus.PENDING);
+            RejectRequest request = new RejectRequest("내용이 부족합니다. 보완해주세요.");
+
+            // when & then
+            mockMvc.perform(post("/api/programs/{programId}/reject", program.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.status").value("REJECTED"))
+                    .andExpect(jsonPath("$.data.rejectionReason").value("내용이 부족합니다. 보완해주세요."));
+        }
+
+        @Test
+        @DisplayName("실패 - 반려 사유 누락")
+        void rejectProgram_fail_missingReason() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Program program = createTestProgramWithStatus("반려 대기 프로그램", designer.getId(), ProgramStatus.PENDING);
+            RejectRequest request = new RejectRequest(null);
+
+            // when & then
+            mockMvc.perform(post("/api/programs/{programId}/reject", program.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("실패 - DRAFT 상태에서 반려 시도")
+        void rejectProgram_fail_draft() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Program program = createTestProgram("DRAFT 프로그램", designer.getId());
+            RejectRequest request = new RejectRequest("반려 사유");
+
+            // when & then
+            mockMvc.perform(post("/api/programs/{programId}/reject", program.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("PG002"));
+        }
+    }
+
+    // ==================== 프로그램 종료 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/programs/{programId}/close - 프로그램 종료")
+    class CloseProgram {
+
+        @Test
+        @DisplayName("성공 - APPROVED → CLOSED 종료")
+        void closeProgram_success() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Program program = createTestProgramWithStatus("승인된 프로그램", designer.getId(), ProgramStatus.APPROVED);
+
+            // when & then
+            mockMvc.perform(post("/api/programs/{programId}/close", program.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.status").value("CLOSED"));
+        }
+
+        @Test
+        @DisplayName("실패 - PENDING 상태에서 종료 시도")
+        void closeProgram_fail_pending() throws Exception {
+            // given
+            User designer = createDesignerUser();
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Program program = createTestProgramWithStatus("승인 대기 프로그램", designer.getId(), ProgramStatus.PENDING);
+
+            // when & then
+            mockMvc.perform(post("/api/programs/{programId}/close", program.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("PG002"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Program Entity 신규 구현 (강의 개설 신청/승인 워크플로우)
- 승인 상태 전이: DRAFT → PENDING → APPROVED/REJECTED → CLOSED
- TenantRole에 DESIGNER 역할 추가
- CourseTime과 Program 연결 구조 추가

## 구현 내용

### 신규 파일 (20개)
- **Constant**: ProgramStatus, ProgramLevel, ProgramType
- **Entity**: Program (cm_programs 테이블)
- **Repository**: ProgramRepository
- **DTO**: Request 4개, Response 3개
- **Exception**: ProgramNotFoundException, ProgramStatusException, ProgramNotModifiableException
- **Service**: ProgramService (인터페이스/구현체)
- **Controller**: ProgramController (9개 API)
- **Test**: ProgramControllerTest (26개 테스트)

### 수정 파일 (3개)
- ErrorCode.java: PG001-PG005 에러코드 추가
- TenantRole.java: DESIGNER 역할 추가
- CourseTime.java: Program 연결 필드 추가

### API 엔드포인트
| Method | Endpoint | 설명 |
|--------|----------|------|
| POST | `/api/programs` | 프로그램 생성 |
| GET | `/api/programs` | 목록 조회 |
| GET | `/api/programs/{id}` | 상세 조회 |
| PUT | `/api/programs/{id}` | 수정 |
| DELETE | `/api/programs/{id}` | 삭제 |
| POST | `/api/programs/{id}/submit` | 승인 요청 |
| POST | `/api/programs/{id}/approve` | 승인 |
| POST | `/api/programs/{id}/reject` | 반려 |
| POST | `/api/programs/{id}/close` | 종료 |

## Test plan

- [x] `./gradlew compileJava` - BUILD SUCCESSFUL
- [x] `./gradlew test --tests "*ProgramControllerTest*"` - 26개 테스트 PASSED
- [x] 로컬 환경에서 API 테스트 완료

## Related Issue

Closes #120