### PR TITLE
feat: Category 도메인 구현 (멀티테넌트 지원)

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -99,7 +99,11 @@ public enum ErrorCode {
     INVALID_PROGRAM_STATUS(HttpStatus.BAD_REQUEST, "PG002", "Invalid program status transition"),
     PROGRAM_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST, "PG003", "Program is not modifiable in current status"),
     PROGRAM_NOT_APPROVED(HttpStatus.BAD_REQUEST, "PG004", "Program is not approved"),
-    REJECTION_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "PG005", "Rejection reason is required");
+    REJECTION_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "PG005", "Rejection reason is required"),
+
+    // Category (CAT)
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CAT001", "Category not found"),
+    DUPLICATE_CATEGORY_CODE(HttpStatus.CONFLICT, "CAT002", "Category code already exists");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/mzc/lp/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/mzc/lp/domain/category/controller/CategoryController.java
@@ -1,0 +1,97 @@
+package com.mzc.lp.domain.category.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.category.dto.request.CreateCategoryRequest;
+import com.mzc.lp.domain.category.dto.request.UpdateCategoryRequest;
+import com.mzc.lp.domain.category.dto.response.CategoryResponse;
+import com.mzc.lp.domain.category.service.CategoryService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/categories")
+@RequiredArgsConstructor
+@Validated
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    /**
+     * 카테고리 생성
+     * POST /api/categories
+     */
+    @PostMapping
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CategoryResponse>> createCategory(
+            @Valid @RequestBody CreateCategoryRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CategoryResponse response = categoryService.createCategory(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 카테고리 목록 조회
+     * GET /api/categories
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CategoryResponse>>> getCategories(
+            @RequestParam(required = false, defaultValue = "false") Boolean activeOnly,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<CategoryResponse> response = categoryService.getCategories(activeOnly);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 카테고리 상세 조회
+     * GET /api/categories/{categoryId}
+     */
+    @GetMapping("/{categoryId}")
+    public ResponseEntity<ApiResponse<CategoryResponse>> getCategory(
+            @PathVariable @Positive Long categoryId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CategoryResponse response = categoryService.getCategory(categoryId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 카테고리 수정
+     * PUT /api/categories/{categoryId}
+     */
+    @PutMapping("/{categoryId}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CategoryResponse>> updateCategory(
+            @PathVariable @Positive Long categoryId,
+            @Valid @RequestBody UpdateCategoryRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CategoryResponse response = categoryService.updateCategory(categoryId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 카테고리 삭제
+     * DELETE /api/categories/{categoryId}
+     */
+    @DeleteMapping("/{categoryId}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> deleteCategory(
+            @PathVariable @Positive Long categoryId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        categoryService.deleteCategory(categoryId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/category/dto/request/CreateCategoryRequest.java
+++ b/src/main/java/com/mzc/lp/domain/category/dto/request/CreateCategoryRequest.java
@@ -1,0 +1,25 @@
+package com.mzc.lp.domain.category.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateCategoryRequest(
+        @NotBlank(message = "카테고리 이름은 필수입니다")
+        @Size(max = 100, message = "카테고리 이름은 100자 이하여야 합니다")
+        String name,
+
+        @NotBlank(message = "카테고리 코드는 필수입니다")
+        @Size(max = 50, message = "카테고리 코드는 50자 이하여야 합니다")
+        String code,
+
+        Integer sortOrder
+) {
+    public CreateCategoryRequest {
+        if (name != null) {
+            name = name.trim();
+        }
+        if (code != null) {
+            code = code.trim();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/category/dto/request/UpdateCategoryRequest.java
+++ b/src/main/java/com/mzc/lp/domain/category/dto/request/UpdateCategoryRequest.java
@@ -1,0 +1,24 @@
+package com.mzc.lp.domain.category.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record UpdateCategoryRequest(
+        @Size(max = 100, message = "카테고리 이름은 100자 이하여야 합니다")
+        String name,
+
+        @Size(max = 50, message = "카테고리 코드는 50자 이하여야 합니다")
+        String code,
+
+        Integer sortOrder,
+
+        Boolean active
+) {
+    public UpdateCategoryRequest {
+        if (name != null) {
+            name = name.trim();
+        }
+        if (code != null) {
+            code = code.trim();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/category/dto/response/CategoryResponse.java
+++ b/src/main/java/com/mzc/lp/domain/category/dto/response/CategoryResponse.java
@@ -1,0 +1,27 @@
+package com.mzc.lp.domain.category.dto.response;
+
+import com.mzc.lp.domain.category.entity.Category;
+
+import java.time.Instant;
+
+public record CategoryResponse(
+        Long id,
+        String name,
+        String code,
+        Integer sortOrder,
+        Boolean active,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static CategoryResponse from(Category category) {
+        return new CategoryResponse(
+                category.getId(),
+                category.getName(),
+                category.getCode(),
+                category.getSortOrder(),
+                category.getActive(),
+                category.getCreatedAt(),
+                category.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/category/entity/Category.java
+++ b/src/main/java/com/mzc/lp/domain/category/entity/Category.java
@@ -1,0 +1,106 @@
+package com.mzc.lp.domain.category.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "cm_categories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category extends TenantEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false, length = 50)
+    private String code;
+
+    @Column(nullable = false)
+    private Integer sortOrder = 0;
+
+    @Column(nullable = false)
+    private Boolean active = true;
+
+    // ===== 정적 팩토리 메서드 =====
+    public static Category create(String name, String code) {
+        Category category = new Category();
+        category.name = name;
+        category.code = code;
+        category.sortOrder = 0;
+        category.active = true;
+        return category;
+    }
+
+    public static Category create(String name, String code, Integer sortOrder) {
+        Category category = new Category();
+        category.name = name;
+        category.code = code;
+        category.sortOrder = sortOrder != null ? sortOrder : 0;
+        category.active = true;
+        return category;
+    }
+
+    // ===== 비즈니스 메서드 =====
+    public void updateName(String name) {
+        validateName(name);
+        this.name = name;
+    }
+
+    public void updateCode(String code) {
+        validateCode(code);
+        this.code = code;
+    }
+
+    public void updateSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder != null ? sortOrder : 0;
+    }
+
+    public void activate() {
+        this.active = true;
+    }
+
+    public void deactivate() {
+        this.active = false;
+    }
+
+    public void update(String name, String code, Integer sortOrder, Boolean active) {
+        if (name != null) {
+            updateName(name);
+        }
+        if (code != null) {
+            updateCode(code);
+        }
+        if (sortOrder != null) {
+            this.sortOrder = sortOrder;
+        }
+        if (active != null) {
+            this.active = active;
+        }
+    }
+
+    // ===== Private 검증 메서드 =====
+    private void validateName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("카테고리 이름은 필수입니다");
+        }
+        if (name.length() > 100) {
+            throw new IllegalArgumentException("카테고리 이름은 100자 이하여야 합니다");
+        }
+    }
+
+    private void validateCode(String code) {
+        if (code == null || code.isBlank()) {
+            throw new IllegalArgumentException("카테고리 코드는 필수입니다");
+        }
+        if (code.length() > 50) {
+            throw new IllegalArgumentException("카테고리 코드는 50자 이하여야 합니다");
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/category/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/category/exception/CategoryNotFoundException.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.category.exception;
+
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.common.constant.ErrorCode;
+
+public class CategoryNotFoundException extends BusinessException {
+
+    public CategoryNotFoundException(Long categoryId) {
+        super(ErrorCode.CATEGORY_NOT_FOUND, "카테고리를 찾을 수 없습니다: " + categoryId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/category/exception/DuplicateCategoryCodeException.java
+++ b/src/main/java/com/mzc/lp/domain/category/exception/DuplicateCategoryCodeException.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.category.exception;
+
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.common.constant.ErrorCode;
+
+public class DuplicateCategoryCodeException extends BusinessException {
+
+    public DuplicateCategoryCodeException(String code) {
+        super(ErrorCode.DUPLICATE_CATEGORY_CODE, "이미 존재하는 카테고리 코드입니다: " + code);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/mzc/lp/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,22 @@
+package com.mzc.lp.domain.category.repository;
+
+import com.mzc.lp.domain.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    Optional<Category> findByIdAndTenantId(Long id, Long tenantId);
+
+    List<Category> findByTenantIdOrderBySortOrderAsc(Long tenantId);
+
+    List<Category> findByTenantIdAndActiveOrderBySortOrderAsc(Long tenantId, Boolean active);
+
+    boolean existsByCodeAndTenantId(String code, Long tenantId);
+
+    boolean existsByCodeAndTenantIdAndIdNot(String code, Long tenantId, Long id);
+
+    boolean existsByIdAndTenantId(Long id, Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/category/service/CategoryService.java
+++ b/src/main/java/com/mzc/lp/domain/category/service/CategoryService.java
@@ -1,0 +1,45 @@
+package com.mzc.lp.domain.category.service;
+
+import com.mzc.lp.domain.category.dto.request.CreateCategoryRequest;
+import com.mzc.lp.domain.category.dto.request.UpdateCategoryRequest;
+import com.mzc.lp.domain.category.dto.response.CategoryResponse;
+
+import java.util.List;
+
+public interface CategoryService {
+
+    /**
+     * 카테고리 생성
+     * @param request 생성 요청 DTO
+     * @return 생성된 카테고리 정보
+     */
+    CategoryResponse createCategory(CreateCategoryRequest request);
+
+    /**
+     * 카테고리 목록 조회 (정렬순)
+     * @param activeOnly 활성 카테고리만 조회할지 여부
+     * @return 카테고리 목록
+     */
+    List<CategoryResponse> getCategories(Boolean activeOnly);
+
+    /**
+     * 카테고리 상세 조회
+     * @param categoryId 카테고리 ID
+     * @return 카테고리 정보
+     */
+    CategoryResponse getCategory(Long categoryId);
+
+    /**
+     * 카테고리 수정
+     * @param categoryId 카테고리 ID
+     * @param request 수정 요청 DTO
+     * @return 수정된 카테고리 정보
+     */
+    CategoryResponse updateCategory(Long categoryId, UpdateCategoryRequest request);
+
+    /**
+     * 카테고리 삭제
+     * @param categoryId 카테고리 ID
+     */
+    void deleteCategory(Long categoryId);
+}

--- a/src/main/java/com/mzc/lp/domain/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/category/service/CategoryServiceImpl.java
@@ -1,0 +1,117 @@
+package com.mzc.lp.domain.category.service;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.domain.category.dto.request.CreateCategoryRequest;
+import com.mzc.lp.domain.category.dto.request.UpdateCategoryRequest;
+import com.mzc.lp.domain.category.dto.response.CategoryResponse;
+import com.mzc.lp.domain.category.entity.Category;
+import com.mzc.lp.domain.category.exception.CategoryNotFoundException;
+import com.mzc.lp.domain.category.exception.DuplicateCategoryCodeException;
+import com.mzc.lp.domain.category.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryServiceImpl implements CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    @Transactional
+    public CategoryResponse createCategory(CreateCategoryRequest request) {
+        log.info("Creating category: name={}, code={}", request.name(), request.code());
+
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 중복 코드 체크
+        if (categoryRepository.existsByCodeAndTenantId(request.code(), tenantId)) {
+            throw new DuplicateCategoryCodeException(request.code());
+        }
+
+        Category category = Category.create(
+                request.name(),
+                request.code(),
+                request.sortOrder()
+        );
+
+        Category savedCategory = categoryRepository.save(category);
+        log.info("Category created: id={}, name={}", savedCategory.getId(), savedCategory.getName());
+
+        return CategoryResponse.from(savedCategory);
+    }
+
+    @Override
+    public List<CategoryResponse> getCategories(Boolean activeOnly) {
+        log.debug("Getting categories: activeOnly={}", activeOnly);
+
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        List<Category> categories;
+        if (Boolean.TRUE.equals(activeOnly)) {
+            categories = categoryRepository.findByTenantIdAndActiveOrderBySortOrderAsc(tenantId, true);
+        } else {
+            categories = categoryRepository.findByTenantIdOrderBySortOrderAsc(tenantId);
+        }
+
+        return categories.stream()
+                .map(CategoryResponse::from)
+                .toList();
+    }
+
+    @Override
+    public CategoryResponse getCategory(Long categoryId) {
+        log.debug("Getting category: categoryId={}", categoryId);
+
+        Category category = categoryRepository.findByIdAndTenantId(categoryId, TenantContext.getCurrentTenantId())
+                .orElseThrow(() -> new CategoryNotFoundException(categoryId));
+
+        return CategoryResponse.from(category);
+    }
+
+    @Override
+    @Transactional
+    public CategoryResponse updateCategory(Long categoryId, UpdateCategoryRequest request) {
+        log.info("Updating category: categoryId={}", categoryId);
+
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        Category category = categoryRepository.findByIdAndTenantId(categoryId, tenantId)
+                .orElseThrow(() -> new CategoryNotFoundException(categoryId));
+
+        // 코드 변경 시 중복 체크
+        if (request.code() != null && !request.code().equals(category.getCode())) {
+            if (categoryRepository.existsByCodeAndTenantIdAndIdNot(request.code(), tenantId, categoryId)) {
+                throw new DuplicateCategoryCodeException(request.code());
+            }
+        }
+
+        category.update(
+                request.name(),
+                request.code(),
+                request.sortOrder(),
+                request.active()
+        );
+
+        log.info("Category updated: id={}", categoryId);
+        return CategoryResponse.from(category);
+    }
+
+    @Override
+    @Transactional
+    public void deleteCategory(Long categoryId) {
+        log.info("Deleting category: categoryId={}", categoryId);
+
+        Category category = categoryRepository.findByIdAndTenantId(categoryId, TenantContext.getCurrentTenantId())
+                .orElseThrow(() -> new CategoryNotFoundException(categoryId));
+
+        categoryRepository.delete(category);
+        log.info("Category deleted: id={}", categoryId);
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/category/controller/CategoryControllerTest.java
@@ -1,0 +1,592 @@
+package com.mzc.lp.domain.category.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.category.dto.request.CreateCategoryRequest;
+import com.mzc.lp.domain.category.dto.request.UpdateCategoryRequest;
+import com.mzc.lp.domain.category.entity.Category;
+import com.mzc.lp.domain.category.repository.CategoryRepository;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.dto.request.RegisterRequest;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CategoryControllerTest extends TenantTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        categoryRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ===== 헬퍼 메서드 =====
+
+    private User createOperatorUser() {
+        User user = User.create("operator@example.com", "운영자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.OPERATOR);
+        return userRepository.save(user);
+    }
+
+    private User createAdminUser() {
+        User user = User.create("admin@example.com", "관리자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.TENANT_ADMIN);
+        return userRepository.save(user);
+    }
+
+    private void createTestUser() throws Exception {
+        RegisterRequest request = new RegisterRequest(
+                "test@example.com",
+                "Password123!",
+                "홍길동",
+                "010-1234-5678"
+        );
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+    }
+
+    private String loginAndGetAccessToken(String email, String password) throws Exception {
+        LoginRequest request = new LoginRequest(email, password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("data").get("accessToken").asText();
+    }
+
+    private Category createTestCategory(String name, String code) {
+        Category category = Category.create(name, code);
+        return categoryRepository.save(category);
+    }
+
+    private Category createTestCategory(String name, String code, int sortOrder) {
+        Category category = Category.create(name, code, sortOrder);
+        return categoryRepository.save(category);
+    }
+
+    // ==================== 카테고리 생성 테스트 ====================
+
+    @Nested
+    @DisplayName("POST /api/categories - 카테고리 생성")
+    class CreateCategory {
+
+        @Test
+        @DisplayName("성공 - OPERATOR가 카테고리 생성")
+        void createCategory_success_operator() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CreateCategoryRequest request = new CreateCategoryRequest(
+                    "프로그래밍",
+                    "PROGRAMMING",
+                    1
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/categories")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.name").value("프로그래밍"))
+                    .andExpect(jsonPath("$.data.code").value("PROGRAMMING"))
+                    .andExpect(jsonPath("$.data.sortOrder").value(1))
+                    .andExpect(jsonPath("$.data.active").value(true));
+        }
+
+        @Test
+        @DisplayName("성공 - TENANT_ADMIN이 카테고리 생성")
+        void createCategory_success_admin() throws Exception {
+            // given
+            createAdminUser();
+            String accessToken = loginAndGetAccessToken("admin@example.com", "Password123!");
+            CreateCategoryRequest request = new CreateCategoryRequest(
+                    "데이터베이스",
+                    "DATABASE",
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/categories")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.name").value("데이터베이스"))
+                    .andExpect(jsonPath("$.data.code").value("DATABASE"));
+        }
+
+        @Test
+        @DisplayName("실패 - 이름 누락")
+        void createCategory_fail_missingName() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CreateCategoryRequest request = new CreateCategoryRequest(
+                    null,
+                    "CODE",
+                    1
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/categories")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("실패 - 코드 누락")
+        void createCategory_fail_missingCode() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            CreateCategoryRequest request = new CreateCategoryRequest(
+                    "카테고리명",
+                    null,
+                    1
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/categories")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("실패 - 중복 코드")
+        void createCategory_fail_duplicateCode() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            createTestCategory("기존 카테고리", "DUPLICATE");
+
+            CreateCategoryRequest request = new CreateCategoryRequest(
+                    "새 카테고리",
+                    "DUPLICATE",
+                    1
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/categories")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CAT002"));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 생성 시도")
+        void createCategory_fail_userRole() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken("test@example.com", "Password123!");
+            CreateCategoryRequest request = new CreateCategoryRequest(
+                    "테스트",
+                    "TEST",
+                    1
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/categories")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 카테고리 목록 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/categories - 카테고리 목록 조회")
+    class GetCategories {
+
+        @Test
+        @DisplayName("성공 - 전체 카테고리 목록 조회")
+        void getCategories_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            createTestCategory("프로그래밍", "PROGRAMMING", 1);
+            createTestCategory("데이터베이스", "DATABASE", 2);
+            createTestCategory("인프라", "INFRA", 3);
+
+            // when & then
+            mockMvc.perform(get("/api/categories")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(3));
+        }
+
+        @Test
+        @DisplayName("성공 - 정렬순 확인")
+        void getCategories_success_sorted() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            createTestCategory("세번째", "THIRD", 3);
+            createTestCategory("첫번째", "FIRST", 1);
+            createTestCategory("두번째", "SECOND", 2);
+
+            // when & then
+            mockMvc.perform(get("/api/categories")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data[0].code").value("FIRST"))
+                    .andExpect(jsonPath("$.data[1].code").value("SECOND"))
+                    .andExpect(jsonPath("$.data[2].code").value("THIRD"));
+        }
+
+        @Test
+        @DisplayName("성공 - 활성 카테고리만 조회")
+        void getCategories_success_activeOnly() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Category active = createTestCategory("활성", "ACTIVE", 1);
+            Category inactive = createTestCategory("비활성", "INACTIVE", 2);
+            inactive.deactivate();
+            categoryRepository.save(inactive);
+
+            // when & then
+            mockMvc.perform(get("/api/categories")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("activeOnly", "true"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.length()").value(1))
+                    .andExpect(jsonPath("$.data[0].code").value("ACTIVE"));
+        }
+
+        @Test
+        @DisplayName("성공 - 빈 결과")
+        void getCategories_success_empty() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/categories")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(0));
+        }
+    }
+
+    // ==================== 카테고리 상세 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/categories/{categoryId} - 카테고리 상세 조회")
+    class GetCategory {
+
+        @Test
+        @DisplayName("성공 - 카테고리 상세 조회")
+        void getCategory_success() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Category category = createTestCategory("프로그래밍", "PROGRAMMING");
+
+            // when & then
+            mockMvc.perform(get("/api/categories/{categoryId}", category.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.id").value(category.getId()))
+                    .andExpect(jsonPath("$.data.name").value("프로그래밍"))
+                    .andExpect(jsonPath("$.data.code").value("PROGRAMMING"));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 카테고리")
+        void getCategory_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/categories/{categoryId}", 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CAT001"));
+        }
+    }
+
+    // ==================== 카테고리 수정 테스트 ====================
+
+    @Nested
+    @DisplayName("PUT /api/categories/{categoryId} - 카테고리 수정")
+    class UpdateCategory {
+
+        @Test
+        @DisplayName("성공 - OPERATOR가 카테고리 수정")
+        void updateCategory_success_operator() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Category category = createTestCategory("원래 이름", "ORIGINAL");
+            UpdateCategoryRequest request = new UpdateCategoryRequest(
+                    "수정된 이름",
+                    "UPDATED",
+                    10,
+                    false
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/categories/{categoryId}", category.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.name").value("수정된 이름"))
+                    .andExpect(jsonPath("$.data.code").value("UPDATED"))
+                    .andExpect(jsonPath("$.data.sortOrder").value(10))
+                    .andExpect(jsonPath("$.data.active").value(false));
+        }
+
+        @Test
+        @DisplayName("성공 - 부분 수정")
+        void updateCategory_success_partial() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Category category = createTestCategory("원래 이름", "ORIGINAL");
+            UpdateCategoryRequest request = new UpdateCategoryRequest(
+                    "수정된 이름만",
+                    null,
+                    null,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/categories/{categoryId}", category.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.name").value("수정된 이름만"))
+                    .andExpect(jsonPath("$.data.code").value("ORIGINAL"));
+        }
+
+        @Test
+        @DisplayName("실패 - 중복 코드로 수정")
+        void updateCategory_fail_duplicateCode() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            createTestCategory("기존 카테고리", "EXISTING");
+            Category target = createTestCategory("수정 대상", "TARGET");
+
+            UpdateCategoryRequest request = new UpdateCategoryRequest(
+                    null,
+                    "EXISTING",
+                    null,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/categories/{categoryId}", target.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CAT002"));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 카테고리")
+        void updateCategory_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            UpdateCategoryRequest request = new UpdateCategoryRequest(
+                    "수정 시도",
+                    null,
+                    null,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/categories/{categoryId}", 99999L)
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CAT001"));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 수정 시도")
+        void updateCategory_fail_userRole() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken("test@example.com", "Password123!");
+            Category category = createTestCategory("테스트", "TEST");
+            UpdateCategoryRequest request = new UpdateCategoryRequest(
+                    "수정 시도",
+                    null,
+                    null,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/categories/{categoryId}", category.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ==================== 카테고리 삭제 테스트 ====================
+
+    @Nested
+    @DisplayName("DELETE /api/categories/{categoryId} - 카테고리 삭제")
+    class DeleteCategory {
+
+        @Test
+        @DisplayName("성공 - OPERATOR가 카테고리 삭제")
+        void deleteCategory_success_operator() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+            Category category = createTestCategory("삭제할 카테고리", "DELETE");
+
+            // when & then
+            mockMvc.perform(delete("/api/categories/{categoryId}", category.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+
+            // 삭제 확인
+            mockMvc.perform(get("/api/categories/{categoryId}", category.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("성공 - TENANT_ADMIN이 카테고리 삭제")
+        void deleteCategory_success_admin() throws Exception {
+            // given
+            createAdminUser();
+            String accessToken = loginAndGetAccessToken("admin@example.com", "Password123!");
+            Category category = createTestCategory("삭제할 카테고리", "DELETE");
+
+            // when & then
+            mockMvc.perform(delete("/api/categories/{categoryId}", category.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 카테고리")
+        void deleteCategory_fail_notFound() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(delete("/api/categories/{categoryId}", 99999L)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("CAT001"));
+        }
+
+        @Test
+        @DisplayName("실패 - USER 권한으로 삭제 시도")
+        void deleteCategory_fail_userRole() throws Exception {
+            // given
+            createTestUser();
+            String accessToken = loginAndGetAccessToken("test@example.com", "Password123!");
+            Category category = createTestCategory("삭제할 카테고리", "DELETE");
+
+            // when & then
+            mockMvc.perform(delete("/api/categories/{categoryId}", category.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Category 엔티티 구현 (id, name, code, tenantId, sortOrder, active)
- CategoryController CRUD API 구현 (`/api/categories`)
- 멀티테넌트 지원 (TenantEntity 상속)
- 중복 코드 검증 로직 추가
- 통합 테스트 코드 작성

## Changes
- `Category` 엔티티 생성 (cm_categories 테이블)
- `CategoryRepository` 생성 (테넌트별 조회/검색)
- `CategoryService` 인터페이스 및 구현체
- `CategoryController` (CRUD API)
- DTO 클래스 (CreateCategoryRequest, UpdateCategoryRequest, CategoryResponse)
- Exception 클래스 (CategoryNotFoundException, DuplicateCategoryCodeException)
- ErrorCode 추가 (CAT001, CAT002)

## API Endpoints
| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/categories` | 카테고리 생성 |
| GET | `/api/categories` | 카테고리 목록 조회 |
| GET | `/api/categories/{id}` | 카테고리 상세 조회 |
| PUT | `/api/categories/{id}` | 카테고리 수정 |
| DELETE | `/api/categories/{id}` | 카테고리 삭제 |

## Test plan
- [x] 빌드 성공 확인
- [x] CategoryControllerTest 통과 확인
- [ ] 로컬 서버 실행 후 API 테스트

Closes #175