### PR TITLE
feat : 강사 본인 통계 조회 API 추가 (#170)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
+++ b/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
@@ -127,6 +127,17 @@ public class InstructorAssignmentController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @GetMapping("/api/users/me/instructor-statistics")
+    public ResponseEntity<ApiResponse<InstructorDetailStatResponse>> getMyInstructorStatistics(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    ) {
+        InstructorDetailStatResponse response = assignmentService.getInstructorDetailStatistics(
+                principal.id(), startDate, endDate);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
     @GetMapping("/api/users/{userId}/instructor-statistics")
     @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<InstructorDetailStatResponse>> getInstructorStatistics(


### PR DESCRIPTION
## Summary

강사 본인이 자신의 배정 통계를 조회할 수 있는 API를 추가합니다.

## Related Issue

- Closes #170

## Changes

- `GET /api/users/me/instructor-statistics` 엔드포인트 추가
- 기간 필터링 지원 (startDate, endDate 쿼리 파라미터)
- 로그인 사용자 본인만 접근 가능 (별도 권한 제한 없음)
- 기존 `getInstructorDetailStatistics` 메서드 재사용
- 테스트 코드 3건 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 기존 `/api/users/{userId}/instructor-statistics`는 OPERATOR, TENANT_ADMIN만 접근 가능
- 새로 추가된 `/api/users/me/instructor-statistics`는 인증된 사용자 본인만 접근 가능