### PR TITLE
[Fix] : 강사 통계 API JPA 쿼리 결과 타입 캐스팅 오류 수정

### DIFF
--- a/src/main/java/com/mzc/lp/domain/iis/repository/InstructorAssignmentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/iis/repository/InstructorAssignmentRepository.java
@@ -129,5 +129,5 @@ public interface InstructorAssignmentRepository extends JpaRepository<Instructor
             "SUM(CASE WHEN ia.role = 'SUB' THEN 1 ELSE 0 END) " +
             "FROM InstructorAssignment ia " +
             "WHERE ia.tenantId = :tenantId AND ia.userKey = :userKey AND ia.status = 'ACTIVE'")
-    Object[] getInstructorStatisticsByUserId(@Param("tenantId") Long tenantId, @Param("userKey") Long userKey);
+    List<Object[]> getInstructorStatisticsByUserId(@Param("tenantId") Long tenantId, @Param("userKey") Long userKey);
 }


### PR DESCRIPTION
## Summary

IIS 강사 통계 API에서 JPA 쿼리 결과 타입 캐스팅 오류(ClassCastException) 수정

## Related Issue

- Closes #128

## Changes

- `InstructorAssignmentRepository`: `getInstructorStatisticsByUserId` 반환 타입을 `Object[]` → `List<Object[]>`로 변경
- `InstructorAssignmentServiceImpl`: Number 타입 캐스팅으로 DB별 타입 차이 대응 (Long, Integer)
- `InstructorAssignmentServiceImpl`: SUM() 결과 null 체크 추가 (데이터 없을 때 null 반환)
- `InstructorAssignmentServiceTest`: Mock 반환값 타입 수정

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

JPA @Query의 집계 함수 반환 타입 처리 시 주의사항:
- GROUP BY 없는 집계 쿼리도 `List<Object[]>` 반환
- SUM()은 데이터 없을 때 null 반환 (COUNT는 0 반환)
- DB별로 Long/Integer 등 타입이 다를 수 있으므로 Number로 캐스팅 권장