### PR TITLE
feat: IIS 강사 배정 통계 API 구현 (#128)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
+++ b/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
@@ -9,6 +9,8 @@ import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
 import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
 import com.mzc.lp.domain.iis.dto.response.AssignmentHistoryResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
+import com.mzc.lp.domain.iis.dto.response.InstructorStatResponse;
+import com.mzc.lp.domain.iis.dto.response.InstructorStatisticsResponse;
 import com.mzc.lp.domain.iis.service.InstructorAssignmentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -107,6 +109,24 @@ public class InstructorAssignmentController {
             @AuthenticationPrincipal UserPrincipal principal
     ) {
         List<InstructorAssignmentResponse> response = assignmentService.getMyAssignments(principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // ========== 통계 API ==========
+
+    @GetMapping("/api/instructor-assignments/statistics")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<InstructorStatisticsResponse>> getStatistics() {
+        InstructorStatisticsResponse response = assignmentService.getStatistics();
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/api/users/{userId}/instructor-statistics")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<InstructorStatResponse>> getInstructorStatistics(
+            @PathVariable Long userId
+    ) {
+        InstructorStatResponse response = assignmentService.getInstructorStatistics(userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/iis/dto/response/InstructorStatResponse.java
+++ b/src/main/java/com/mzc/lp/domain/iis/dto/response/InstructorStatResponse.java
@@ -1,0 +1,13 @@
+package com.mzc.lp.domain.iis.dto.response;
+
+public record InstructorStatResponse(
+        Long userId,
+        String userName,
+        Long totalCount,
+        Long mainCount,
+        Long subCount
+) {
+    public static InstructorStatResponse of(Long userId, String userName, Long totalCount, Long mainCount, Long subCount) {
+        return new InstructorStatResponse(userId, userName, totalCount, mainCount, subCount);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/iis/dto/response/InstructorStatisticsResponse.java
+++ b/src/main/java/com/mzc/lp/domain/iis/dto/response/InstructorStatisticsResponse.java
@@ -1,0 +1,25 @@
+package com.mzc.lp.domain.iis.dto.response;
+
+import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.constant.InstructorRole;
+
+import java.util.List;
+import java.util.Map;
+
+public record InstructorStatisticsResponse(
+        Long totalAssignments,
+        Long activeAssignments,
+        Map<InstructorRole, Long> byRole,
+        Map<AssignmentStatus, Long> byStatus,
+        List<InstructorStatResponse> instructorStats
+) {
+    public static InstructorStatisticsResponse of(
+            Long totalAssignments,
+            Long activeAssignments,
+            Map<InstructorRole, Long> byRole,
+            Map<AssignmentStatus, Long> byStatus,
+            List<InstructorStatResponse> instructorStats
+    ) {
+        return new InstructorStatisticsResponse(totalAssignments, activeAssignments, byRole, byStatus, instructorStats);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/iis/repository/InstructorAssignmentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/iis/repository/InstructorAssignmentRepository.java
@@ -93,4 +93,41 @@ public interface InstructorAssignmentRepository extends JpaRepository<Instructor
     List<InstructorAssignment> findActiveByTimeKeyIn(
             @Param("timeKeys") List<Long> timeKeys,
             @Param("tenantId") Long tenantId);
+
+    // ========== 통계 API용 메서드 ==========
+
+    // 전체 배정 건수
+    long countByTenantId(Long tenantId);
+
+    // 상태별 배정 건수
+    long countByTenantIdAndStatus(Long tenantId, AssignmentStatus status);
+
+    // 역할별 집계
+    @Query("SELECT ia.role, COUNT(ia) FROM InstructorAssignment ia " +
+            "WHERE ia.tenantId = :tenantId " +
+            "GROUP BY ia.role")
+    List<Object[]> countGroupByRole(@Param("tenantId") Long tenantId);
+
+    // 상태별 집계
+    @Query("SELECT ia.status, COUNT(ia) FROM InstructorAssignment ia " +
+            "WHERE ia.tenantId = :tenantId " +
+            "GROUP BY ia.status")
+    List<Object[]> countGroupByStatus(@Param("tenantId") Long tenantId);
+
+    // 강사별 통계 (ACTIVE 상태만)
+    @Query("SELECT ia.userKey, COUNT(ia), " +
+            "SUM(CASE WHEN ia.role = 'MAIN' THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN ia.role = 'SUB' THEN 1 ELSE 0 END) " +
+            "FROM InstructorAssignment ia " +
+            "WHERE ia.tenantId = :tenantId AND ia.status = 'ACTIVE' " +
+            "GROUP BY ia.userKey")
+    List<Object[]> getInstructorStatistics(@Param("tenantId") Long tenantId);
+
+    // 특정 강사의 통계
+    @Query("SELECT COUNT(ia), " +
+            "SUM(CASE WHEN ia.role = 'MAIN' THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN ia.role = 'SUB' THEN 1 ELSE 0 END) " +
+            "FROM InstructorAssignment ia " +
+            "WHERE ia.tenantId = :tenantId AND ia.userKey = :userKey AND ia.status = 'ACTIVE'")
+    Object[] getInstructorStatisticsByUserId(@Param("tenantId") Long tenantId, @Param("userKey") Long userKey);
 }

--- a/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentService.java
+++ b/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentService.java
@@ -8,6 +8,8 @@ import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
 import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
 import com.mzc.lp.domain.iis.dto.response.AssignmentHistoryResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
+import com.mzc.lp.domain.iis.dto.response.InstructorStatResponse;
+import com.mzc.lp.domain.iis.dto.response.InstructorStatisticsResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -59,4 +61,19 @@ public interface InstructorAssignmentService {
      * @return 이력 목록 (최신순 정렬)
      */
     List<AssignmentHistoryResponse> getAssignmentHistories(Long assignmentId, AssignmentAction action);
+
+    // ========== 통계 API ==========
+
+    /**
+     * 전체 강사 배정 통계 조회
+     * @return 전체 통계 (역할별, 상태별, 강사별)
+     */
+    InstructorStatisticsResponse getStatistics();
+
+    /**
+     * 특정 강사의 배정 통계 조회
+     * @param userId 강사 ID
+     * @return 강사 개인 통계
+     */
+    InstructorStatResponse getInstructorStatistics(Long userId);
 }


### PR DESCRIPTION
## Summary

IIS 강사 배정 통계 API 구현. 관리자 대시보드에서 강사별 배정 현황을 확인할 수 있는 통계 기능 제공.

## Related Issue

- Closes #128

## Changes

- `InstructorStatResponse` DTO 생성 (강사 개인 통계)
- `InstructorStatisticsResponse` DTO 생성 (전체 통계)
- `InstructorAssignmentRepository`에 통계 쿼리 메서드 추가
- `InstructorAssignmentService`에 통계 조회 메서드 추가
- 전체 통계 API: `GET /api/instructor-assignments/statistics`
- 강사 개인 통계 API: `GET /api/users/{userId}/instructor-statistics`

### 통계 항목
- 전체/활성 배정 건수
- 역할별 집계 (MAIN/SUB/ASSISTANT)
- 상태별 집계 (ACTIVE/CANCELLED/REPLACED)
- 강사별 배정 현황 (총 건수, MAIN 건수, SUB 건수)

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## API Response Example

```json
// GET /api/instructor-assignments/statistics
{
  "success": true,
  "data": {
    "totalAssignments": 50,
    "activeAssignments": 35,
    "byRole": { "MAIN": 20, "SUB": 15, "ASSISTANT": 15 },
    "byStatus": { "ACTIVE": 35, "CANCELLED": 10, "REPLACED": 5 },
    "instructorStats": [
      { "userId": 1, "userName": "홍길동", "totalCount": 10, "mainCount": 5, "subCount": 5 }
    ]
  }
}
```
Additional Notes
권한: OPERATOR, TENANT_ADMIN만 접근 가능
테넌트 격리 적용
N+1 방지를 위한 User 벌크 조회 적용