### PR TITLE
[Fix] 버전 기록 시 변경 후 상태 저장 (#180)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/content/service/ContentVersionServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/content/service/ContentVersionServiceImpl.java
@@ -75,13 +75,6 @@ public class ContentVersionServiceImpl implements ContentVersionService {
         ContentVersion version = contentVersionRepository.findByContentIdAndVersionNumber(contentId, versionNumber)
                 .orElseThrow(() -> new ContentVersionNotFoundException(contentId, versionNumber));
 
-        // 현재 상태 백업
-        String summary = "Before restore to v" + versionNumber;
-        if (changeSummary != null && !changeSummary.isBlank()) {
-            summary += ": " + changeSummary;
-        }
-        createVersion(content, VersionChangeType.FILE_REPLACE, userId, summary);
-
         // 버전 복원 (콘텐츠 이름은 유지, 파일 정보만 복원)
         content.replaceFile(
                 version.getUploadedFileName(),
@@ -91,6 +84,13 @@ public class ContentVersionServiceImpl implements ContentVersionService {
         );
         content.updateThumbnailPath(version.getThumbnailPath());
         content.incrementVersion();
+
+        // 복원 후 상태로 버전 기록
+        String summary = "Restored from v" + versionNumber;
+        if (changeSummary != null && !changeSummary.isBlank()) {
+            summary += ": " + changeSummary;
+        }
+        createVersion(content, VersionChangeType.FILE_REPLACE, userId, summary);
 
         log.info("Content restored to version {}: contentId={}", versionNumber, contentId);
 


### PR DESCRIPTION
## Summary
- 버전 기록 생성 시 변경 전 상태가 아닌 변경 후 상태를 저장하도록 수정
- `updateContent()`: 메타데이터 변경 후 버전 기록 생성
- `replaceFile()`: 파일 교체 및 썸네일 생성 후 버전 기록 생성
- `restoreVersion()`: 복원 후 상태로 버전 기록 생성

## 변경 파일
- `ContentServiceImpl.java`
- `ContentVersionServiceImpl.java`

## Test plan
- [x] 메타데이터 수정 후 현재 버전 확인 (이름 일치)
- [x] 파일 교체 후 현재 버전 확인 (파일명 일치)
- [x] 버전 복원 후 기본정보와 버전 기록 비교 (파일명 일치)

Closes #180