### PR TITLE
feat : 강사 일정 충돌 검사 기능 추가 (#171)

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -83,6 +83,7 @@ public enum ErrorCode {
     INSTRUCTOR_ALREADY_ASSIGNED(HttpStatus.CONFLICT, "IIS002", "Instructor already assigned to this course time"),
     MAIN_INSTRUCTOR_ALREADY_EXISTS(HttpStatus.CONFLICT, "IIS003", "Main instructor already exists for this course time"),
     CANNOT_MODIFY_INACTIVE_ASSIGNMENT(HttpStatus.BAD_REQUEST, "IIS004", "Cannot modify inactive assignment"),
+    INSTRUCTOR_SCHEDULE_CONFLICT(HttpStatus.CONFLICT, "IIS005", "Instructor has schedule conflict with another course time"),
 
     // Tenant (TN)
     TENANT_NOT_FOUND(HttpStatus.NOT_FOUND, "TN001", "Tenant not found"),

--- a/src/main/java/com/mzc/lp/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mzc/lp/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.mzc.lp.common.exception;
 
 import com.mzc.lp.common.constant.ErrorCode;
 import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.domain.iis.dto.response.ScheduleConflictResponse;
+import com.mzc.lp.domain.iis.exception.InstructorScheduleConflictException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -9,9 +11,22 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.List;
+
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(InstructorScheduleConflictException.class)
+    protected ResponseEntity<ApiResponse<List<ScheduleConflictResponse>>> handleInstructorScheduleConflictException(
+            InstructorScheduleConflictException e) {
+        log.error("InstructorScheduleConflictException: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(new ApiResponse<>(false, e.getConflicts(),
+                        ApiResponse.ErrorInfo.of(errorCode, e.getMessage())));
+    }
 
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {

--- a/src/main/java/com/mzc/lp/domain/iis/dto/request/AssignInstructorRequest.java
+++ b/src/main/java/com/mzc/lp/domain/iis/dto/request/AssignInstructorRequest.java
@@ -8,6 +8,13 @@ public record AssignInstructorRequest(
         Long userId,
 
         @NotNull(message = "역할은 필수입니다")
-        InstructorRole role
+        InstructorRole role,
+
+        Boolean forceAssign
 ) {
+    public AssignInstructorRequest {
+        if (forceAssign == null) {
+            forceAssign = false;
+        }
+    }
 }

--- a/src/main/java/com/mzc/lp/domain/iis/dto/response/ScheduleConflictResponse.java
+++ b/src/main/java/com/mzc/lp/domain/iis/dto/response/ScheduleConflictResponse.java
@@ -1,0 +1,24 @@
+package com.mzc.lp.domain.iis.dto.response;
+
+import java.time.LocalDate;
+
+public record ScheduleConflictResponse(
+        Long conflictingTimeId,
+        String conflictingTimeTitle,
+        LocalDate classStartDate,
+        LocalDate classEndDate
+) {
+    public static ScheduleConflictResponse of(
+            Long conflictingTimeId,
+            String conflictingTimeTitle,
+            LocalDate classStartDate,
+            LocalDate classEndDate
+    ) {
+        return new ScheduleConflictResponse(
+                conflictingTimeId,
+                conflictingTimeTitle,
+                classStartDate,
+                classEndDate
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/iis/exception/InstructorScheduleConflictException.java
+++ b/src/main/java/com/mzc/lp/domain/iis/exception/InstructorScheduleConflictException.java
@@ -1,0 +1,20 @@
+package com.mzc.lp.domain.iis.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.domain.iis.dto.response.ScheduleConflictResponse;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class InstructorScheduleConflictException extends BusinessException {
+
+    private final List<ScheduleConflictResponse> conflicts;
+
+    public InstructorScheduleConflictException(Long userId, List<ScheduleConflictResponse> conflicts) {
+        super(ErrorCode.INSTRUCTOR_SCHEDULE_CONFLICT,
+                "Instructor has " + conflicts.size() + " schedule conflict(s): userId=" + userId);
+        this.conflicts = conflicts;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/repository/CourseTimeRepository.java
+++ b/src/main/java/com/mzc/lp/domain/ts/repository/CourseTimeRepository.java
@@ -69,4 +69,20 @@ public interface CourseTimeRepository extends JpaRepository<CourseTime, Long> {
      * (상시 모집 차수는 classEndDate가 9999-12-31이므로 자연스럽게 제외)
      */
     List<CourseTime> findByStatusAndClassEndDateLessThan(CourseTimeStatus status, LocalDate today);
+
+    // ===== IIS 충돌 검사용 =====
+
+    /**
+     * 특정 기간과 겹치는 CourseTime 조회
+     * 기간 겹침 조건: NOT (ct.classEndDate < startDate OR ct.classStartDate > endDate)
+     * = ct.classEndDate >= startDate AND ct.classStartDate <= endDate
+     */
+    @Query("SELECT ct FROM CourseTime ct " +
+            "WHERE ct.id IN :timeIds " +
+            "AND ct.classStartDate <= :endDate " +
+            "AND ct.classEndDate >= :startDate")
+    List<CourseTime> findByIdInAndDateRangeOverlap(
+            @Param("timeIds") List<Long> timeIds,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate);
 }

--- a/src/test/java/com/mzc/lp/domain/iis/service/InstructorAssignmentConcurrencyTest.java
+++ b/src/test/java/com/mzc/lp/domain/iis/service/InstructorAssignmentConcurrencyTest.java
@@ -114,7 +114,7 @@ class InstructorAssignmentConcurrencyTest extends TenantTestSupport {
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
                 try {
-                    AssignInstructorRequest request = new AssignInstructorRequest(instructorId, InstructorRole.SUB);
+                    AssignInstructorRequest request = new AssignInstructorRequest(instructorId, InstructorRole.SUB, null);
                     assignmentService.assignInstructor(timeId, request, 1L);
                     successCount.incrementAndGet();
                 } catch (Exception e) {
@@ -164,7 +164,7 @@ class InstructorAssignmentConcurrencyTest extends TenantTestSupport {
             final Long instructorId = instructors.get(i).getId();
             executorService.submit(() -> {
                 try {
-                    AssignInstructorRequest request = new AssignInstructorRequest(instructorId, InstructorRole.MAIN);
+                    AssignInstructorRequest request = new AssignInstructorRequest(instructorId, InstructorRole.MAIN, null);
                     assignmentService.assignInstructor(timeId, request, 1L);
                     successCount.incrementAndGet();
                 } catch (Exception e) {

--- a/src/test/java/com/mzc/lp/domain/iis/service/InstructorAssignmentServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/iis/service/InstructorAssignmentServiceTest.java
@@ -18,6 +18,7 @@ import com.mzc.lp.domain.iis.entity.InstructorAssignment;
 import com.mzc.lp.domain.iis.exception.CannotModifyInactiveAssignmentException;
 import com.mzc.lp.domain.iis.exception.InstructorAlreadyAssignedException;
 import com.mzc.lp.domain.iis.exception.InstructorAssignmentNotFoundException;
+import com.mzc.lp.domain.iis.exception.InstructorScheduleConflictException;
 import com.mzc.lp.domain.iis.exception.MainInstructorAlreadyExistsException;
 import com.mzc.lp.domain.iis.repository.AssignmentHistoryRepository;
 import com.mzc.lp.domain.iis.repository.InstructorAssignmentRepository;
@@ -143,7 +144,7 @@ class InstructorAssignmentServiceTest extends TenantTestSupport {
         @DisplayName("성공 - MAIN 강사 배정")
         void assignInstructor_success_main() {
             // given
-            AssignInstructorRequest request = new AssignInstructorRequest(USER_ID, InstructorRole.MAIN);
+            AssignInstructorRequest request = new AssignInstructorRequest(USER_ID, InstructorRole.MAIN, false);
             InstructorAssignment saved = createTestAssignment(1L, USER_ID, TIME_ID, InstructorRole.MAIN);
             User user = createTestUser(USER_ID, "강사", "instructor@example.com");
             CourseTime courseTime = createTestCourseTime();
@@ -154,6 +155,8 @@ class InstructorAssignmentServiceTest extends TenantTestSupport {
                     TIME_ID, USER_ID, TENANT_ID, AssignmentStatus.ACTIVE)).willReturn(false);
             given(assignmentRepository.findActiveByTimeKeyAndRole(TIME_ID, TENANT_ID, InstructorRole.MAIN))
                     .willReturn(Optional.empty());
+            // 일정 충돌 없음
+            given(assignmentRepository.findActiveByUserKey(TENANT_ID, USER_ID)).willReturn(List.of());
             given(assignmentRepository.save(any())).willReturn(saved);
             given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
 
@@ -173,7 +176,7 @@ class InstructorAssignmentServiceTest extends TenantTestSupport {
         @DisplayName("성공 - SUB 강사 배정")
         void assignInstructor_success_sub() {
             // given
-            AssignInstructorRequest request = new AssignInstructorRequest(USER_ID, InstructorRole.SUB);
+            AssignInstructorRequest request = new AssignInstructorRequest(USER_ID, InstructorRole.SUB, false);
             InstructorAssignment saved = createTestAssignment(1L, USER_ID, TIME_ID, InstructorRole.SUB);
             User user = createTestUser(USER_ID, "부강사", "sub@example.com");
             CourseTime courseTime = createTestCourseTime();
@@ -182,6 +185,8 @@ class InstructorAssignmentServiceTest extends TenantTestSupport {
             given(courseTimeRepository.findByIdWithLock(TIME_ID)).willReturn(Optional.of(courseTime));
             given(assignmentRepository.existsByTimeKeyAndUserKeyAndTenantIdAndStatus(
                     TIME_ID, USER_ID, TENANT_ID, AssignmentStatus.ACTIVE)).willReturn(false);
+            // 일정 충돌 없음
+            given(assignmentRepository.findActiveByUserKey(TENANT_ID, USER_ID)).willReturn(List.of());
             given(assignmentRepository.save(any())).willReturn(saved);
             given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
 
@@ -196,7 +201,7 @@ class InstructorAssignmentServiceTest extends TenantTestSupport {
         @DisplayName("실패 - 중복 배정")
         void assignInstructor_fail_alreadyAssigned() {
             // given
-            AssignInstructorRequest request = new AssignInstructorRequest(USER_ID, InstructorRole.MAIN);
+            AssignInstructorRequest request = new AssignInstructorRequest(USER_ID, InstructorRole.MAIN, false);
             CourseTime courseTime = createTestCourseTime();
 
             // Race Condition 방지를 위한 비관적 락
@@ -213,7 +218,7 @@ class InstructorAssignmentServiceTest extends TenantTestSupport {
         @DisplayName("실패 - 주강사 중복")
         void assignInstructor_fail_mainAlreadyExists() {
             // given
-            AssignInstructorRequest request = new AssignInstructorRequest(USER_ID, InstructorRole.MAIN);
+            AssignInstructorRequest request = new AssignInstructorRequest(USER_ID, InstructorRole.MAIN, false);
             InstructorAssignment existingMain = createTestAssignment(99L, 999L, TIME_ID, InstructorRole.MAIN);
             CourseTime courseTime = createTestCourseTime();
 
@@ -228,6 +233,100 @@ class InstructorAssignmentServiceTest extends TenantTestSupport {
             assertThatThrownBy(() -> assignmentService.assignInstructor(TIME_ID, request, OPERATOR_ID))
                     .isInstanceOf(MainInstructorAlreadyExistsException.class);
         }
+
+        @Test
+        @DisplayName("실패 - 일정 충돌 (forceAssign=false)")
+        void assignInstructor_fail_scheduleConflict() {
+            // given
+            Long conflictingTimeId = 200L;
+            AssignInstructorRequest request = new AssignInstructorRequest(USER_ID, InstructorRole.SUB, false);
+            CourseTime targetCourseTime = createTestCourseTime();
+            CourseTime conflictingCourseTime = createTestCourseTimeWithId(conflictingTimeId,
+                    LocalDate.now().plusDays(10), LocalDate.now().plusDays(20)); // 겹치는 기간
+
+            // 기존 배정 (다른 차수에 이미 배정되어 있음)
+            InstructorAssignment existingAssignment = createTestAssignment(50L, USER_ID, conflictingTimeId, InstructorRole.MAIN);
+
+            given(courseTimeRepository.findByIdWithLock(TIME_ID)).willReturn(Optional.of(targetCourseTime));
+            given(assignmentRepository.existsByTimeKeyAndUserKeyAndTenantIdAndStatus(
+                    TIME_ID, USER_ID, TENANT_ID, AssignmentStatus.ACTIVE)).willReturn(false);
+            // 기존 ACTIVE 배정 존재
+            given(assignmentRepository.findActiveByUserKey(TENANT_ID, USER_ID)).willReturn(List.of(existingAssignment));
+            // 기간 겹치는 CourseTime 조회
+            given(courseTimeRepository.findByIdInAndDateRangeOverlap(
+                    eq(List.of(conflictingTimeId)),
+                    any(LocalDate.class),
+                    any(LocalDate.class)
+            )).willReturn(List.of(conflictingCourseTime));
+
+            // when & then
+            assertThatThrownBy(() -> assignmentService.assignInstructor(TIME_ID, request, OPERATOR_ID))
+                    .isInstanceOf(InstructorScheduleConflictException.class)
+                    .satisfies(ex -> {
+                        InstructorScheduleConflictException conflictException = (InstructorScheduleConflictException) ex;
+                        assertThat(conflictException.getConflicts()).hasSize(1);
+                        assertThat(conflictException.getConflicts().get(0).conflictingTimeId()).isEqualTo(conflictingTimeId);
+                    });
+        }
+
+        @Test
+        @DisplayName("성공 - 일정 충돌 무시 (forceAssign=true)")
+        void assignInstructor_success_forceAssignWithConflict() {
+            // given
+            Long conflictingTimeId = 200L;
+            AssignInstructorRequest request = new AssignInstructorRequest(USER_ID, InstructorRole.SUB, true); // forceAssign=true
+            InstructorAssignment saved = createTestAssignment(1L, USER_ID, TIME_ID, InstructorRole.SUB);
+            User user = createTestUser(USER_ID, "강사", "instructor@example.com");
+            CourseTime targetCourseTime = createTestCourseTime();
+
+            // 기존 배정 (다른 차수에 이미 배정되어 있음)
+            InstructorAssignment existingAssignment = createTestAssignment(50L, USER_ID, conflictingTimeId, InstructorRole.MAIN);
+
+            given(courseTimeRepository.findByIdWithLock(TIME_ID)).willReturn(Optional.of(targetCourseTime));
+            given(assignmentRepository.existsByTimeKeyAndUserKeyAndTenantIdAndStatus(
+                    TIME_ID, USER_ID, TENANT_ID, AssignmentStatus.ACTIVE)).willReturn(false);
+            // forceAssign=true이므로 충돌 검사 스킵 -> findActiveByUserKey 호출 안됨
+            given(assignmentRepository.save(any())).willReturn(saved);
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+            // when
+            InstructorAssignmentResponse response = assignmentService.assignInstructor(TIME_ID, request, OPERATOR_ID);
+
+            // then
+            assertThat(response.id()).isEqualTo(1L);
+            assertThat(response.userId()).isEqualTo(USER_ID);
+        }
+    }
+
+    private CourseTime createTestCourseTimeWithId(Long id, LocalDate classStartDate, LocalDate classEndDate) {
+        CourseTime courseTime = CourseTime.create(
+                "충돌 테스트 차수",
+                DeliveryType.ONLINE,
+                LocalDate.now().minusDays(1),
+                LocalDate.now().plusDays(7),
+                classStartDate,
+                classEndDate,
+                30,
+                5,
+                EnrollmentMethod.FIRST_COME,
+                80,
+                new BigDecimal("100000"),
+                false,
+                null,
+                true,
+                1L
+        );
+        try {
+            var idField = com.mzc.lp.common.entity.BaseEntity.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(courseTime, id);
+            var tenantIdField = com.mzc.lp.common.entity.TenantEntity.class.getDeclaredField("tenantId");
+            tenantIdField.setAccessible(true);
+            tenantIdField.set(courseTime, TENANT_ID);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return courseTime;
     }
 
     // ==================== 조회 테스트 ====================

--- a/src/test/java/com/mzc/lp/domain/ts/controller/CourseTimeInstructorControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/ts/controller/CourseTimeInstructorControllerTest.java
@@ -167,7 +167,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             CourseTime courseTime = createTestCourseTime();
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
-            AssignInstructorRequest request = new AssignInstructorRequest(instructor.getId(), InstructorRole.MAIN);
+            AssignInstructorRequest request = new AssignInstructorRequest(instructor.getId(), InstructorRole.MAIN, null);
 
             // when & then
             mockMvc.perform(post("/api/times/{timeId}/instructors", courseTime.getId())
@@ -200,7 +200,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             courseTimeRepository.save(courseTime);
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
-            AssignInstructorRequest request = new AssignInstructorRequest(instructor.getId(), InstructorRole.SUB);
+            AssignInstructorRequest request = new AssignInstructorRequest(instructor.getId(), InstructorRole.SUB, null);
 
             // when & then
             mockMvc.perform(post("/api/times/{timeId}/instructors", courseTime.getId())
@@ -222,7 +222,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             CourseTime courseTime = createOngoingCourseTime();
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
-            AssignInstructorRequest request = new AssignInstructorRequest(instructor.getId(), InstructorRole.ASSISTANT);
+            AssignInstructorRequest request = new AssignInstructorRequest(instructor.getId(), InstructorRole.ASSISTANT, null);
 
             // when & then
             mockMvc.perform(post("/api/times/{timeId}/instructors", courseTime.getId())
@@ -244,7 +244,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             CourseTime courseTime = createClosedCourseTime();
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
-            AssignInstructorRequest request = new AssignInstructorRequest(instructor.getId(), InstructorRole.MAIN);
+            AssignInstructorRequest request = new AssignInstructorRequest(instructor.getId(), InstructorRole.MAIN, null);
 
             // when & then
             mockMvc.perform(post("/api/times/{timeId}/instructors", courseTime.getId())
@@ -268,7 +268,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             courseTimeRepository.save(courseTime);
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
-            AssignInstructorRequest request = new AssignInstructorRequest(instructor.getId(), InstructorRole.MAIN);
+            AssignInstructorRequest request = new AssignInstructorRequest(instructor.getId(), InstructorRole.MAIN, null);
 
             // when & then
             mockMvc.perform(post("/api/times/{timeId}/instructors", courseTime.getId())
@@ -288,7 +288,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             createOperatorUser();
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
-            AssignInstructorRequest request = new AssignInstructorRequest(100L, InstructorRole.MAIN);
+            AssignInstructorRequest request = new AssignInstructorRequest(100L, InstructorRole.MAIN, null);
 
             // when & then
             mockMvc.perform(post("/api/times/{timeId}/instructors", 99999L)
@@ -309,7 +309,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             CourseTime courseTime = createTestCourseTime();
             String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
 
-            AssignInstructorRequest request = new AssignInstructorRequest(instructor.getId(), InstructorRole.MAIN);
+            AssignInstructorRequest request = new AssignInstructorRequest(instructor.getId(), InstructorRole.MAIN, null);
 
             // when & then
             mockMvc.perform(post("/api/times/{timeId}/instructors", courseTime.getId())
@@ -332,7 +332,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             // 먼저 강사 배정
             createInstructorAssignment(instructor.getId(), courseTime.getId(), InstructorRole.SUB, operator.getId());
 
-            AssignInstructorRequest request = new AssignInstructorRequest(instructor.getId(), InstructorRole.ASSISTANT);
+            AssignInstructorRequest request = new AssignInstructorRequest(instructor.getId(), InstructorRole.ASSISTANT, null);
 
             // when & then
             mockMvc.perform(post("/api/times/{timeId}/instructors", courseTime.getId())
@@ -358,7 +358,7 @@ class CourseTimeInstructorControllerTest extends TenantTestSupport {
             // 먼저 MAIN 강사 배정
             createInstructorAssignment(instructor1.getId(), courseTime.getId(), InstructorRole.MAIN, operator.getId());
 
-            AssignInstructorRequest request = new AssignInstructorRequest(instructor2.getId(), InstructorRole.MAIN);
+            AssignInstructorRequest request = new AssignInstructorRequest(instructor2.getId(), InstructorRole.MAIN, null);
 
             // when & then
             mockMvc.perform(post("/api/times/{timeId}/instructors", courseTime.getId())


### PR DESCRIPTION
## Summary

강사 배정 시 동일 기간에 다른 차수에 이미 배정되어 있는지 확인하는 일정 충돌 검사 기능을 추가합니다.

## Related Issue

- Closes #171

## Changes

- ErrorCode에 `INSTRUCTOR_SCHEDULE_CONFLICT(IIS005)` 추가
- `InstructorScheduleConflictException` 예외 클래스 생성
- `ScheduleConflictResponse` DTO 생성 (충돌 정보 응답용)
- `AssignInstructorRequest`에 `forceAssign` 필드 추가 (기본값: false)
- `CourseTimeRepository`에 기간 겹침 검사 쿼리 `findByIdInAndDateRangeOverlap()` 추가
- `InstructorAssignmentServiceImpl`에 `checkScheduleConflict()` 메서드 추가
- `GlobalExceptionHandler`에 충돌 예외 전용 핸들러 추가
- 일정 충돌 관련 테스트 케이스 2개 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### 동작 방식
| forceAssign | 충돌 발생 시 |
|-------------|-------------|
| `false` (기본값) | 409 CONFLICT 응답 + 충돌 차수 정보 반환 |
| `true` | 충돌 검사 생략, 배정 진행 |

### 응답 예시 (충돌 발생 시)
```json
{
  "success": false,
  "data": [
    {
      "conflictingTimeId": 200,
      "conflictingTimeTitle": "AWS 기초 2024년 1차",
      "classStartDate": "2024-03-01",
      "classEndDate": "2024-03-31"
    }
  ],
  "error": {
    "code": "IIS005",
    "message": "Instructor has 1 schedule conflict(s): userId=10"
  }
}