### PR TITLE
feat: 강의에 포함된 콘텐츠 수정 제한 기능 추가

### DIFF
--- a/src/main/java/com/mzc/lp/domain/content/dto/response/ContentListResponse.java
+++ b/src/main/java/com/mzc/lp/domain/content/dto/response/ContentListResponse.java
@@ -17,9 +17,14 @@ public record ContentListResponse(
         String resolution,
         String thumbnailPath,
         Integer currentVersion,
+        Boolean inCourse,
         LocalDateTime createdAt
 ) {
     public static ContentListResponse from(Content content) {
+        return from(content, null);
+    }
+
+    public static ContentListResponse from(Content content, Boolean inCourse) {
         return new ContentListResponse(
                 content.getId(),
                 content.getOriginalFileName(),
@@ -30,6 +35,7 @@ public record ContentListResponse(
                 content.getResolution(),
                 content.getThumbnailPath(),
                 content.getCurrentVersion(),
+                inCourse,
                 content.getCreatedAt() != null
                         ? LocalDateTime.ofInstant(content.getCreatedAt(), ZoneId.systemDefault())
                         : null

--- a/src/main/java/com/mzc/lp/domain/content/dto/response/ContentResponse.java
+++ b/src/main/java/com/mzc/lp/domain/content/dto/response/ContentResponse.java
@@ -22,10 +22,15 @@ public record ContentResponse(
         String thumbnailPath,
         Long createdBy,
         Integer currentVersion,
+        Boolean inCourse,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
     public static ContentResponse from(Content content) {
+        return from(content, null);
+    }
+
+    public static ContentResponse from(Content content, Boolean inCourse) {
         return new ContentResponse(
                 content.getId(),
                 content.getOriginalFileName(),
@@ -41,6 +46,7 @@ public record ContentResponse(
                 content.getThumbnailPath(),
                 content.getCreatedBy(),
                 content.getCurrentVersion(),
+                inCourse,
                 content.getCreatedAt() != null
                         ? LocalDateTime.ofInstant(content.getCreatedAt(), ZoneId.systemDefault())
                         : null,

--- a/src/main/java/com/mzc/lp/domain/course/repository/CourseItemRepository.java
+++ b/src/main/java/com/mzc/lp/domain/course/repository/CourseItemRepository.java
@@ -40,4 +40,12 @@ public interface CourseItemRepository extends JpaRepository<CourseItem, Long> {
     long countByCourseIdAndTenantId(Long courseId, Long tenantId);
 
     long countByCourseIdAndTenantIdAndLearningObjectIdIsNotNull(Long courseId, Long tenantId);
+
+    /**
+     * 특정 콘텐츠가 LearningObject를 통해 강의(Course)에 포함되어 있는지 확인
+     */
+    @Query("SELECT CASE WHEN COUNT(ci) > 0 THEN true ELSE false END " +
+           "FROM CourseItem ci WHERE ci.learningObjectId IN " +
+           "(SELECT lo.id FROM LearningObject lo WHERE lo.content.id = :contentId)")
+    boolean existsByContentIdThroughLearningObject(@Param("contentId") Long contentId);
 }


### PR DESCRIPTION
## Summary

강의(Course)에 포함된 콘텐츠의 수정/삭제를 제한하는 기능 구현

## Related Issue

- Closes #140

## Changes

- `CourseItemRepository`: `existsByContentIdThroughLearningObject()` 메서드 추가
- `ContentServiceImpl`: `isContentInCourse()`, `validateContentNotInUse()` 메서드 추가
- `ContentResponse`: `inCourse` 필드 추가
- `ContentListResponse`: `inCourse` 필드 추가
- 강의에 포함된 콘텐츠 수정/삭제 시 CT010 에러 반환

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- Content → LearningObject → CourseItem 연결 체인을 통해 강의 포함 여부 확인
- 단건 조회 시에만 `inCourse` 값을 계산하여 반환 (목록 조회는 N+1 방지를 위해 null)