### PR TITLE
[Feat] SnapshotItem/Relation API 구현

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     CM_SNAPSHOT_NOT_FOUND(HttpStatus.NOT_FOUND, "CM006", "Snapshot not found"),
     CM_SNAPSHOT_STATE_ERROR(HttpStatus.BAD_REQUEST, "CM007", "Invalid snapshot state"),
     CM_LEARNING_OBJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "CM008", "LearningObject not found"),
+    CM_SNAPSHOT_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "CM009", "SnapshotItem not found"),
 
     // Content (CMS)
     CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CT001", "Content not found"),

--- a/src/main/java/com/mzc/lp/domain/snapshot/controller/SnapshotItemController.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/controller/SnapshotItemController.java
@@ -1,0 +1,117 @@
+package com.mzc.lp.domain.snapshot.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.snapshot.dto.request.CreateSnapshotItemRequest;
+import com.mzc.lp.domain.snapshot.dto.request.MoveSnapshotItemRequest;
+import com.mzc.lp.domain.snapshot.dto.request.UpdateSnapshotItemRequest;
+import com.mzc.lp.domain.snapshot.dto.response.SnapshotItemResponse;
+import com.mzc.lp.domain.snapshot.service.SnapshotItemService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/snapshots/{snapshotId}/items")
+@RequiredArgsConstructor
+@Validated
+public class SnapshotItemController {
+
+    private final SnapshotItemService snapshotItemService;
+
+    /**
+     * 아이템 계층 구조 조회
+     * GET /api/snapshots/{snapshotId}/items
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<SnapshotItemResponse>>> getHierarchy(
+            @PathVariable @Positive Long snapshotId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<SnapshotItemResponse> response = snapshotItemService.getHierarchy(snapshotId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 아이템 평면 목록 조회
+     * GET /api/snapshots/{snapshotId}/items/flat
+     */
+    @GetMapping("/flat")
+    public ResponseEntity<ApiResponse<List<SnapshotItemResponse>>> getFlatItems(
+            @PathVariable @Positive Long snapshotId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<SnapshotItemResponse> response = snapshotItemService.getFlatItems(snapshotId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 아이템 추가 (DRAFT 상태에서만)
+     * POST /api/snapshots/{snapshotId}/items
+     */
+    @PostMapping
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<SnapshotItemResponse>> createItem(
+            @PathVariable @Positive Long snapshotId,
+            @Valid @RequestBody CreateSnapshotItemRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        SnapshotItemResponse response = snapshotItemService.createItem(snapshotId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 아이템 수정 (이름 변경)
+     * PUT /api/snapshots/{snapshotId}/items/{itemId}
+     */
+    @PutMapping("/{itemId}")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<SnapshotItemResponse>> updateItem(
+            @PathVariable @Positive Long snapshotId,
+            @PathVariable @Positive Long itemId,
+            @Valid @RequestBody UpdateSnapshotItemRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        SnapshotItemResponse response = snapshotItemService.updateItem(snapshotId, itemId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 아이템 이동 (DRAFT 상태에서만)
+     * PUT /api/snapshots/{snapshotId}/items/{itemId}/move
+     */
+    @PutMapping("/{itemId}/move")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<SnapshotItemResponse>> moveItem(
+            @PathVariable @Positive Long snapshotId,
+            @PathVariable @Positive Long itemId,
+            @Valid @RequestBody MoveSnapshotItemRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        SnapshotItemResponse response = snapshotItemService.moveItem(snapshotId, itemId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 아이템 삭제 (DRAFT 상태에서만)
+     * DELETE /api/snapshots/{snapshotId}/items/{itemId}
+     */
+    @DeleteMapping("/{itemId}")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> deleteItem(
+            @PathVariable @Positive Long snapshotId,
+            @PathVariable @Positive Long itemId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        snapshotItemService.deleteItem(snapshotId, itemId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/controller/SnapshotRelationController.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/controller/SnapshotRelationController.java
@@ -1,0 +1,99 @@
+package com.mzc.lp.domain.snapshot.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.snapshot.dto.request.CreateSnapshotRelationRequest;
+import com.mzc.lp.domain.snapshot.dto.request.SetStartSnapshotItemRequest;
+import com.mzc.lp.domain.snapshot.dto.response.SnapshotRelationResponse;
+import com.mzc.lp.domain.snapshot.service.SnapshotRelationService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/snapshots/{snapshotId}/relations")
+@RequiredArgsConstructor
+@Validated
+public class SnapshotRelationController {
+
+    private final SnapshotRelationService snapshotRelationService;
+
+    /**
+     * 연결 목록 조회
+     * GET /api/snapshots/{snapshotId}/relations
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<SnapshotRelationResponse.SnapshotRelationsResponse>> getRelations(
+            @PathVariable @Positive Long snapshotId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        SnapshotRelationResponse.SnapshotRelationsResponse response = snapshotRelationService.getRelations(snapshotId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 순서대로 아이템 조회
+     * GET /api/snapshots/{snapshotId}/relations/ordered
+     */
+    @GetMapping("/ordered")
+    public ResponseEntity<ApiResponse<List<SnapshotRelationResponse.OrderedItem>>> getOrderedItems(
+            @PathVariable @Positive Long snapshotId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<SnapshotRelationResponse.OrderedItem> response = snapshotRelationService.getOrderedItems(snapshotId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 연결 생성
+     * POST /api/snapshots/{snapshotId}/relations
+     */
+    @PostMapping
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<SnapshotRelationResponse>> createRelation(
+            @PathVariable @Positive Long snapshotId,
+            @Valid @RequestBody CreateSnapshotRelationRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        SnapshotRelationResponse response = snapshotRelationService.createRelation(snapshotId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 시작점 설정
+     * PUT /api/snapshots/{snapshotId}/relations/start
+     */
+    @PutMapping("/start")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<SnapshotRelationResponse>> setStartItem(
+            @PathVariable @Positive Long snapshotId,
+            @Valid @RequestBody SetStartSnapshotItemRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        SnapshotRelationResponse response = snapshotRelationService.setStartItem(snapshotId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 연결 삭제
+     * DELETE /api/snapshots/{snapshotId}/relations/{relationId}
+     */
+    @DeleteMapping("/{relationId}")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> deleteRelation(
+            @PathVariable @Positive Long snapshotId,
+            @PathVariable @Positive Long relationId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        snapshotRelationService.deleteRelation(snapshotId, relationId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/dto/request/CreateSnapshotRelationRequest.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/dto/request/CreateSnapshotRelationRequest.java
@@ -1,0 +1,13 @@
+package com.mzc.lp.domain.snapshot.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record CreateSnapshotRelationRequest(
+        Long fromItemId,
+
+        @NotNull(message = "대상 항목 ID는 필수입니다")
+        @Positive(message = "대상 항목 ID는 양수여야 합니다")
+        Long toItemId
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/dto/request/MoveSnapshotItemRequest.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/dto/request/MoveSnapshotItemRequest.java
@@ -1,0 +1,6 @@
+package com.mzc.lp.domain.snapshot.dto.request;
+
+public record MoveSnapshotItemRequest(
+        Long newParentId
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/dto/request/SetStartSnapshotItemRequest.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/dto/request/SetStartSnapshotItemRequest.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.snapshot.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record SetStartSnapshotItemRequest(
+        @NotNull(message = "시작 항목 ID는 필수입니다")
+        @Positive(message = "시작 항목 ID는 양수여야 합니다")
+        Long itemId
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/dto/request/UpdateSnapshotItemRequest.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/dto/request/UpdateSnapshotItemRequest.java
@@ -1,0 +1,16 @@
+package com.mzc.lp.domain.snapshot.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateSnapshotItemRequest(
+        @NotBlank(message = "항목 이름은 필수입니다")
+        @Size(max = 255, message = "항목 이름은 255자 이하여야 합니다")
+        String itemName
+) {
+    public UpdateSnapshotItemRequest {
+        if (itemName != null) {
+            itemName = itemName.trim();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/dto/response/SnapshotRelationResponse.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/dto/response/SnapshotRelationResponse.java
@@ -1,0 +1,55 @@
+package com.mzc.lp.domain.snapshot.dto.response;
+
+import com.mzc.lp.domain.snapshot.entity.SnapshotRelation;
+
+import java.time.Instant;
+import java.util.List;
+
+public record SnapshotRelationResponse(
+        Long relationId,
+        Long snapshotId,
+        Long fromItemId,
+        String fromItemName,
+        Long toItemId,
+        String toItemName,
+        Boolean isStartPoint,
+        Instant createdAt
+) {
+    public static SnapshotRelationResponse from(SnapshotRelation relation) {
+        return new SnapshotRelationResponse(
+                relation.getId(),
+                relation.getSnapshot().getId(),
+                relation.getFromItem() != null ? relation.getFromItem().getId() : null,
+                relation.getFromItem() != null ? relation.getFromItem().getItemName() : null,
+                relation.getToItem().getId(),
+                relation.getToItem().getItemName(),
+                relation.isStartPoint(),
+                relation.getCreatedAt()
+        );
+    }
+
+    public record OrderedItem(
+            Long itemId,
+            String itemName,
+            Integer seq
+    ) {
+    }
+
+    public record SnapshotRelationsResponse(
+            Long snapshotId,
+            List<OrderedItem> orderedItems,
+            List<SnapshotRelationResponse> relations
+    ) {
+        public static SnapshotRelationsResponse from(
+                Long snapshotId,
+                List<OrderedItem> orderedItems,
+                List<SnapshotRelation> relations
+        ) {
+            List<SnapshotRelationResponse> relationResponses = relations.stream()
+                    .map(SnapshotRelationResponse::from)
+                    .toList();
+
+            return new SnapshotRelationsResponse(snapshotId, orderedItems, relationResponses);
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/exception/SnapshotItemNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/exception/SnapshotItemNotFoundException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.snapshot.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class SnapshotItemNotFoundException extends BusinessException {
+
+    public SnapshotItemNotFoundException() {
+        super(ErrorCode.CM_SNAPSHOT_ITEM_NOT_FOUND);
+    }
+
+    public SnapshotItemNotFoundException(Long itemId) {
+        super(ErrorCode.CM_SNAPSHOT_ITEM_NOT_FOUND, "스냅샷 항목을 찾을 수 없습니다. ID: " + itemId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/service/SnapshotItemService.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/service/SnapshotItemService.java
@@ -1,0 +1,58 @@
+package com.mzc.lp.domain.snapshot.service;
+
+import com.mzc.lp.domain.snapshot.dto.request.CreateSnapshotItemRequest;
+import com.mzc.lp.domain.snapshot.dto.request.MoveSnapshotItemRequest;
+import com.mzc.lp.domain.snapshot.dto.request.UpdateSnapshotItemRequest;
+import com.mzc.lp.domain.snapshot.dto.response.SnapshotItemResponse;
+
+import java.util.List;
+
+public interface SnapshotItemService {
+
+    /**
+     * 아이템 계층 구조 조회
+     * @param snapshotId 스냅샷 ID
+     * @return 계층 구조로 정렬된 아이템 목록
+     */
+    List<SnapshotItemResponse> getHierarchy(Long snapshotId);
+
+    /**
+     * 아이템 평면 목록 조회
+     * @param snapshotId 스냅샷 ID
+     * @return 평면 목록 (children 없음)
+     */
+    List<SnapshotItemResponse> getFlatItems(Long snapshotId);
+
+    /**
+     * 아이템 추가 (DRAFT 상태에서만 가능)
+     * @param snapshotId 스냅샷 ID
+     * @param request 생성 요청 DTO
+     * @return 생성된 아이템 정보
+     */
+    SnapshotItemResponse createItem(Long snapshotId, CreateSnapshotItemRequest request);
+
+    /**
+     * 아이템 수정 (이름 변경)
+     * @param snapshotId 스냅샷 ID
+     * @param itemId 아이템 ID
+     * @param request 수정 요청 DTO
+     * @return 수정된 아이템 정보
+     */
+    SnapshotItemResponse updateItem(Long snapshotId, Long itemId, UpdateSnapshotItemRequest request);
+
+    /**
+     * 아이템 이동 (DRAFT 상태에서만 가능)
+     * @param snapshotId 스냅샷 ID
+     * @param itemId 아이템 ID
+     * @param request 이동 요청 DTO
+     * @return 이동된 아이템 정보
+     */
+    SnapshotItemResponse moveItem(Long snapshotId, Long itemId, MoveSnapshotItemRequest request);
+
+    /**
+     * 아이템 삭제 (DRAFT 상태에서만 가능, 폴더일 경우 하위 항목도 삭제)
+     * @param snapshotId 스냅샷 ID
+     * @param itemId 아이템 ID
+     */
+    void deleteItem(Long snapshotId, Long itemId);
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/service/SnapshotItemServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/service/SnapshotItemServiceImpl.java
@@ -1,0 +1,217 @@
+package com.mzc.lp.domain.snapshot.service;
+
+import com.mzc.lp.domain.course.exception.InvalidParentException;
+import com.mzc.lp.domain.course.exception.MaxDepthExceededException;
+import com.mzc.lp.domain.snapshot.dto.request.CreateSnapshotItemRequest;
+import com.mzc.lp.domain.snapshot.dto.request.MoveSnapshotItemRequest;
+import com.mzc.lp.domain.snapshot.dto.request.UpdateSnapshotItemRequest;
+import com.mzc.lp.domain.snapshot.dto.response.SnapshotItemResponse;
+import com.mzc.lp.domain.snapshot.entity.CourseSnapshot;
+import com.mzc.lp.domain.snapshot.entity.SnapshotItem;
+import com.mzc.lp.domain.snapshot.entity.SnapshotLearningObject;
+import com.mzc.lp.domain.snapshot.exception.SnapshotItemNotFoundException;
+import com.mzc.lp.domain.snapshot.exception.SnapshotNotFoundException;
+import com.mzc.lp.domain.snapshot.exception.SnapshotStateException;
+import com.mzc.lp.domain.snapshot.repository.CourseSnapshotRepository;
+import com.mzc.lp.domain.snapshot.repository.SnapshotItemRepository;
+import com.mzc.lp.domain.snapshot.repository.SnapshotLearningObjectRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SnapshotItemServiceImpl implements SnapshotItemService {
+
+    private final CourseSnapshotRepository snapshotRepository;
+    private final SnapshotItemRepository snapshotItemRepository;
+    private final SnapshotLearningObjectRepository snapshotLoRepository;
+
+    private static final Long DEFAULT_TENANT_ID = 1L;
+
+    @Override
+    public List<SnapshotItemResponse> getHierarchy(Long snapshotId) {
+        log.debug("Getting item hierarchy: snapshotId={}", snapshotId);
+
+        validateSnapshotExists(snapshotId);
+
+        List<SnapshotItem> rootItems = snapshotItemRepository.findRootItemsWithLo(snapshotId, DEFAULT_TENANT_ID);
+
+        return rootItems.stream()
+                .map(SnapshotItemResponse::fromWithChildren)
+                .toList();
+    }
+
+    @Override
+    public List<SnapshotItemResponse> getFlatItems(Long snapshotId) {
+        log.debug("Getting flat items: snapshotId={}", snapshotId);
+
+        validateSnapshotExists(snapshotId);
+
+        List<SnapshotItem> items = snapshotItemRepository.findBySnapshotIdWithLo(snapshotId, DEFAULT_TENANT_ID);
+
+        return items.stream()
+                .map(SnapshotItemResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public SnapshotItemResponse createItem(Long snapshotId, CreateSnapshotItemRequest request) {
+        log.info("Creating snapshot item: snapshotId={}, itemName={}", snapshotId, request.itemName());
+
+        CourseSnapshot snapshot = findSnapshotById(snapshotId);
+        validateItemModifiable(snapshot);
+
+        SnapshotItem parent = findParentIfExists(request.parentId(), snapshotId);
+
+        SnapshotLearningObject snapshotLo = null;
+        if (request.learningObjectId() != null) {
+            snapshotLo = SnapshotLearningObject.create(
+                    request.learningObjectId(),
+                    request.itemName()
+            );
+            snapshotLo = snapshotLoRepository.save(snapshotLo);
+        }
+
+        try {
+            SnapshotItem item;
+            if (request.learningObjectId() == null) {
+                item = SnapshotItem.createFolder(snapshot, request.itemName(), parent);
+            } else {
+                item = SnapshotItem.createItem(
+                        snapshot,
+                        request.itemName(),
+                        parent,
+                        snapshotLo,
+                        request.itemType()
+                );
+            }
+
+            SnapshotItem savedItem = snapshotItemRepository.save(item);
+            log.info("Snapshot item created: itemId={}, snapshotId={}", savedItem.getId(), snapshotId);
+
+            return SnapshotItemResponse.from(savedItem);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().contains("최대 깊이")) {
+                throw new MaxDepthExceededException();
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    @Transactional
+    public SnapshotItemResponse updateItem(Long snapshotId, Long itemId, UpdateSnapshotItemRequest request) {
+        log.info("Updating snapshot item: snapshotId={}, itemId={}, newName={}",
+                snapshotId, itemId, request.itemName());
+
+        CourseSnapshot snapshot = findSnapshotById(snapshotId);
+        validateMetadataModifiable(snapshot);
+
+        SnapshotItem item = findItemById(itemId);
+        validateItemBelongsToSnapshot(item, snapshotId);
+
+        item.updateItemName(request.itemName());
+        log.info("Snapshot item updated: itemId={}", itemId);
+
+        return SnapshotItemResponse.from(item);
+    }
+
+    @Override
+    @Transactional
+    public SnapshotItemResponse moveItem(Long snapshotId, Long itemId, MoveSnapshotItemRequest request) {
+        log.info("Moving snapshot item: snapshotId={}, itemId={}, newParentId={}",
+                snapshotId, itemId, request.newParentId());
+
+        CourseSnapshot snapshot = findSnapshotById(snapshotId);
+        validateItemModifiable(snapshot);
+
+        SnapshotItem item = findItemById(itemId);
+        validateItemBelongsToSnapshot(item, snapshotId);
+
+        SnapshotItem newParent = findParentIfExists(request.newParentId(), snapshotId);
+
+        try {
+            item.moveTo(newParent);
+            log.info("Snapshot item moved: itemId={}, newParentId={}, newDepth={}",
+                    itemId, request.newParentId(), item.getDepth());
+
+            return SnapshotItemResponse.from(item);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().contains("최대 깊이")) {
+                throw new MaxDepthExceededException();
+            }
+            if (e.getMessage().contains("하위 항목으로 이동")) {
+                throw new InvalidParentException("자기 자신 또는 하위 항목으로 이동할 수 없습니다");
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    @Transactional
+    public void deleteItem(Long snapshotId, Long itemId) {
+        log.info("Deleting snapshot item: snapshotId={}, itemId={}", snapshotId, itemId);
+
+        CourseSnapshot snapshot = findSnapshotById(snapshotId);
+        validateItemModifiable(snapshot);
+
+        SnapshotItem item = findItemById(itemId);
+        validateItemBelongsToSnapshot(item, snapshotId);
+
+        snapshotItemRepository.delete(item);
+        log.info("Snapshot item deleted: itemId={}", itemId);
+    }
+
+    // ===== Private Helper Methods =====
+
+    private CourseSnapshot findSnapshotById(Long snapshotId) {
+        return snapshotRepository.findByIdAndTenantId(snapshotId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new SnapshotNotFoundException(snapshotId));
+    }
+
+    private void validateSnapshotExists(Long snapshotId) {
+        if (!snapshotRepository.existsByIdAndTenantId(snapshotId, DEFAULT_TENANT_ID)) {
+            throw new SnapshotNotFoundException(snapshotId);
+        }
+    }
+
+    private void validateItemModifiable(CourseSnapshot snapshot) {
+        if (!snapshot.isItemModifiable()) {
+            throw new SnapshotStateException(snapshot.getStatus(), "아이템 수정");
+        }
+    }
+
+    private void validateMetadataModifiable(CourseSnapshot snapshot) {
+        if (!snapshot.isModifiable()) {
+            throw new SnapshotStateException(snapshot.getStatus(), "수정");
+        }
+    }
+
+    private SnapshotItem findItemById(Long itemId) {
+        return snapshotItemRepository.findByIdAndTenantId(itemId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new SnapshotItemNotFoundException(itemId));
+    }
+
+    private SnapshotItem findParentIfExists(Long parentId, Long snapshotId) {
+        if (parentId == null) {
+            return null;
+        }
+        SnapshotItem parent = snapshotItemRepository.findByIdAndTenantId(parentId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new SnapshotItemNotFoundException(parentId));
+        validateItemBelongsToSnapshot(parent, snapshotId);
+        return parent;
+    }
+
+    private void validateItemBelongsToSnapshot(SnapshotItem item, Long snapshotId) {
+        if (!item.getSnapshot().getId().equals(snapshotId)) {
+            throw new SnapshotItemNotFoundException(item.getId());
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/service/SnapshotRelationService.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/service/SnapshotRelationService.java
@@ -1,0 +1,47 @@
+package com.mzc.lp.domain.snapshot.service;
+
+import com.mzc.lp.domain.snapshot.dto.request.CreateSnapshotRelationRequest;
+import com.mzc.lp.domain.snapshot.dto.request.SetStartSnapshotItemRequest;
+import com.mzc.lp.domain.snapshot.dto.response.SnapshotRelationResponse;
+
+import java.util.List;
+
+public interface SnapshotRelationService {
+
+    /**
+     * 연결 목록 조회
+     * @param snapshotId 스냅샷 ID
+     * @return 연결 목록과 순서 정보
+     */
+    SnapshotRelationResponse.SnapshotRelationsResponse getRelations(Long snapshotId);
+
+    /**
+     * 순서대로 아이템 조회 (Linked List 순회)
+     * @param snapshotId 스냅샷 ID
+     * @return 순서대로 정렬된 아이템 목록
+     */
+    List<SnapshotRelationResponse.OrderedItem> getOrderedItems(Long snapshotId);
+
+    /**
+     * 연결 생성
+     * @param snapshotId 스냅샷 ID
+     * @param request 연결 생성 요청 DTO
+     * @return 생성된 연결 정보
+     */
+    SnapshotRelationResponse createRelation(Long snapshotId, CreateSnapshotRelationRequest request);
+
+    /**
+     * 시작점 설정
+     * @param snapshotId 스냅샷 ID
+     * @param request 시작점 설정 요청 DTO
+     * @return 설정된 시작점 연결 정보
+     */
+    SnapshotRelationResponse setStartItem(Long snapshotId, SetStartSnapshotItemRequest request);
+
+    /**
+     * 연결 삭제
+     * @param snapshotId 스냅샷 ID
+     * @param relationId 연결 ID
+     */
+    void deleteRelation(Long snapshotId, Long relationId);
+}

--- a/src/main/java/com/mzc/lp/domain/snapshot/service/SnapshotRelationServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/service/SnapshotRelationServiceImpl.java
@@ -1,0 +1,254 @@
+package com.mzc.lp.domain.snapshot.service;
+
+import com.mzc.lp.domain.course.exception.CircularReferenceException;
+import com.mzc.lp.domain.snapshot.dto.request.CreateSnapshotRelationRequest;
+import com.mzc.lp.domain.snapshot.dto.request.SetStartSnapshotItemRequest;
+import com.mzc.lp.domain.snapshot.dto.response.SnapshotRelationResponse;
+import com.mzc.lp.domain.snapshot.entity.CourseSnapshot;
+import com.mzc.lp.domain.snapshot.entity.SnapshotItem;
+import com.mzc.lp.domain.snapshot.entity.SnapshotRelation;
+import com.mzc.lp.domain.snapshot.exception.SnapshotItemNotFoundException;
+import com.mzc.lp.domain.snapshot.exception.SnapshotNotFoundException;
+import com.mzc.lp.domain.snapshot.repository.CourseSnapshotRepository;
+import com.mzc.lp.domain.snapshot.repository.SnapshotItemRepository;
+import com.mzc.lp.domain.snapshot.repository.SnapshotRelationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SnapshotRelationServiceImpl implements SnapshotRelationService {
+
+    private final CourseSnapshotRepository snapshotRepository;
+    private final SnapshotItemRepository snapshotItemRepository;
+    private final SnapshotRelationRepository snapshotRelationRepository;
+
+    private static final Long DEFAULT_TENANT_ID = 1L;
+
+    @Override
+    public SnapshotRelationResponse.SnapshotRelationsResponse getRelations(Long snapshotId) {
+        log.debug("Getting relations: snapshotId={}", snapshotId);
+
+        validateSnapshotExists(snapshotId);
+
+        List<SnapshotRelation> relations = snapshotRelationRepository.findBySnapshotIdWithItems(
+                snapshotId, DEFAULT_TENANT_ID);
+
+        if (relations.isEmpty()) {
+            return SnapshotRelationResponse.SnapshotRelationsResponse.from(
+                    snapshotId, Collections.emptyList(), Collections.emptyList());
+        }
+
+        List<SnapshotRelationResponse.OrderedItem> orderedItems = buildOrderedItems(relations);
+
+        return SnapshotRelationResponse.SnapshotRelationsResponse.from(snapshotId, orderedItems, relations);
+    }
+
+    @Override
+    public List<SnapshotRelationResponse.OrderedItem> getOrderedItems(Long snapshotId) {
+        log.debug("Getting ordered items: snapshotId={}", snapshotId);
+
+        validateSnapshotExists(snapshotId);
+
+        List<SnapshotRelation> relations = snapshotRelationRepository.findBySnapshotIdWithItems(
+                snapshotId, DEFAULT_TENANT_ID);
+
+        if (relations.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return buildOrderedItems(relations);
+    }
+
+    @Override
+    @Transactional
+    public SnapshotRelationResponse createRelation(Long snapshotId, CreateSnapshotRelationRequest request) {
+        log.info("Creating relation: snapshotId={}, fromItemId={}, toItemId={}",
+                snapshotId, request.fromItemId(), request.toItemId());
+
+        CourseSnapshot snapshot = findSnapshotById(snapshotId);
+
+        SnapshotItem fromItem = null;
+        if (request.fromItemId() != null) {
+            fromItem = findItemById(request.fromItemId());
+            validateItemBelongsToSnapshot(fromItem, snapshotId);
+        }
+
+        SnapshotItem toItem = findItemById(request.toItemId());
+        validateItemBelongsToSnapshot(toItem, snapshotId);
+
+        // toItem이 이미 다른 관계에서 참조되고 있는지 확인
+        if (snapshotRelationRepository.existsByToItemIdAndTenantId(request.toItemId(), DEFAULT_TENANT_ID)) {
+            throw new IllegalArgumentException("이 항목은 이미 학습 순서에 포함되어 있습니다: " + request.toItemId());
+        }
+
+        // 순환 참조 검증
+        if (request.fromItemId() != null) {
+            validateNoCircularReference(snapshotId, request.fromItemId(), request.toItemId());
+        }
+
+        SnapshotRelation relation;
+        if (request.fromItemId() == null) {
+            // 기존 시작점이 있으면 삭제
+            snapshotRelationRepository.findBySnapshotIdAndFromItemIsNullAndTenantId(snapshotId, DEFAULT_TENANT_ID)
+                    .ifPresent(snapshotRelationRepository::delete);
+            relation = SnapshotRelation.createStartPoint(snapshot, toItem);
+        } else {
+            relation = SnapshotRelation.create(snapshot, fromItem, toItem);
+        }
+
+        SnapshotRelation savedRelation = snapshotRelationRepository.save(relation);
+        log.info("Relation created: relationId={}, snapshotId={}", savedRelation.getId(), snapshotId);
+
+        return SnapshotRelationResponse.from(savedRelation);
+    }
+
+    @Override
+    @Transactional
+    public SnapshotRelationResponse setStartItem(Long snapshotId, SetStartSnapshotItemRequest request) {
+        log.info("Setting start item: snapshotId={}, itemId={}", snapshotId, request.itemId());
+
+        CourseSnapshot snapshot = findSnapshotById(snapshotId);
+
+        SnapshotItem newStartItem = findItemById(request.itemId());
+        validateItemBelongsToSnapshot(newStartItem, snapshotId);
+
+        if (newStartItem.isFolder()) {
+            throw new IllegalArgumentException("폴더는 시작점으로 설정할 수 없습니다");
+        }
+
+        // 기존 시작점 찾기
+        Optional<SnapshotRelation> existingStart = snapshotRelationRepository
+                .findBySnapshotIdAndFromItemIsNullAndTenantId(snapshotId, DEFAULT_TENANT_ID);
+
+        // 새 시작점이 이미 다른 곳에서 참조되고 있다면 해당 관계 삭제
+        Optional<SnapshotRelation> existingToNew = snapshotRelationRepository
+                .findByToItemIdAndTenantId(request.itemId(), DEFAULT_TENANT_ID);
+        existingToNew.ifPresent(snapshotRelationRepository::delete);
+
+        SnapshotRelation startRelation;
+        if (existingStart.isPresent()) {
+            startRelation = existingStart.get();
+            startRelation.updateToItem(newStartItem);
+        } else {
+            startRelation = SnapshotRelation.createStartPoint(snapshot, newStartItem);
+            startRelation = snapshotRelationRepository.save(startRelation);
+        }
+
+        log.info("Start item set: snapshotId={}, itemId={}", snapshotId, request.itemId());
+
+        return SnapshotRelationResponse.from(startRelation);
+    }
+
+    @Override
+    @Transactional
+    public void deleteRelation(Long snapshotId, Long relationId) {
+        log.info("Deleting relation: snapshotId={}, relationId={}", snapshotId, relationId);
+
+        validateSnapshotExists(snapshotId);
+
+        SnapshotRelation relation = snapshotRelationRepository.findByIdAndTenantId(relationId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new IllegalArgumentException("순서 연결을 찾을 수 없습니다: " + relationId));
+
+        if (!relation.getSnapshot().getId().equals(snapshotId)) {
+            throw new IllegalArgumentException("해당 스냅샷의 순서 연결이 아닙니다");
+        }
+
+        snapshotRelationRepository.delete(relation);
+        log.info("Relation deleted: relationId={}", relationId);
+    }
+
+    // ===== Private Helper Methods =====
+
+    private CourseSnapshot findSnapshotById(Long snapshotId) {
+        return snapshotRepository.findByIdAndTenantId(snapshotId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new SnapshotNotFoundException(snapshotId));
+    }
+
+    private void validateSnapshotExists(Long snapshotId) {
+        if (!snapshotRepository.existsByIdAndTenantId(snapshotId, DEFAULT_TENANT_ID)) {
+            throw new SnapshotNotFoundException(snapshotId);
+        }
+    }
+
+    private SnapshotItem findItemById(Long itemId) {
+        return snapshotItemRepository.findByIdAndTenantId(itemId, DEFAULT_TENANT_ID)
+                .orElseThrow(() -> new SnapshotItemNotFoundException(itemId));
+    }
+
+    private void validateItemBelongsToSnapshot(SnapshotItem item, Long snapshotId) {
+        if (!item.getSnapshot().getId().equals(snapshotId)) {
+            throw new SnapshotItemNotFoundException(item.getId());
+        }
+    }
+
+    private void validateNoCircularReference(Long snapshotId, Long fromItemId, Long toItemId) {
+        List<SnapshotRelation> relations = snapshotRelationRepository.findBySnapshotIdAndTenantId(
+                snapshotId, DEFAULT_TENANT_ID);
+
+        Map<Long, Long> fromToMap = new HashMap<>();
+        for (SnapshotRelation relation : relations) {
+            if (relation.getFromItem() != null) {
+                fromToMap.put(relation.getFromItem().getId(), relation.getToItem().getId());
+            }
+        }
+
+        // 새로운 관계 추가
+        fromToMap.put(fromItemId, toItemId);
+
+        // toItemId에서 시작해서 순환 참조 검사
+        Set<Long> visited = new HashSet<>();
+        Long current = toItemId;
+
+        while (current != null) {
+            if (visited.contains(current)) {
+                throw new CircularReferenceException("순환 참조가 감지되었습니다");
+            }
+            visited.add(current);
+            current = fromToMap.get(current);
+        }
+    }
+
+    private List<SnapshotRelationResponse.OrderedItem> buildOrderedItems(List<SnapshotRelation> relations) {
+        Map<Long, SnapshotRelation> fromMap = new HashMap<>();
+        SnapshotRelation startRelation = null;
+
+        for (SnapshotRelation relation : relations) {
+            if (relation.isStartPoint()) {
+                startRelation = relation;
+            } else {
+                fromMap.put(relation.getFromItem().getId(), relation);
+            }
+        }
+
+        if (startRelation == null) {
+            return Collections.emptyList();
+        }
+
+        List<SnapshotRelationResponse.OrderedItem> orderedItems = new ArrayList<>();
+        int seq = 1;
+
+        SnapshotItem current = startRelation.getToItem();
+        Set<Long> visited = new HashSet<>();
+
+        while (current != null && !visited.contains(current.getId())) {
+            visited.add(current.getId());
+            orderedItems.add(new SnapshotRelationResponse.OrderedItem(
+                    current.getId(),
+                    current.getItemName(),
+                    seq++
+            ));
+
+            SnapshotRelation nextRelation = fromMap.get(current.getId());
+            current = nextRelation != null ? nextRelation.getToItem() : null;
+        }
+
+        return orderedItems;
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/snapshot/controller/SnapshotItemControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/snapshot/controller/SnapshotItemControllerTest.java
@@ -1,0 +1,550 @@
+package com.mzc.lp.domain.snapshot.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.snapshot.constant.SnapshotStatus;
+import com.mzc.lp.domain.snapshot.dto.request.CreateSnapshotItemRequest;
+import com.mzc.lp.domain.snapshot.dto.request.MoveSnapshotItemRequest;
+import com.mzc.lp.domain.snapshot.dto.request.UpdateSnapshotItemRequest;
+import com.mzc.lp.domain.snapshot.entity.CourseSnapshot;
+import com.mzc.lp.domain.snapshot.entity.SnapshotItem;
+import com.mzc.lp.domain.snapshot.repository.CourseSnapshotRepository;
+import com.mzc.lp.domain.snapshot.repository.SnapshotItemRepository;
+import com.mzc.lp.domain.snapshot.repository.SnapshotLearningObjectRepository;
+import com.mzc.lp.domain.snapshot.repository.SnapshotRelationRepository;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.dto.request.RegisterRequest;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SnapshotItemControllerTest extends TenantTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CourseSnapshotRepository snapshotRepository;
+
+    @Autowired
+    private SnapshotItemRepository snapshotItemRepository;
+
+    @Autowired
+    private SnapshotLearningObjectRepository snapshotLoRepository;
+
+    @Autowired
+    private SnapshotRelationRepository snapshotRelationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private UserCourseRoleRepository userCourseRoleRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        snapshotRelationRepository.deleteAll();
+        snapshotItemRepository.deleteAll();
+        snapshotLoRepository.deleteAll();
+        snapshotRepository.deleteAll();
+        userCourseRoleRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ===== 헬퍼 메서드 =====
+
+    private User createOperatorUser() {
+        User user = User.create("operator@example.com", "운영자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.OPERATOR);
+        return userRepository.save(user);
+    }
+
+    private void createTestUser() throws Exception {
+        RegisterRequest request = new RegisterRequest(
+                "test@example.com",
+                "Password123!",
+                "홍길동",
+                "010-1234-5678"
+        );
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+    }
+
+    private String loginAndGetAccessToken(String email, String password) throws Exception {
+        LoginRequest request = new LoginRequest(email, password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("data").get("accessToken").asText();
+    }
+
+    private CourseSnapshot createTestSnapshot(String name, Long createdBy) {
+        CourseSnapshot snapshot = CourseSnapshot.create(name, "설명", "#태그", createdBy);
+        return snapshotRepository.save(snapshot);
+    }
+
+    private CourseSnapshot createTestSnapshotWithStatus(String name, Long createdBy, SnapshotStatus status) {
+        CourseSnapshot snapshot = CourseSnapshot.create(name, "설명", "#태그", createdBy);
+        snapshotRepository.save(snapshot);
+
+        if (status == SnapshotStatus.ACTIVE) {
+            snapshot.publish();
+        } else if (status == SnapshotStatus.COMPLETED) {
+            snapshot.publish();
+            snapshot.complete();
+        }
+
+        return snapshotRepository.save(snapshot);
+    }
+
+    private SnapshotItem createTestItem(CourseSnapshot snapshot, String name, SnapshotItem parent) {
+        SnapshotItem item = SnapshotItem.createItem(snapshot, name, parent, null, "VIDEO");
+        return snapshotItemRepository.save(item);
+    }
+
+    private SnapshotItem createTestFolder(CourseSnapshot snapshot, String name, SnapshotItem parent) {
+        SnapshotItem folder = SnapshotItem.createFolder(snapshot, name, parent);
+        return snapshotItemRepository.save(folder);
+    }
+
+    // ==================== 계층 구조 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/snapshots/{snapshotId}/items - 아이템 계층 구조 조회")
+    class GetHierarchy {
+
+        @Test
+        @DisplayName("성공 - 아이템 계층 구조 조회")
+        void getHierarchy_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+
+            SnapshotItem folder = createTestFolder(snapshot, "1장. 입문", null);
+            createTestItem(snapshot, "1-1. 소개", folder);
+            createTestItem(snapshot, "1-2. 설치", folder);
+
+            // when & then
+            mockMvc.perform(get("/api/snapshots/{snapshotId}/items", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data[0].itemName").value("1장. 입문"))
+                    .andExpect(jsonPath("$.data[0].isFolder").value(true))
+                    .andExpect(jsonPath("$.data[0].children").isArray())
+                    .andExpect(jsonPath("$.data[0].children.length()").value(2));
+        }
+
+        @Test
+        @DisplayName("성공 - 빈 스냅샷 조회")
+        void getHierarchy_success_empty() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("빈 스냅샷", 1L);
+
+            // when & then
+            mockMvc.perform(get("/api/snapshots/{snapshotId}/items", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(0));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 스냅샷")
+        void getHierarchy_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/snapshots/{snapshotId}/items", 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM006"));
+        }
+    }
+
+    // ==================== 평면 목록 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/snapshots/{snapshotId}/items/flat - 아이템 평면 목록 조회")
+    class GetFlatItems {
+
+        @Test
+        @DisplayName("성공 - 평면 목록 조회")
+        void getFlatItems_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+
+            SnapshotItem folder = createTestFolder(snapshot, "폴더", null);
+            createTestItem(snapshot, "아이템1", folder);
+            createTestItem(snapshot, "아이템2", null);
+
+            // when & then
+            mockMvc.perform(get("/api/snapshots/{snapshotId}/items/flat", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(3));
+        }
+    }
+
+    // ==================== 아이템 추가 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/snapshots/{snapshotId}/items - 아이템 추가")
+    class CreateItem {
+
+        @Test
+        @DisplayName("성공 - DRAFT 상태에서 차시 추가")
+        void createItem_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+            CreateSnapshotItemRequest request = new CreateSnapshotItemRequest(
+                    "새 차시",
+                    null,
+                    100L,
+                    "VIDEO"
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots/{snapshotId}/items", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.itemName").value("새 차시"))
+                    .andExpect(jsonPath("$.data.isFolder").value(false))
+                    .andExpect(jsonPath("$.data.itemType").value("VIDEO"));
+        }
+
+        @Test
+        @DisplayName("성공 - 폴더 추가")
+        void createItem_success_folder() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+            CreateSnapshotItemRequest request = new CreateSnapshotItemRequest(
+                    "새 폴더",
+                    null,
+                    null,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots/{snapshotId}/items", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.itemName").value("새 폴더"))
+                    .andExpect(jsonPath("$.data.isFolder").value(true));
+        }
+
+        @Test
+        @DisplayName("실패 - ACTIVE 상태에서 추가 시도")
+        void createItem_fail_activeState() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshotWithStatus("ACTIVE 스냅샷", 1L, SnapshotStatus.ACTIVE);
+            CreateSnapshotItemRequest request = new CreateSnapshotItemRequest(
+                    "추가 시도",
+                    null,
+                    100L,
+                    "VIDEO"
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots/{snapshotId}/items", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM007"));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 추가 시도")
+        void createItem_fail_userRole() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken("test@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+            CreateSnapshotItemRequest request = new CreateSnapshotItemRequest(
+                    "추가 시도",
+                    null,
+                    100L,
+                    "VIDEO"
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots/{snapshotId}/items", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("실패 - 이름 누락")
+        void createItem_fail_missingName() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+            CreateSnapshotItemRequest request = new CreateSnapshotItemRequest(
+                    null,
+                    null,
+                    100L,
+                    "VIDEO"
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots/{snapshotId}/items", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    // ==================== 아이템 수정 테스트 ====================
+
+    @Nested
+    @DisplayName("PUT /api/snapshots/{snapshotId}/items/{itemId} - 아이템 수정")
+    class UpdateItem {
+
+        @Test
+        @DisplayName("성공 - 아이템 이름 변경")
+        void updateItem_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+            SnapshotItem item = createTestItem(snapshot, "원래 이름", null);
+            UpdateSnapshotItemRequest request = new UpdateSnapshotItemRequest("새 이름");
+
+            // when & then
+            mockMvc.perform(put("/api/snapshots/{snapshotId}/items/{itemId}", snapshot.getId(), item.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.itemName").value("새 이름"));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 아이템")
+        void updateItem_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+            UpdateSnapshotItemRequest request = new UpdateSnapshotItemRequest("새 이름");
+
+            // when & then
+            mockMvc.perform(put("/api/snapshots/{snapshotId}/items/{itemId}", snapshot.getId(), 99999L)
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM009"));
+        }
+    }
+
+    // ==================== 아이템 이동 테스트 ====================
+
+    @Nested
+    @DisplayName("PUT /api/snapshots/{snapshotId}/items/{itemId}/move - 아이템 이동")
+    class MoveItem {
+
+        @Test
+        @DisplayName("성공 - 폴더로 아이템 이동")
+        void moveItem_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+            SnapshotItem folder = createTestFolder(snapshot, "대상 폴더", null);
+            SnapshotItem item = createTestItem(snapshot, "이동할 아이템", null);
+            MoveSnapshotItemRequest request = new MoveSnapshotItemRequest(folder.getId());
+
+            // when & then
+            mockMvc.perform(put("/api/snapshots/{snapshotId}/items/{itemId}/move", snapshot.getId(), item.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.parentId").value(folder.getId()))
+                    .andExpect(jsonPath("$.data.depth").value(1));
+        }
+
+        @Test
+        @DisplayName("성공 - 루트로 이동")
+        void moveItem_success_toRoot() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+            SnapshotItem folder = createTestFolder(snapshot, "폴더", null);
+            SnapshotItem item = createTestItem(snapshot, "아이템", folder);
+            MoveSnapshotItemRequest request = new MoveSnapshotItemRequest(null);
+
+            // when & then
+            mockMvc.perform(put("/api/snapshots/{snapshotId}/items/{itemId}/move", snapshot.getId(), item.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.parentId").isEmpty())
+                    .andExpect(jsonPath("$.data.depth").value(0));
+        }
+
+        @Test
+        @DisplayName("실패 - ACTIVE 상태에서 이동 시도")
+        void moveItem_fail_activeState() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshotWithStatus("ACTIVE 스냅샷", 1L, SnapshotStatus.ACTIVE);
+            SnapshotItem item = createTestItem(snapshot, "아이템", null);
+            MoveSnapshotItemRequest request = new MoveSnapshotItemRequest(null);
+
+            // when & then
+            mockMvc.perform(put("/api/snapshots/{snapshotId}/items/{itemId}/move", snapshot.getId(), item.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM007"));
+        }
+    }
+
+    // ==================== 아이템 삭제 테스트 ====================
+
+    @Nested
+    @DisplayName("DELETE /api/snapshots/{snapshotId}/items/{itemId} - 아이템 삭제")
+    class DeleteItem {
+
+        @Test
+        @DisplayName("성공 - 아이템 삭제")
+        void deleteItem_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+            SnapshotItem item = createTestItem(snapshot, "삭제할 아이템", null);
+
+            // when & then
+            mockMvc.perform(delete("/api/snapshots/{snapshotId}/items/{itemId}", snapshot.getId(), item.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("실패 - ACTIVE 상태에서 삭제 시도")
+        void deleteItem_fail_activeState() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshotWithStatus("ACTIVE 스냅샷", 1L, SnapshotStatus.ACTIVE);
+            SnapshotItem item = createTestItem(snapshot, "아이템", null);
+
+            // when & then
+            mockMvc.perform(delete("/api/snapshots/{snapshotId}/items/{itemId}", snapshot.getId(), item.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM007"));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 아이템")
+        void deleteItem_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+
+            // when & then
+            mockMvc.perform(delete("/api/snapshots/{snapshotId}/items/{itemId}", snapshot.getId(), 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM009"));
+        }
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/snapshot/controller/SnapshotRelationControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/snapshot/controller/SnapshotRelationControllerTest.java
@@ -1,0 +1,476 @@
+package com.mzc.lp.domain.snapshot.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.snapshot.dto.request.CreateSnapshotRelationRequest;
+import com.mzc.lp.domain.snapshot.dto.request.SetStartSnapshotItemRequest;
+import com.mzc.lp.domain.snapshot.entity.CourseSnapshot;
+import com.mzc.lp.domain.snapshot.entity.SnapshotItem;
+import com.mzc.lp.domain.snapshot.entity.SnapshotLearningObject;
+import com.mzc.lp.domain.snapshot.entity.SnapshotRelation;
+import com.mzc.lp.domain.snapshot.repository.CourseSnapshotRepository;
+import com.mzc.lp.domain.snapshot.repository.SnapshotItemRepository;
+import com.mzc.lp.domain.snapshot.repository.SnapshotLearningObjectRepository;
+import com.mzc.lp.domain.snapshot.repository.SnapshotRelationRepository;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.dto.request.RegisterRequest;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SnapshotRelationControllerTest extends TenantTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CourseSnapshotRepository snapshotRepository;
+
+    @Autowired
+    private SnapshotItemRepository snapshotItemRepository;
+
+    @Autowired
+    private SnapshotLearningObjectRepository snapshotLoRepository;
+
+    @Autowired
+    private SnapshotRelationRepository snapshotRelationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private UserCourseRoleRepository userCourseRoleRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        snapshotRelationRepository.deleteAll();
+        snapshotItemRepository.deleteAll();
+        snapshotLoRepository.deleteAll();
+        snapshotRepository.deleteAll();
+        userCourseRoleRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ===== 헬퍼 메서드 =====
+
+    private User createOperatorUser() {
+        User user = User.create("operator@example.com", "운영자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.OPERATOR);
+        return userRepository.save(user);
+    }
+
+    private void createTestUser() throws Exception {
+        RegisterRequest request = new RegisterRequest(
+                "test@example.com",
+                "Password123!",
+                "홍길동",
+                "010-1234-5678"
+        );
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+    }
+
+    private String loginAndGetAccessToken(String email, String password) throws Exception {
+        LoginRequest request = new LoginRequest(email, password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("data").get("accessToken").asText();
+    }
+
+    private CourseSnapshot createTestSnapshot(String name, Long createdBy) {
+        CourseSnapshot snapshot = CourseSnapshot.create(name, "설명", "#태그", createdBy);
+        return snapshotRepository.save(snapshot);
+    }
+
+    private SnapshotItem createTestItem(CourseSnapshot snapshot, String name) {
+        SnapshotLearningObject slo = SnapshotLearningObject.create(100L, name);
+        slo = snapshotLoRepository.save(slo);
+        SnapshotItem item = SnapshotItem.createItem(snapshot, name, null, slo, "VIDEO");
+        return snapshotItemRepository.save(item);
+    }
+
+    private SnapshotRelation createTestRelation(CourseSnapshot snapshot, SnapshotItem from, SnapshotItem to) {
+        SnapshotRelation relation;
+        if (from == null) {
+            relation = SnapshotRelation.createStartPoint(snapshot, to);
+        } else {
+            relation = SnapshotRelation.create(snapshot, from, to);
+        }
+        return snapshotRelationRepository.save(relation);
+    }
+
+    // ==================== 연결 목록 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/snapshots/{snapshotId}/relations - 연결 목록 조회")
+    class GetRelations {
+
+        @Test
+        @DisplayName("성공 - 연결 목록 조회")
+        void getRelations_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+
+            SnapshotItem item1 = createTestItem(snapshot, "1강");
+            SnapshotItem item2 = createTestItem(snapshot, "2강");
+            SnapshotItem item3 = createTestItem(snapshot, "3강");
+
+            createTestRelation(snapshot, null, item1);  // 시작점
+            createTestRelation(snapshot, item1, item2);
+            createTestRelation(snapshot, item2, item3);
+
+            // when & then
+            mockMvc.perform(get("/api/snapshots/{snapshotId}/relations", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.snapshotId").value(snapshot.getId()))
+                    .andExpect(jsonPath("$.data.orderedItems").isArray())
+                    .andExpect(jsonPath("$.data.orderedItems.length()").value(3))
+                    .andExpect(jsonPath("$.data.orderedItems[0].itemName").value("1강"))
+                    .andExpect(jsonPath("$.data.orderedItems[0].seq").value(1))
+                    .andExpect(jsonPath("$.data.relations").isArray());
+        }
+
+        @Test
+        @DisplayName("성공 - 빈 연결 목록")
+        void getRelations_success_empty() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("빈 스냅샷", 1L);
+
+            // when & then
+            mockMvc.perform(get("/api/snapshots/{snapshotId}/relations", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.orderedItems").isArray())
+                    .andExpect(jsonPath("$.data.orderedItems.length()").value(0));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 스냅샷")
+        void getRelations_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/snapshots/{snapshotId}/relations", 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM006"));
+        }
+    }
+
+    // ==================== 순서대로 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/snapshots/{snapshotId}/relations/ordered - 순서대로 조회")
+    class GetOrderedItems {
+
+        @Test
+        @DisplayName("성공 - 순서대로 아이템 조회")
+        void getOrderedItems_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+
+            SnapshotItem item1 = createTestItem(snapshot, "1강");
+            SnapshotItem item2 = createTestItem(snapshot, "2강");
+
+            createTestRelation(snapshot, null, item1);
+            createTestRelation(snapshot, item1, item2);
+
+            // when & then
+            mockMvc.perform(get("/api/snapshots/{snapshotId}/relations/ordered", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(2))
+                    .andExpect(jsonPath("$.data[0].seq").value(1))
+                    .andExpect(jsonPath("$.data[0].itemName").value("1강"))
+                    .andExpect(jsonPath("$.data[1].seq").value(2))
+                    .andExpect(jsonPath("$.data[1].itemName").value("2강"));
+        }
+    }
+
+    // ==================== 연결 생성 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/snapshots/{snapshotId}/relations - 연결 생성")
+    class CreateRelation {
+
+        @Test
+        @DisplayName("성공 - 시작점 생성")
+        void createRelation_success_startPoint() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+            SnapshotItem item = createTestItem(snapshot, "1강");
+
+            CreateSnapshotRelationRequest request = new CreateSnapshotRelationRequest(null, item.getId());
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots/{snapshotId}/relations", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.isStartPoint").value(true))
+                    .andExpect(jsonPath("$.data.toItemId").value(item.getId()));
+        }
+
+        @Test
+        @DisplayName("성공 - 연결 생성")
+        void createRelation_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+            SnapshotItem item1 = createTestItem(snapshot, "1강");
+            SnapshotItem item2 = createTestItem(snapshot, "2강");
+
+            createTestRelation(snapshot, null, item1);  // 시작점 먼저 생성
+
+            CreateSnapshotRelationRequest request = new CreateSnapshotRelationRequest(item1.getId(), item2.getId());
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots/{snapshotId}/relations", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.isStartPoint").value(false))
+                    .andExpect(jsonPath("$.data.fromItemId").value(item1.getId()))
+                    .andExpect(jsonPath("$.data.toItemId").value(item2.getId()));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 생성 시도")
+        void createRelation_fail_userRole() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken("test@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+            SnapshotItem item = createTestItem(snapshot, "1강");
+
+            CreateSnapshotRelationRequest request = new CreateSnapshotRelationRequest(null, item.getId());
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots/{snapshotId}/relations", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 아이템")
+        void createRelation_fail_itemNotFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+
+            CreateSnapshotRelationRequest request = new CreateSnapshotRelationRequest(null, 99999L);
+
+            // when & then
+            mockMvc.perform(post("/api/snapshots/{snapshotId}/relations", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM009"));
+        }
+    }
+
+    // ==================== 시작점 설정 테스트 ====================
+
+    @Nested
+    @DisplayName("PUT /api/snapshots/{snapshotId}/relations/start - 시작점 설정")
+    class SetStartItem {
+
+        @Test
+        @DisplayName("성공 - 시작점 설정")
+        void setStartItem_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+            SnapshotItem item = createTestItem(snapshot, "새 시작점");
+
+            SetStartSnapshotItemRequest request = new SetStartSnapshotItemRequest(item.getId());
+
+            // when & then
+            mockMvc.perform(put("/api/snapshots/{snapshotId}/relations/start", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.isStartPoint").value(true))
+                    .andExpect(jsonPath("$.data.toItemId").value(item.getId()));
+        }
+
+        @Test
+        @DisplayName("성공 - 기존 시작점 변경")
+        void setStartItem_success_change() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+            SnapshotItem item1 = createTestItem(snapshot, "기존 시작점");
+            SnapshotItem item2 = createTestItem(snapshot, "새 시작점");
+
+            createTestRelation(snapshot, null, item1);  // 기존 시작점
+
+            SetStartSnapshotItemRequest request = new SetStartSnapshotItemRequest(item2.getId());
+
+            // when & then
+            mockMvc.perform(put("/api/snapshots/{snapshotId}/relations/start", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.toItemId").value(item2.getId()));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 아이템")
+        void setStartItem_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+
+            SetStartSnapshotItemRequest request = new SetStartSnapshotItemRequest(99999L);
+
+            // when & then
+            mockMvc.perform(put("/api/snapshots/{snapshotId}/relations/start", snapshot.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CM009"));
+        }
+    }
+
+    // ==================== 연결 삭제 테스트 ====================
+
+    @Nested
+    @DisplayName("DELETE /api/snapshots/{snapshotId}/relations/{relationId} - 연결 삭제")
+    class DeleteRelation {
+
+        @Test
+        @DisplayName("성공 - 연결 삭제")
+        void deleteRelation_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+            SnapshotItem item = createTestItem(snapshot, "1강");
+            SnapshotRelation relation = createTestRelation(snapshot, null, item);
+
+            // when & then
+            mockMvc.perform(delete("/api/snapshots/{snapshotId}/relations/{relationId}",
+                            snapshot.getId(), relation.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 연결")
+        void deleteRelation_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+
+            // when & then
+            mockMvc.perform(delete("/api/snapshots/{snapshotId}/relations/{relationId}",
+                            snapshot.getId(), 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 삭제 시도")
+        void deleteRelation_fail_userRole() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken("test@example.com", "Password123!");
+            CourseSnapshot snapshot = createTestSnapshot("테스트 스냅샷", 1L);
+            SnapshotItem item = createTestItem(snapshot, "1강");
+            SnapshotRelation relation = createTestRelation(snapshot, null, item);
+
+            // when & then
+            mockMvc.perform(delete("/api/snapshots/{snapshotId}/relations/{relationId}",
+                            snapshot.getId(), relation.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+}


### PR DESCRIPTION
## 개요

Phase 7: SnapshotItem/Relation API 구현

Closes #83

## 구현 내용

### SnapshotItem API (6개)

| Method | Endpoint | 기능 |
|--------|----------|------|
| GET | `/api/snapshots/{snapshotId}/items` | 계층 구조 조회 |
| GET | `/api/snapshots/{snapshotId}/items/flat` | 평면 목록 조회 |
| POST | `/api/snapshots/{snapshotId}/items` | 아이템 추가 (DRAFT만) |
| PUT | `/api/snapshots/{snapshotId}/items/{itemId}` | 아이템 수정 |
| PUT | `/api/snapshots/{snapshotId}/items/{itemId}/move` | 아이템 이동 (DRAFT만) |
| DELETE | `/api/snapshots/{snapshotId}/items/{itemId}` | 아이템 삭제 (DRAFT만) |

### SnapshotRelation API (5개)

| Method | Endpoint | 기능 |
|--------|----------|------|
| GET | `/api/snapshots/{snapshotId}/relations` | 연결 목록 조회 |
| GET | `/api/snapshots/{snapshotId}/relations/ordered` | 순서대로 조회 |
| POST | `/api/snapshots/{snapshotId}/relations` | 연결 생성 |
| PUT | `/api/snapshots/{snapshotId}/relations/start` | 시작점 설정 |
| DELETE | `/api/snapshots/{snapshotId}/relations/{relationId}` | 연결 삭제 |

## 주요 변경사항

### Service 계층
- `SnapshotItemService/ServiceImpl` - 아이템 관리
  - DRAFT 상태에서만 아이템 추가/이동/삭제 가능
  - 계층 구조 및 평면 목록 조회
- `SnapshotRelationService/ServiceImpl` - 학습경로 관리
  - Linked List 패턴으로 학습 순서 관리
  - 순환 참조 검증

### Controller 계층
- `SnapshotItemController` - 아이템 API 엔드포인트
- `SnapshotRelationController` - 학습경로 API 엔드포인트

### DTO
- Request: `CreateSnapshotItemRequest`, `UpdateSnapshotItemRequest`, `MoveSnapshotItemRequest`
- Request: `CreateSnapshotRelationRequest`, `SetStartSnapshotItemRequest`
- Response: `SnapshotRelationResponse` (OrderedItem, SnapshotRelationsResponse 포함)

### Exception
- `SnapshotItemNotFoundException` 추가 (CM009)

### 테스트
- `SnapshotItemControllerTest` - 23개 테스트 케이스
- `SnapshotRelationControllerTest` - 8개 테스트 케이스

## 테스트 결과

✅ 31개 테스트 케이스 모두 통과
✅ 빌드 성공

## 체크리스트

- [x] Service/ServiceImpl 분리 및 `@Transactional` 적용
- [x] Controller에서 권한 검증 (`@PreAuthorize`)
- [x] DTO 검증 (`@Valid`, `@NotNull` 등)
- [x] 에러 코드 추가 (CM009)
- [x] 테스트 코드 작성 (Given-When-Then 패턴)
- [x] 빌드 및 테스트 통과