### PR TITLE
perf: 콘텐츠 폴더 N+1 쿼리 최적화 및 낙관적 락 추가 (#141)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/learning/entity/ContentFolder.java
+++ b/src/main/java/com/mzc/lp/domain/learning/entity/ContentFolder.java
@@ -21,6 +21,9 @@ public class ContentFolder extends TenantEntity {
 
     public static final int MAX_DEPTH = 2; // 0, 1, 2 -> 3단계
 
+    @Version
+    private Long version;
+
     @Column(name = "folder_name", nullable = false, length = 255)
     private String folderName;
 

--- a/src/main/java/com/mzc/lp/domain/learning/entity/LearningObject.java
+++ b/src/main/java/com/mzc/lp/domain/learning/entity/LearningObject.java
@@ -18,6 +18,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LearningObject extends TenantEntity {
 
+    @Version
+    private Long version;
+
     @Column(name = "name", nullable = false, length = 500)
     private String name;
 

--- a/src/main/java/com/mzc/lp/domain/learning/repository/ContentFolderRepository.java
+++ b/src/main/java/com/mzc/lp/domain/learning/repository/ContentFolderRepository.java
@@ -21,6 +21,12 @@ public interface ContentFolderRepository extends JpaRepository<ContentFolder, Lo
     @Query("SELECT cf FROM ContentFolder cf WHERE cf.tenantId = :tenantId ORDER BY cf.depth ASC, cf.folderName ASC")
     List<ContentFolder> findAllByTenantIdOrdered(@Param("tenantId") Long tenantId);
 
+    @Query("SELECT DISTINCT cf FROM ContentFolder cf " +
+            "LEFT JOIN FETCH cf.children " +
+            "WHERE cf.tenantId = :tenantId " +
+            "ORDER BY cf.depth ASC, cf.folderName ASC")
+    List<ContentFolder> findAllWithChildrenByTenantId(@Param("tenantId") Long tenantId);
+
     boolean existsByTenantIdAndParentIdAndFolderName(Long tenantId, Long parentId, String folderName);
 
     boolean existsByTenantIdAndParentIsNullAndFolderName(Long tenantId, String folderName);

--- a/src/main/java/com/mzc/lp/domain/learning/service/ContentFolderServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/learning/service/ContentFolderServiceImpl.java
@@ -53,10 +53,13 @@ public class ContentFolderServiceImpl implements ContentFolderService {
 
     @Override
     public List<ContentFolderResponse> getFolderTree(Long tenantId) {
-        List<ContentFolder> rootFolders = contentFolderRepository
-                .findByTenantIdAndParentIsNullOrderByFolderNameAsc(tenantId);
+        // JOIN FETCH로 모든 폴더를 한 번에 조회 (N+1 최적화)
+        List<ContentFolder> allFolders = contentFolderRepository
+                .findAllWithChildrenByTenantId(tenantId);
 
-        return rootFolders.stream()
+        // 루트 폴더만 필터링 (children은 이미 로드됨)
+        return allFolders.stream()
+                .filter(folder -> folder.getParent() == null)
                 .map(ContentFolderResponse::fromWithChildren)
                 .toList();
     }


### PR DESCRIPTION
## Summary
- ContentFolder, LearningObject 엔티티에 @Version 추가 (낙관적 락)
- JOIN FETCH 쿼리로 폴더 트리 조회 시 N+1 문제 해결
- getFolderTree()에서 최적화된 쿼리 사용

## Changes
- `ContentFolder.java`: @Version 필드 추가
- `LearningObject.java`: @Version 필드 추가
- `ContentFolderRepository.java`: findAllWithChildrenByTenantId() JOIN FETCH 쿼리 추가
- `ContentFolderServiceImpl.java`: getFolderTree() 최적화

## Test
- [x] API 테스트 완료 (폴더 트리 조회)
- [x] DB 테스트 완료 (version 컬럼 확인)