### PR TITLE
feat(snapshot): 낙관적 락 추가

### DIFF
--- a/src/main/java/com/mzc/lp/domain/snapshot/entity/CourseSnapshot.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/entity/CourseSnapshot.java
@@ -23,6 +23,10 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CourseSnapshot extends TenantEntity {
 
+    // JPA 낙관적 락 (동시 수정 감지)
+    @Version
+    private Long jpaVersion;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "source_course_id")
     private Course sourceCourse;

--- a/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotItem.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotItem.java
@@ -20,6 +20,10 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SnapshotItem extends TenantEntity {
 
+    // 낙관적 락 (동시 수정 감지)
+    @Version
+    private Long version;
+
     private static final int MAX_DEPTH = 9;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotLearningObject.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotLearningObject.java
@@ -16,6 +16,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SnapshotLearningObject extends TenantEntity {
 
+    // 낙관적 락 (동시 수정 감지)
+    @Version
+    private Long version;
+
     @Column(name = "source_lo_id")
     private Long sourceLoId;
 

--- a/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotRelation.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotRelation.java
@@ -18,6 +18,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SnapshotRelation extends TenantEntity {
 
+    // 낙관적 락 (동시 수정 감지)
+    @Version
+    private Long version;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "snapshot_id", nullable = false)
     private CourseSnapshot snapshot;


### PR DESCRIPTION
## Summary
- Snapshot 도메인 엔티티에 낙관적 락(@Version) 추가
- 팀 컨벤션 일관성 유지 (Course, Program 등과 동일 패턴)

## Related Issue
- Closes #148

## Changes
| 엔티티 | 변경 내용 |
|--------|----------|
| `CourseSnapshot` | `jpaVersion` 필드 추가 (기존 `version`은 비즈니스 버전) |
| `SnapshotItem` | `version` 필드 추가 |
| `SnapshotRelation` | `version` 필드 추가 |
| `SnapshotLearningObject` | `version` 필드 추가 |

## DB Migration
- `ddl-auto: update` 사용으로 자동 적용
- 운영 배포 시 참고용 SQL:
```sql
ALTER TABLE cm_snapshots ADD COLUMN jpa_version BIGINT DEFAULT 0;
ALTER TABLE cm_snapshot_items ADD COLUMN version BIGINT DEFAULT 0;
ALTER TABLE cm_snapshot_relations ADD COLUMN version BIGINT DEFAULT 0;
ALTER TABLE cm_snapshot_los ADD COLUMN version BIGINT DEFAULT 0;
```

## Test plan
- [x] 컴파일 성공
- [x] 전체 테스트 통과