### PR TITLE
feat : TS 차수 생성 시 날짜 검증 강화 및 CI 설정 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           JWT_SECRET: ${{ secrets.JWT_SECRET || 'test-jwt-secret-key-that-is-at-least-256-bits-long-for-hmac-sha256' }}
 
       - name: SonarQube Scan
-        if: ${{ secrets.SONAR_TOKEN != '' && secrets.SONAR_HOST_URL != '' }}
+        if: ${{ env.SONAR_TOKEN != '' && env.SONAR_HOST_URL != '' }}
         run: ./gradlew sonar
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           JWT_SECRET: ${{ secrets.JWT_SECRET || 'test-jwt-secret-key-that-is-at-least-256-bits-long-for-hmac-sha256' }}
 
       - name: SonarQube Scan
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ secrets.SONAR_TOKEN != '' && secrets.SONAR_HOST_URL != '' }}
         run: ./gradlew sonar
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
   build:
     name: Build & Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
 
     steps:
       - name: Checkout code

--- a/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeServiceImpl.java
@@ -360,7 +360,8 @@ public class CourseTimeServiceImpl implements CourseTimeService {
                 request.enrollStartDate(),
                 request.enrollEndDate(),
                 request.classStartDate(),
-                request.classEndDate()
+                request.classEndDate(),
+                true
         );
     }
 
@@ -370,19 +371,34 @@ public class CourseTimeServiceImpl implements CourseTimeService {
             LocalDate classStartDate,
             LocalDate classEndDate
     ) {
-        // [R09] enroll_end_date <= class_end_date
-        if (enrollEndDate.isAfter(classEndDate)) {
-            throw new InvalidDateRangeException("모집 종료일은 학습 종료일 이전이어야 합니다");
+        validateDateRange(enrollStartDate, enrollEndDate, classStartDate, classEndDate, false);
+    }
+
+    private void validateDateRange(
+            LocalDate enrollStartDate,
+            LocalDate enrollEndDate,
+            LocalDate classStartDate,
+            LocalDate classEndDate,
+            boolean isNewCreation
+    ) {
+        // [R-DATE-04] 모집 시작일 >= 오늘 (신규 생성 시)
+        if (isNewCreation && enrollStartDate.isBefore(LocalDate.now())) {
+            throw new InvalidDateRangeException("모집 시작일은 오늘 이후여야 합니다");
         }
 
-        // 모집 시작일 <= 모집 종료일
+        // [R-DATE-01] 모집 시작일 <= 모집 종료일
         if (enrollStartDate.isAfter(enrollEndDate)) {
             throw new InvalidDateRangeException("모집 시작일은 모집 종료일 이전이어야 합니다");
         }
 
-        // 학습 시작일 <= 학습 종료일
+        // [R-DATE-02] 학습 시작일 <= 학습 종료일
         if (classStartDate.isAfter(classEndDate)) {
             throw new InvalidDateRangeException("학습 시작일은 학습 종료일 이전이어야 합니다");
+        }
+
+        // [R-DATE-03] 모집 종료일 <= 학습 시작일
+        if (enrollEndDate.isAfter(classStartDate)) {
+            throw new InvalidDateRangeException("모집 종료일은 학습 시작일 이전이어야 합니다");
         }
     }
 


### PR DESCRIPTION
## Summary

차수 생성 시 날짜 검증 로직을 강화하여 데이터 정합성 개선

## Related Issue

- Closes #156

## Changes

- `validateDateRange()`: 신규 생성 여부를 구분하는 오버로드 메서드 추가
- R-DATE-03: 모집 종료일 ≤ 학습 시작일 검증 추가
- R-DATE-04: 모집 시작일 ≥ 오늘 검증 추가 (신규 생성 시에만 적용)

## 추가 변경사항
- CI workflow에 `permissions` 설정 추가 (test-reporter 권한 오류 해결)
  - `contents: read`
  - `checks: write`
  - `pull-requests: write`
- SonarQube Scan secrets 미설정 시 skip 처리
  - if 조건에서 secrets 직접 참조 불가하여 env로 변경
  - `SONAR_TOKEN`, `SONAR_HOST_URL` 미설정 시 SonarQube Scan 단계 건너뜀
  
## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Test plan
- [x] R-DATE-03: 모집 종료일 > 학습 시작일 시 `InvalidDateRangeException` 발생 확인
- [x] R-DATE-04: 과거 날짜로 모집 시작일 설정 시 `InvalidDateRangeException` 발생 확인
- [x] 오늘 날짜로 모집 시작일 설정 시 정상 생성 확인
- [x] getCapacity, getPrice 테스트가 테넌트 검증과 함께 정상 동작 확인
- [x] 전체 테스트 통과 확인 (515+ tests)

## Additional Notes

| 규칙 | 설명 | 적용 시점 |
|------|------|-----------|
| R-DATE-01 | 모집 시작일 ≤ 모집 종료일 | 생성/수정 |
| R-DATE-02 | 학습 시작일 ≤ 학습 종료일 | 생성/수정 |
| R-DATE-03 | 모집 종료일 ≤ 학습 시작일 | 생성/수정 |
| R-DATE-04 | 모집 시작일 ≥ 오늘 | 신규 생성 시에만 |