### PR TITLE
Fix: 차수 복제 시 program 필드 누락 수정 (#127)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/ts/entity/CourseTime.java
+++ b/src/main/java/com/mzc/lp/domain/ts/entity/CourseTime.java
@@ -112,6 +112,7 @@ public class CourseTime extends TenantEntity {
     ) {
         CourseTime courseTime = new CourseTime();
         // 복제 대상 필드
+        courseTime.program = source.program;
         courseTime.deliveryType = source.deliveryType;
         courseTime.capacity = source.capacity;
         courseTime.maxWaitingCount = source.maxWaitingCount;


### PR DESCRIPTION
## Summary

차수 복제 API에서 원본 차수의 program 연결이 복제되지 않는 버그 수정

## Related Issue

- Closes #127

## Changes

- `CourseTime.cloneFrom()` 메서드에 `program` 필드 복제 로직 추가

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- Program 필드는 최근 추가된 기능으로, 기존 cloneFrom() 구현 시 누락됨
- 기존 테스트는 program 없이 동작하므로 별도 테스트 추가 불필요
