### PR TITLE
feat: Course 엔티티에 startDate, endDate, tags 필드 추가

### DIFF
--- a/src/main/java/com/mzc/lp/domain/course/dto/request/CreateCourseRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/CreateCourseRequest.java
@@ -6,6 +6,9 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public record CreateCourseRequest(
         @NotBlank(message = "강의 제목은 필수입니다")
         @Size(max = 255, message = "강의 제목은 255자 이하여야 합니다")
@@ -24,7 +27,13 @@ public record CreateCourseRequest(
         Long categoryId,
 
         @Size(max = 500, message = "썸네일 URL은 500자 이하여야 합니다")
-        String thumbnailUrl
+        String thumbnailUrl,
+
+        LocalDate startDate,
+
+        LocalDate endDate,
+
+        List<String> tags
 ) {
     public CreateCourseRequest {
         if (title != null) {

--- a/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateCourseRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateCourseRequest.java
@@ -5,6 +5,9 @@ import com.mzc.lp.domain.course.constant.CourseType;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public record UpdateCourseRequest(
         @Size(max = 255, message = "강의 제목은 255자 이하여야 합니다")
         String title,
@@ -22,7 +25,13 @@ public record UpdateCourseRequest(
         Long categoryId,
 
         @Size(max = 500, message = "썸네일 URL은 500자 이하여야 합니다")
-        String thumbnailUrl
+        String thumbnailUrl,
+
+        LocalDate startDate,
+
+        LocalDate endDate,
+
+        List<String> tags
 ) {
     public UpdateCourseRequest {
         if (title != null) {

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseDetailResponse.java
@@ -5,6 +5,7 @@ import com.mzc.lp.domain.course.constant.CourseType;
 import com.mzc.lp.domain.course.entity.Course;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 
 public record CourseDetailResponse(
@@ -16,6 +17,9 @@ public record CourseDetailResponse(
         CourseType type,
         Integer estimatedHours,
         Long categoryId,
+        LocalDate startDate,
+        LocalDate endDate,
+        List<String> tags,
         List<CourseItemResponse> items,
         long itemCount,
         Instant createdAt,
@@ -31,6 +35,9 @@ public record CourseDetailResponse(
                 course.getType(),
                 course.getEstimatedHours(),
                 course.getCategoryId(),
+                course.getStartDate(),
+                course.getEndDate(),
+                course.getTags(),
                 items,
                 items != null ? items.size() : 0,
                 course.getCreatedAt(),

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseResponse.java
@@ -5,6 +5,8 @@ import com.mzc.lp.domain.course.constant.CourseType;
 import com.mzc.lp.domain.course.entity.Course;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
 
 public record CourseResponse(
         Long courseId,
@@ -15,6 +17,9 @@ public record CourseResponse(
         CourseType type,
         Integer estimatedHours,
         Long categoryId,
+        LocalDate startDate,
+        LocalDate endDate,
+        List<String> tags,
         Instant createdAt,
         Instant updatedAt
 ) {
@@ -28,6 +33,9 @@ public record CourseResponse(
                 course.getType(),
                 course.getEstimatedHours(),
                 course.getCategoryId(),
+                course.getStartDate(),
+                course.getEndDate(),
+                course.getTags(),
                 course.getCreatedAt(),
                 course.getUpdatedAt()
         );

--- a/src/main/java/com/mzc/lp/domain/course/entity/Course.java
+++ b/src/main/java/com/mzc/lp/domain/course/entity/Course.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -44,6 +45,17 @@ public class Course extends TenantEntity {
     @Column
     private Long categoryId;
 
+    @Column
+    private LocalDate startDate;
+
+    @Column
+    private LocalDate endDate;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "cm_course_tags", joinColumns = @JoinColumn(name = "course_id"))
+    @Column(name = "tag", length = 100)
+    private List<String> tags = new ArrayList<>();
+
     @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CourseItem> items = new ArrayList<>();
 
@@ -56,7 +68,8 @@ public class Course extends TenantEntity {
 
     public static Course create(String title, String description, CourseLevel level,
                                 CourseType type, Integer estimatedHours,
-                                Long categoryId, String thumbnailUrl) {
+                                Long categoryId, String thumbnailUrl,
+                                LocalDate startDate, LocalDate endDate, List<String> tags) {
         Course course = new Course();
         course.title = title;
         course.description = description;
@@ -65,6 +78,9 @@ public class Course extends TenantEntity {
         course.estimatedHours = estimatedHours;
         course.categoryId = categoryId;
         course.thumbnailUrl = thumbnailUrl;
+        course.startDate = startDate;
+        course.endDate = endDate;
+        course.tags = tags != null ? new ArrayList<>(tags) : new ArrayList<>();
         return course;
     }
 
@@ -98,9 +114,22 @@ public class Course extends TenantEntity {
         this.categoryId = categoryId;
     }
 
+    public void updateStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public void updateEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public void updateTags(List<String> tags) {
+        this.tags = tags != null ? new ArrayList<>(tags) : new ArrayList<>();
+    }
+
     public void update(String title, String description, CourseLevel level,
                        CourseType type, Integer estimatedHours,
-                       Long categoryId, String thumbnailUrl) {
+                       Long categoryId, String thumbnailUrl,
+                       LocalDate startDate, LocalDate endDate, List<String> tags) {
         if (title != null) {
             updateTitle(title);
         }
@@ -110,6 +139,9 @@ public class Course extends TenantEntity {
         this.estimatedHours = estimatedHours;
         this.categoryId = categoryId;
         this.thumbnailUrl = thumbnailUrl;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.tags = tags != null ? new ArrayList<>(tags) : new ArrayList<>();
     }
 
     // ===== 연관관계 편의 메서드 =====

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
@@ -38,7 +38,10 @@ public class CourseServiceImpl implements CourseService {
                 request.type(),
                 request.estimatedHours(),
                 request.categoryId(),
-                request.thumbnailUrl()
+                request.thumbnailUrl(),
+                request.startDate(),
+                request.endDate(),
+                request.tags()
         );
 
         Course savedCourse = courseRepository.save(course);
@@ -98,7 +101,10 @@ public class CourseServiceImpl implements CourseService {
                 request.type(),
                 request.estimatedHours(),
                 request.categoryId(),
-                request.thumbnailUrl()
+                request.thumbnailUrl(),
+                request.startDate(),
+                request.endDate(),
+                request.tags()
         );
 
         log.info("Course updated: id={}", courseId);

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseControllerTest.java
@@ -111,6 +111,9 @@ class CourseControllerTest extends TenantTestSupport {
                 CourseType.ONLINE,
                 10,
                 1L,
+                null,
+                null,
+                null,
                 null
         );
         return courseRepository.save(course);
@@ -135,6 +138,9 @@ class CourseControllerTest extends TenantTestSupport {
                     CourseType.ONLINE,
                     20,
                     1L,
+                    null,
+                    null,
+                    null,
                     null
             );
 
@@ -166,6 +172,9 @@ class CourseControllerTest extends TenantTestSupport {
                     CourseType.BLENDED,
                     30,
                     2L,
+                    null,
+                    null,
+                    null,
                     null
             );
 
@@ -188,6 +197,9 @@ class CourseControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
             CreateCourseRequest request = new CreateCourseRequest(
                     "최소 강의",
+                    null,
+                    null,
+                    null,
                     null,
                     null,
                     null,
@@ -220,6 +232,9 @@ class CourseControllerTest extends TenantTestSupport {
                     CourseType.ONLINE,
                     10,
                     1L,
+                    null,
+                    null,
+                    null,
                     null
             );
 
@@ -246,6 +261,9 @@ class CourseControllerTest extends TenantTestSupport {
                     CourseType.ONLINE,
                     10,
                     1L,
+                    null,
+                    null,
+                    null,
                     null
             );
 
@@ -273,6 +291,9 @@ class CourseControllerTest extends TenantTestSupport {
                     CourseType.ONLINE,
                     10,
                     1L,
+                    null,
+                    null,
+                    null,
                     null
             );
 
@@ -299,6 +320,9 @@ class CourseControllerTest extends TenantTestSupport {
                     null,
                     null,
                     null,
+                    null,
+                    null,
+                    null,
                     null
             );
 
@@ -317,6 +341,9 @@ class CourseControllerTest extends TenantTestSupport {
             // given
             CreateCourseRequest request = new CreateCourseRequest(
                     "테스트 강의",
+                    null,
+                    null,
+                    null,
                     null,
                     null,
                     null,
@@ -387,9 +414,9 @@ class CourseControllerTest extends TenantTestSupport {
             createOperatorUser();
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
-            Course course1 = Course.create("Spring Boot", "설명", CourseLevel.BEGINNER, CourseType.ONLINE, 10, 1L, null);
-            Course course2 = Course.create("React", "설명", CourseLevel.BEGINNER, CourseType.ONLINE, 10, 2L, null);
-            Course course3 = Course.create("Docker", "설명", CourseLevel.BEGINNER, CourseType.ONLINE, 10, 1L, null);
+            Course course1 = Course.create("Spring Boot", "설명", CourseLevel.BEGINNER, CourseType.ONLINE, 10, 1L, null, null, null, null);
+            Course course2 = Course.create("React", "설명", CourseLevel.BEGINNER, CourseType.ONLINE, 10, 2L, null, null, null, null);
+            Course course3 = Course.create("Docker", "설명", CourseLevel.BEGINNER, CourseType.ONLINE, 10, 1L, null, null, null, null);
             courseRepository.save(course1);
             courseRepository.save(course2);
             courseRepository.save(course3);
@@ -508,6 +535,9 @@ class CourseControllerTest extends TenantTestSupport {
                     CourseType.BLENDED,
                     50,
                     2L,
+                    null,
+                    null,
+                    null,
                     null
             );
 
@@ -540,6 +570,9 @@ class CourseControllerTest extends TenantTestSupport {
                     null,
                     null,
                     null,
+                    null,
+                    null,
+                    null,
                     null
             );
 
@@ -562,6 +595,9 @@ class CourseControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
             UpdateCourseRequest request = new UpdateCourseRequest(
                     "수정 시도",
+                    null,
+                    null,
+                    null,
                     null,
                     null,
                     null,
@@ -590,6 +626,9 @@ class CourseControllerTest extends TenantTestSupport {
             Course course = createTestCourse("테스트 강의");
             UpdateCourseRequest request = new UpdateCourseRequest(
                     "수정 시도",
+                    null,
+                    null,
+                    null,
                     null,
                     null,
                     null,

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseItemControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseItemControllerTest.java
@@ -105,6 +105,9 @@ class CourseItemControllerTest extends TenantTestSupport {
                 CourseType.ONLINE,
                 10,
                 1L,
+                null,
+                null,
+                null,
                 null
         );
         return courseRepository.save(course);

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseRelationControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseRelationControllerTest.java
@@ -112,6 +112,9 @@ class CourseRelationControllerTest extends TenantTestSupport {
                 CourseType.ONLINE,
                 10,
                 1L,
+                null,
+                null,
+                null,
                 null
         );
         return courseRepository.save(course);

--- a/src/test/java/com/mzc/lp/domain/snapshot/controller/SnapshotControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/snapshot/controller/SnapshotControllerTest.java
@@ -128,6 +128,9 @@ class SnapshotControllerTest extends TenantTestSupport {
                 CourseType.ONLINE,
                 10,
                 1L,
+                null,
+                null,
+                null,
                 null
         );
         return courseRepository.save(course);


### PR DESCRIPTION
## Summary
- Course 엔티티에 `startDate`, `endDate` (LocalDate) 필드 추가
- Course 엔티티에 `tags` 필드 추가 (`@ElementCollection`으로 `cm_course_tags` 테이블 생성)
- 관련 Request/Response DTO 및 Service 수정
- 테스트 코드 업데이트

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `Course.java` | startDate, endDate, tags 필드 + 관련 메서드 |
| `CreateCourseRequest.java` | 새 필드 3개 추가 |
| `UpdateCourseRequest.java` | 새 필드 3개 추가 |
| `CourseResponse.java` | 새 필드 3개 + from() 수정 |
| `CourseDetailResponse.java` | 새 필드 3개 + from() 수정 |
| `CourseServiceImpl.java` | create/update 호출 수정 |
| 테스트 파일 4개 | 생성자 파라미터 업데이트 |

## DB 변경사항
- `cm_courses` 테이블: `start_date`, `end_date` 컬럼 추가
- `cm_course_tags` 테이블 생성 (course_id FK, tag)

## Test plan
- [x] `./gradlew build` 통과 (526 tests)

Closes #169