### PR TITLE
refactor: CourseTime Entity에 상태 전이 검증 로직 추가 (#151)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/ts/entity/CourseTime.java
+++ b/src/main/java/com/mzc/lp/domain/ts/entity/CourseTime.java
@@ -5,6 +5,7 @@ import com.mzc.lp.domain.program.entity.Program;
 import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
 import com.mzc.lp.domain.ts.constant.DeliveryType;
 import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
+import com.mzc.lp.domain.ts.exception.InvalidStatusTransitionException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -240,19 +241,47 @@ public class CourseTime extends TenantEntity {
 
     // 상태 전이 메서드
 
+    /**
+     * DRAFT → RECRUITING 상태 전이
+     * @throws InvalidStatusTransitionException DRAFT 상태가 아닌 경우
+     */
     public void open() {
+        if (this.status != CourseTimeStatus.DRAFT) {
+            throw new InvalidStatusTransitionException(this.status, CourseTimeStatus.RECRUITING);
+        }
         this.status = CourseTimeStatus.RECRUITING;
     }
 
+    /**
+     * RECRUITING → ONGOING 상태 전이
+     * @throws InvalidStatusTransitionException RECRUITING 상태가 아닌 경우
+     */
     public void startClass() {
+        if (this.status != CourseTimeStatus.RECRUITING) {
+            throw new InvalidStatusTransitionException(this.status, CourseTimeStatus.ONGOING);
+        }
         this.status = CourseTimeStatus.ONGOING;
     }
 
+    /**
+     * ONGOING → CLOSED 상태 전이
+     * @throws InvalidStatusTransitionException ONGOING 상태가 아닌 경우
+     */
     public void close() {
+        if (this.status != CourseTimeStatus.ONGOING) {
+            throw new InvalidStatusTransitionException(this.status, CourseTimeStatus.CLOSED);
+        }
         this.status = CourseTimeStatus.CLOSED;
     }
 
+    /**
+     * CLOSED → ARCHIVED 상태 전이
+     * @throws InvalidStatusTransitionException CLOSED 상태가 아닌 경우
+     */
     public void archive() {
+        if (this.status != CourseTimeStatus.CLOSED) {
+            throw new InvalidStatusTransitionException(this.status, CourseTimeStatus.ARCHIVED);
+        }
         this.status = CourseTimeStatus.ARCHIVED;
     }
 

--- a/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeServiceImpl.java
@@ -254,13 +254,6 @@ public class CourseTimeServiceImpl implements CourseTimeService {
         CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, TenantContext.getCurrentTenantId())
                 .orElseThrow(() -> new CourseTimeNotFoundException(id));
 
-        if (!courseTime.isDraft()) {
-            throw new InvalidStatusTransitionException(
-                    courseTime.getStatus(),
-                    CourseTimeStatus.RECRUITING
-            );
-        }
-
         // 장소 정보 필수 검증 (OFFLINE/BLENDED)
         if (courseTime.requiresLocationInfo() &&
                 (courseTime.getLocationInfo() == null || courseTime.getLocationInfo().isBlank())) {
@@ -272,6 +265,7 @@ public class CourseTimeServiceImpl implements CourseTimeService {
             throw new MainInstructorRequiredException(id);
         }
 
+        // 상태 전이 (Entity에서 DRAFT 상태 검증)
         courseTime.open();
         log.info("Course time opened: id={}", id);
 
@@ -289,13 +283,7 @@ public class CourseTimeServiceImpl implements CourseTimeService {
         CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, TenantContext.getCurrentTenantId())
                 .orElseThrow(() -> new CourseTimeNotFoundException(id));
 
-        if (!courseTime.isRecruiting()) {
-            throw new InvalidStatusTransitionException(
-                    courseTime.getStatus(),
-                    CourseTimeStatus.ONGOING
-            );
-        }
-
+        // 상태 전이 (Entity에서 RECRUITING 상태 검증)
         courseTime.startClass();
         log.info("Course time started: id={}", id);
 
@@ -313,13 +301,7 @@ public class CourseTimeServiceImpl implements CourseTimeService {
         CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, TenantContext.getCurrentTenantId())
                 .orElseThrow(() -> new CourseTimeNotFoundException(id));
 
-        if (!courseTime.isOngoing()) {
-            throw new InvalidStatusTransitionException(
-                    courseTime.getStatus(),
-                    CourseTimeStatus.CLOSED
-            );
-        }
-
+        // 상태 전이 (Entity에서 ONGOING 상태 검증)
         courseTime.close();
         log.info("Course time closed: id={}", id);
 
@@ -337,13 +319,7 @@ public class CourseTimeServiceImpl implements CourseTimeService {
         CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, TenantContext.getCurrentTenantId())
                 .orElseThrow(() -> new CourseTimeNotFoundException(id));
 
-        if (!courseTime.isClosed()) {
-            throw new InvalidStatusTransitionException(
-                    courseTime.getStatus(),
-                    CourseTimeStatus.ARCHIVED
-            );
-        }
-
+        // 상태 전이 (Entity에서 CLOSED 상태 검증)
         courseTime.archive();
         log.info("Course time archived: id={}", id);
 


### PR DESCRIPTION
## Summary

- CourseTime Entity의 상태 전이 메서드에 검증 로직 추가 (DDD 원칙)
- Service 레이어의 중복 검증 로직 제거

## Related Issue

- Closes #151

## Changes

- `CourseTime.open()`: DRAFT 상태 검증 추가
- `CourseTime.startClass()`: RECRUITING 상태 검증 추가
- `CourseTime.close()`: ONGOING 상태 검증 추가
- `CourseTime.archive()`: CLOSED 상태 검증 추가
- `CourseTimeServiceImpl`: Entity 위임으로 변경, 중복 검증 제거

## Type of Change

- [x] Refactor: 리팩토링

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 로컬에서 테스트가 통과합니다

## Test plan

- [x] 컴파일 확인
- [x] TS 도메인 테스트 통과
- [x] 전체 테스트 통과
