### PR TITLE
feat: 강사 배정 통계 API 기간 필터링 및 차수별 상세 통계 기능 추가 (#130)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
+++ b/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
@@ -9,6 +9,7 @@ import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
 import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
 import com.mzc.lp.domain.iis.dto.response.AssignmentHistoryResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
+import com.mzc.lp.domain.iis.dto.response.InstructorDetailStatResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorStatResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorStatisticsResponse;
 import com.mzc.lp.domain.iis.service.InstructorAssignmentService;
@@ -17,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -24,6 +26,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -116,17 +119,22 @@ public class InstructorAssignmentController {
 
     @GetMapping("/api/instructor-assignments/statistics")
     @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
-    public ResponseEntity<ApiResponse<InstructorStatisticsResponse>> getStatistics() {
-        InstructorStatisticsResponse response = assignmentService.getStatistics();
+    public ResponseEntity<ApiResponse<InstructorStatisticsResponse>> getStatistics(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    ) {
+        InstructorStatisticsResponse response = assignmentService.getStatistics(startDate, endDate);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @GetMapping("/api/users/{userId}/instructor-statistics")
     @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
-    public ResponseEntity<ApiResponse<InstructorStatResponse>> getInstructorStatistics(
-            @PathVariable Long userId
+    public ResponseEntity<ApiResponse<InstructorDetailStatResponse>> getInstructorStatistics(
+            @PathVariable Long userId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
     ) {
-        InstructorStatResponse response = assignmentService.getInstructorStatistics(userId);
+        InstructorDetailStatResponse response = assignmentService.getInstructorDetailStatistics(userId, startDate, endDate);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/iis/dto/response/CourseTimeStatResponse.java
+++ b/src/main/java/com/mzc/lp/domain/iis/dto/response/CourseTimeStatResponse.java
@@ -1,0 +1,55 @@
+package com.mzc.lp.domain.iis.dto.response;
+
+import com.mzc.lp.domain.iis.constant.InstructorRole;
+
+import java.math.BigDecimal;
+
+/**
+ * 차수별 강사 통계 Response
+ */
+public record CourseTimeStatResponse(
+        Long timeKey,
+        String courseName,
+        String timeName,
+        InstructorRole role,
+        Long totalStudents,
+        Long completedStudents,
+        BigDecimal completionRate
+) {
+    public static CourseTimeStatResponse of(
+            Long timeKey,
+            String courseName,
+            String timeName,
+            InstructorRole role,
+            Long totalStudents,
+            Long completedStudents,
+            BigDecimal completionRate
+    ) {
+        return new CourseTimeStatResponse(
+                timeKey,
+                courseName,
+                timeName,
+                role,
+                totalStudents,
+                completedStudents,
+                completionRate
+        );
+    }
+
+    public static CourseTimeStatResponse withoutStudentStats(
+            Long timeKey,
+            String courseName,
+            String timeName,
+            InstructorRole role
+    ) {
+        return new CourseTimeStatResponse(
+                timeKey,
+                courseName,
+                timeName,
+                role,
+                null,
+                null,
+                null
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/iis/dto/response/InstructorDetailStatResponse.java
+++ b/src/main/java/com/mzc/lp/domain/iis/dto/response/InstructorDetailStatResponse.java
@@ -1,0 +1,44 @@
+package com.mzc.lp.domain.iis.dto.response;
+
+import java.util.List;
+
+/**
+ * 강사 개인 상세 통계 Response (차수별 통계 포함)
+ */
+public record InstructorDetailStatResponse(
+        Long userId,
+        String userName,
+        Long totalCount,
+        Long mainCount,
+        Long subCount,
+        List<CourseTimeStatResponse> courseTimeStats
+) {
+    public static InstructorDetailStatResponse of(
+            Long userId,
+            String userName,
+            Long totalCount,
+            Long mainCount,
+            Long subCount,
+            List<CourseTimeStatResponse> courseTimeStats
+    ) {
+        return new InstructorDetailStatResponse(
+                userId,
+                userName,
+                totalCount,
+                mainCount,
+                subCount,
+                courseTimeStats != null ? courseTimeStats : List.of()
+        );
+    }
+
+    public static InstructorDetailStatResponse from(InstructorStatResponse stat, List<CourseTimeStatResponse> courseTimeStats) {
+        return new InstructorDetailStatResponse(
+                stat.userId(),
+                stat.userName(),
+                stat.totalCount(),
+                stat.mainCount(),
+                stat.subCount(),
+                courseTimeStats != null ? courseTimeStats : List.of()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentService.java
+++ b/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentService.java
@@ -8,11 +8,13 @@ import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
 import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
 import com.mzc.lp.domain.iis.dto.response.AssignmentHistoryResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
+import com.mzc.lp.domain.iis.dto.response.InstructorDetailStatResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorStatResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorStatisticsResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
@@ -71,9 +73,26 @@ public interface InstructorAssignmentService {
     InstructorStatisticsResponse getStatistics();
 
     /**
+     * 전체 강사 배정 통계 조회 (기간 필터링)
+     * @param startDate 시작일 (null이면 전체 기간)
+     * @param endDate 종료일 (null이면 전체 기간)
+     * @return 전체 통계 (역할별, 상태별, 강사별)
+     */
+    InstructorStatisticsResponse getStatistics(LocalDate startDate, LocalDate endDate);
+
+    /**
      * 특정 강사의 배정 통계 조회
      * @param userId 강사 ID
      * @return 강사 개인 통계
      */
     InstructorStatResponse getInstructorStatistics(Long userId);
+
+    /**
+     * 특정 강사의 상세 배정 통계 조회 (차수별 통계 포함)
+     * @param userId 강사 ID
+     * @param startDate 시작일 (null이면 전체 기간)
+     * @param endDate 종료일 (null이면 전체 기간)
+     * @return 강사 개인 상세 통계 (차수별 통계 포함)
+     */
+    InstructorDetailStatResponse getInstructorDetailStatistics(Long userId, LocalDate startDate, LocalDate endDate);
 }


### PR DESCRIPTION
## Summary

강사 배정 통계 API에 기간 필터링 기능과 차수별 상세 통계 기능을 추가합니다.

## Related Issue

- Closes #130

## Changes

- 통계 API에 `startDate`, `endDate` 파라미터 추가하여 기간 필터링 지원
- 강사 개인 통계에 차수별 상세 정보(`courseTimeStats`) 포함
- SIS 모듈 연동으로 수강생 수, 수료자 수, 수료율 제공
- Repository에 기간 필터링 쿼리 메서드 추가
- 테스트 코드 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### 변경된 파일
| 파일 | 변경 내용 |
|------|----------|
| `CourseTimeStatResponse.java` | 차수별 통계 DTO 생성 |
| `InstructorDetailStatResponse.java` | courseTimeStats 필드 포함 DTO 생성 |
| `InstructorAssignmentRepository.java` | 기간 필터링 쿼리 추가 |
| `InstructorAssignmentService.java` | 인터페이스 메서드 추가 |
| `InstructorAssignmentServiceImpl.java` | 기간 필터링 및 차수별 통계 구현 |
| `InstructorAssignmentController.java` | @RequestParam 추가 |
| `InstructorAssignmentServiceTest.java` | 테스트 케이스 추가 |