### PR TITLE
refactor: 차수 목록 조회 쿼리 최적화

### DIFF
--- a/src/main/java/com/mzc/lp/domain/ts/repository/CourseTimeRepository.java
+++ b/src/main/java/com/mzc/lp/domain/ts/repository/CourseTimeRepository.java
@@ -44,6 +44,16 @@ public interface CourseTimeRepository extends JpaRepository<CourseTime, Long> {
             @Param("statuses") List<CourseTimeStatus> statuses
     );
 
+    Page<CourseTime> findByCmCourseIdAndTenantId(Long cmCourseId, Long tenantId, Pageable pageable);
+
+    @Query("SELECT ct FROM CourseTime ct WHERE ct.cmCourseId = :cmCourseId AND ct.tenantId = :tenantId AND ct.status = :status")
+    Page<CourseTime> findByCmCourseIdAndTenantIdAndStatus(
+            @Param("cmCourseId") Long cmCourseId,
+            @Param("tenantId") Long tenantId,
+            @Param("status") CourseTimeStatus status,
+            Pageable pageable
+    );
+
     boolean existsByCmCourseIdAndTenantIdAndStatus(Long cmCourseId, Long tenantId, CourseTimeStatus status);
 
     // ===== 배치 Job용 쿼리 =====


### PR DESCRIPTION
## Summary

차수 목록 조회 시 메모리 필터링을 DB 레벨 필터링으로 변경하여 성능 개선

## Related Issue

- Closes #155

## Changes

- `CourseTimeRepository`: 페이징 지원 쿼리 메서드 2개 추가
- `CourseTimeServiceImpl.getCourseTimes()`: 조건별 Repository 메서드 활용으로 리팩토링
- `PageImpl` 직접 생성 제거로 페이징 정확성 개선

## Type of Change

- [x] Refactor: 리팩토링

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 기존: 전체 데이터 조회 후 메모리에서 필터링 → 페이징 부정확
- 변경: DB에서 조건 필터링 후 페이징 → 정확한 totalElements