### PR TITLE
refactor: TS 삭제 API 소유권 검증 추가 (#168)

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -63,6 +63,7 @@ public enum ErrorCode {
     COURSE_TIME_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST, "TS006", "CourseTime is not modifiable in current status"),
     CANNOT_DELETE_MAIN_INSTRUCTOR(HttpStatus.BAD_REQUEST, "TS007", "Cannot delete main instructor while course is ongoing"),
     MAIN_INSTRUCTOR_REQUIRED(HttpStatus.BAD_REQUEST, "TS008", "Main instructor required for opening course time"),
+    UNAUTHORIZED_COURSE_TIME_ACCESS(HttpStatus.FORBIDDEN, "TS009", "Not authorized to access this course time"),
 
     // Enrollment (SIS)
     ENROLLMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "SIS001", "Enrollment not found"),
@@ -83,6 +84,7 @@ public enum ErrorCode {
     INSTRUCTOR_ALREADY_ASSIGNED(HttpStatus.CONFLICT, "IIS002", "Instructor already assigned to this course time"),
     MAIN_INSTRUCTOR_ALREADY_EXISTS(HttpStatus.CONFLICT, "IIS003", "Main instructor already exists for this course time"),
     CANNOT_MODIFY_INACTIVE_ASSIGNMENT(HttpStatus.BAD_REQUEST, "IIS004", "Cannot modify inactive assignment"),
+    UNAUTHORIZED_ASSIGNMENT_ACCESS(HttpStatus.FORBIDDEN, "IIS005", "Not authorized to access this assignment"),
 
     // Tenant (TN)
     TENANT_NOT_FOUND(HttpStatus.NOT_FOUND, "TN001", "Tenant not found"),

--- a/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
+++ b/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
@@ -76,9 +76,11 @@ public class InstructorAssignmentController {
             @AuthenticationPrincipal UserPrincipal principal,
             @Valid @RequestBody(required = false) CancelAssignmentRequest request
     ) {
+        boolean isTenantAdmin = "TENANT_ADMIN".equals(principal.role());
         assignmentService.cancelAssignment(id,
                 request != null ? request : new CancelAssignmentRequest(null),
-                principal.id());
+                principal.id(),
+                isTenantAdmin);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/mzc/lp/domain/iis/exception/UnauthorizedAssignmentAccessException.java
+++ b/src/main/java/com/mzc/lp/domain/iis/exception/UnauthorizedAssignmentAccessException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.iis.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class UnauthorizedAssignmentAccessException extends BusinessException {
+
+    public UnauthorizedAssignmentAccessException() {
+        super(ErrorCode.UNAUTHORIZED_ASSIGNMENT_ACCESS);
+    }
+
+    public UnauthorizedAssignmentAccessException(String message) {
+        super(ErrorCode.UNAUTHORIZED_ASSIGNMENT_ACCESS, message);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentService.java
+++ b/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentService.java
@@ -37,7 +37,7 @@ public interface InstructorAssignmentService {
 
     InstructorAssignmentResponse replaceInstructor(Long id, ReplaceInstructorRequest request, Long operatorId);
 
-    void cancelAssignment(Long id, CancelAssignmentRequest request, Long operatorId);
+    void cancelAssignment(Long id, CancelAssignmentRequest request, Long operatorId, boolean isTenantAdmin);
 
     // ========== TS 모듈 연동용 메서드 ==========
 

--- a/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentServiceImpl.java
@@ -20,6 +20,7 @@ import com.mzc.lp.domain.iis.exception.CannotModifyInactiveAssignmentException;
 import com.mzc.lp.domain.iis.exception.InstructorAlreadyAssignedException;
 import com.mzc.lp.domain.iis.exception.InstructorAssignmentNotFoundException;
 import com.mzc.lp.domain.iis.exception.MainInstructorAlreadyExistsException;
+import com.mzc.lp.domain.iis.exception.UnauthorizedAssignmentAccessException;
 import com.mzc.lp.domain.iis.repository.AssignmentHistoryRepository;
 import com.mzc.lp.domain.iis.repository.InstructorAssignmentRepository;
 import com.mzc.lp.domain.student.dto.response.CourseTimeEnrollmentStatsResponse;
@@ -242,13 +243,18 @@ public class InstructorAssignmentServiceImpl implements InstructorAssignmentServ
 
     @Override
     @Transactional
-    public void cancelAssignment(Long id, CancelAssignmentRequest request, Long operatorId) {
-        log.info("Cancelling assignment: id={}", id);
+    public void cancelAssignment(Long id, CancelAssignmentRequest request, Long operatorId, boolean isTenantAdmin) {
+        log.info("Cancelling assignment: id={}, operatorId={}, isTenantAdmin={}", id, operatorId, isTenantAdmin);
 
         InstructorAssignment assignment = findAssignmentById(id);
 
         // ACTIVE 상태 체크
         validateActiveStatus(assignment);
+
+        // 소유권 검증: 본인이 배정한 건 또는 TENANT_ADMIN만 취소 가능
+        if (!isTenantAdmin && !operatorId.equals(assignment.getAssignedBy())) {
+            throw new UnauthorizedAssignmentAccessException("본인이 배정한 강사만 취소할 수 있습니다");
+        }
 
         // 취소 처리
         assignment.cancel();

--- a/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeController.java
+++ b/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeController.java
@@ -72,9 +72,11 @@ public class CourseTimeController {
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<Void> deleteCourseTime(
-            @PathVariable Long id
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserPrincipal principal
     ) {
-        courseTimeService.deleteCourseTime(id);
+        boolean isTenantAdmin = "TENANT_ADMIN".equals(principal.role());
+        courseTimeService.deleteCourseTime(id, principal.id(), isTenantAdmin);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeInstructorController.java
+++ b/src/main/java/com/mzc/lp/domain/ts/controller/CourseTimeInstructorController.java
@@ -127,7 +127,8 @@ public class CourseTimeInstructorController {
         validateModifiable(courseTime);
 
         CancelAssignmentRequest cancelRequest = request != null ? request : new CancelAssignmentRequest(null);
-        instructorAssignmentService.cancelAssignment(assignmentId, cancelRequest, principal.id());
+        boolean isTenantAdmin = "TENANT_ADMIN".equals(principal.role());
+        instructorAssignmentService.cancelAssignment(assignmentId, cancelRequest, principal.id(), isTenantAdmin);
 
         log.info("Instructor assignment cancelled: assignmentId={}", assignmentId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/mzc/lp/domain/ts/exception/UnauthorizedCourseTimeAccessException.java
+++ b/src/main/java/com/mzc/lp/domain/ts/exception/UnauthorizedCourseTimeAccessException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.ts.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class UnauthorizedCourseTimeAccessException extends BusinessException {
+
+    public UnauthorizedCourseTimeAccessException() {
+        super(ErrorCode.UNAUTHORIZED_COURSE_TIME_ACCESS);
+    }
+
+    public UnauthorizedCourseTimeAccessException(String message) {
+        super(ErrorCode.UNAUTHORIZED_COURSE_TIME_ACCESS, message);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeService.java
+++ b/src/main/java/com/mzc/lp/domain/ts/service/CourseTimeService.java
@@ -28,7 +28,7 @@ public interface CourseTimeService {
 
     CourseTimeDetailResponse updateCourseTime(Long id, UpdateCourseTimeRequest request);
 
-    void deleteCourseTime(Long id);
+    void deleteCourseTime(Long id, Long currentUserId, boolean isTenantAdmin);
 
     // 상태 전이
     CourseTimeDetailResponse openCourseTime(Long id);

--- a/src/test/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentControllerTest.java
@@ -114,7 +114,11 @@ class InstructorAssignmentControllerTest extends TenantTestSupport {
     }
 
     private InstructorAssignment createAssignment(Long userId, Long timeId, InstructorRole role) {
-        return assignmentRepository.save(InstructorAssignment.create(userId, timeId, role, 1L));
+        return createAssignment(userId, timeId, role, 1L);
+    }
+
+    private InstructorAssignment createAssignment(Long userId, Long timeId, InstructorRole role, Long assignedBy) {
+        return assignmentRepository.save(InstructorAssignment.create(userId, timeId, role, assignedBy));
     }
 
     private CourseTime createCourseTime() {
@@ -256,11 +260,11 @@ class InstructorAssignmentControllerTest extends TenantTestSupport {
         @DisplayName("성공 - 배정 취소")
         void cancelAssignment_success() throws Exception {
             // given
-            createOperatorUser();
+            User operator = createOperatorUser();
             User instructor = createInstructorUser();
             String token = loginAndGetAccessToken("operator@example.com", "Password123!");
 
-            InstructorAssignment assignment = createAssignment(instructor.getId(), TIME_ID, InstructorRole.MAIN);
+            InstructorAssignment assignment = createAssignment(instructor.getId(), TIME_ID, InstructorRole.MAIN, operator.getId());
 
             CancelAssignmentRequest request = new CancelAssignmentRequest("취소 사유");
 

--- a/src/test/java/com/mzc/lp/domain/iis/service/InstructorAssignmentServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/iis/service/InstructorAssignmentServiceTest.java
@@ -483,7 +483,7 @@ class InstructorAssignmentServiceTest extends TenantTestSupport {
             given(assignmentRepository.findByIdAndTenantId(1L, TENANT_ID)).willReturn(Optional.of(assignment));
 
             // when
-            assignmentService.cancelAssignment(1L, request, OPERATOR_ID);
+            assignmentService.cancelAssignment(1L, request, OPERATOR_ID, false);
 
             // then
             assertThat(assignment.getStatus()).isEqualTo(AssignmentStatus.CANCELLED);
@@ -501,7 +501,7 @@ class InstructorAssignmentServiceTest extends TenantTestSupport {
             given(assignmentRepository.findByIdAndTenantId(1L, TENANT_ID)).willReturn(Optional.of(assignment));
 
             // when & then
-            assertThatThrownBy(() -> assignmentService.cancelAssignment(1L, request, OPERATOR_ID))
+            assertThatThrownBy(() -> assignmentService.cancelAssignment(1L, request, OPERATOR_ID, false))
                     .isInstanceOf(CannotModifyInactiveAssignmentException.class);
         }
     }

--- a/src/test/java/com/mzc/lp/domain/ts/controller/CourseTimeControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/ts/controller/CourseTimeControllerTest.java
@@ -143,6 +143,10 @@ class CourseTimeControllerTest extends TenantTestSupport {
     }
 
     private CourseTime createTestCourseTime() {
+        return createTestCourseTime(1L);
+    }
+
+    private CourseTime createTestCourseTime(Long createdBy) {
         CourseTime courseTime = CourseTime.create(
                 "테스트 차수",
                 DeliveryType.ONLINE,
@@ -158,7 +162,7 @@ class CourseTimeControllerTest extends TenantTestSupport {
                 false,
                 null,
                 true,
-                1L
+                createdBy
         );
         return courseTimeRepository.save(courseTime);
     }
@@ -485,8 +489,8 @@ class CourseTimeControllerTest extends TenantTestSupport {
         @DisplayName("성공 - DRAFT 상태 차수 삭제")
         void deleteCourseTime_success() throws Exception {
             // given
-            createOperatorUser();
-            CourseTime courseTime = createTestCourseTime();
+            User operator = createOperatorUser();
+            CourseTime courseTime = createTestCourseTime(operator.getId());
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
             // when & then
@@ -505,8 +509,8 @@ class CourseTimeControllerTest extends TenantTestSupport {
         @DisplayName("실패 - RECRUITING 상태 차수 삭제")
         void deleteCourseTime_fail_recruiting() throws Exception {
             // given
-            createOperatorUser();
-            CourseTime courseTime = createTestCourseTime();
+            User operator = createOperatorUser();
+            CourseTime courseTime = createTestCourseTime(operator.getId());
             courseTime.open();
             courseTimeRepository.save(courseTime);
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");


### PR DESCRIPTION
## Summary

- 차수(CourseTime) 삭제 시 본인이 생성한 차수만 삭제할 수 있도록 소유권 검증 추가
- 강사 배정(InstructorAssignment) 취소 시 본인이 배정한 건만 취소할 수 있도록 소유권 검증 추가
- TENANT_ADMIN은 테넌트 내 모든 리소스 삭제/취소 가능

## Related Issue

- Closes #168

## Changes

- `CourseTimeService.deleteCourseTime(Long id, Long currentUserId, boolean isTenantAdmin)` 시그니처 변경
- `InstructorAssignmentService.cancelAssignment(..., boolean isTenantAdmin)` 시그니처 변경
- `UnauthorizedCourseTimeAccessException` (TS009) 예외 추가
- `UnauthorizedAssignmentAccessException` (IIS005) 예외 추가
- Controller: `@AuthenticationPrincipal UserPrincipal`로 현재 사용자 정보 획득

## Type of Change

- [x] Refactor: 리팩토링

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 로컬에서 테스트가 통과합니다

## Test plan

- [x] 컴파일 확인
- [x] TS 도메인 테스트 통과
- [x] IIS 도메인 테스트 통과
- [x] 전체 테스트 통과