### PR TITLE
feat: CourseTime 생성 시 Program 연결 로직 구현 (#179)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/program/exception/ProgramNotApprovedException.java
+++ b/src/main/java/com/mzc/lp/domain/program/exception/ProgramNotApprovedException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.program.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class ProgramNotApprovedException extends BusinessException {
+
+    public ProgramNotApprovedException() {
+        super(ErrorCode.PROGRAM_NOT_APPROVED);
+    }
+
+    public ProgramNotApprovedException(Long programId) {
+        super(ErrorCode.PROGRAM_NOT_APPROVED, "승인된 프로그램만 차수를 생성할 수 있습니다. ID: " + programId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/dto/request/CreateCourseTimeRequest.java
+++ b/src/main/java/com/mzc/lp/domain/ts/dto/request/CreateCourseTimeRequest.java
@@ -8,8 +8,13 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record CreateCourseTimeRequest(
+        @NotNull(message = "프로그램 ID는 필수입니다")
+        Long programId,
+
+        @Deprecated
         Long cmCourseId,
 
+        @Deprecated
         Long cmCourseVersionId,
 
         @NotBlank(message = "제목은 필수입니다")

--- a/src/test/java/com/mzc/lp/domain/ts/service/CourseTimeServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/ts/service/CourseTimeServiceTest.java
@@ -1,6 +1,9 @@
 package com.mzc.lp.domain.ts.service;
 import com.mzc.lp.common.support.TenantTestSupport;
 
+import com.mzc.lp.domain.program.constant.ProgramStatus;
+import com.mzc.lp.domain.program.entity.Program;
+import com.mzc.lp.domain.program.repository.ProgramRepository;
 import com.mzc.lp.domain.ts.constant.DeliveryType;
 import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
 import com.mzc.lp.domain.ts.dto.response.CapacityResponse;
@@ -19,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -37,6 +41,9 @@ class CourseTimeServiceTest extends TenantTestSupport {
 
     @Mock
     private CourseTimeRepository courseTimeRepository;
+
+    @Mock
+    private ProgramRepository programRepository;
 
     @Mock
     private InstructorAssignmentService instructorAssignmentService;
@@ -64,6 +71,13 @@ class CourseTimeServiceTest extends TenantTestSupport {
             courseTime.incrementEnrollment();
         }
         return courseTime;
+    }
+
+    private Program createApprovedProgram() {
+        Program program = Program.create("테스트 프로그램", 1L);
+        ReflectionTestUtils.setField(program, "id", 1L);
+        ReflectionTestUtils.setField(program, "status", ProgramStatus.APPROVED);
+        return program;
     }
 
     // ==================== 좌석 점유 테스트 ====================
@@ -276,6 +290,7 @@ class CourseTimeServiceTest extends TenantTestSupport {
             // given
             LocalDate today = LocalDate.now();
             CreateCourseTimeRequest request = new CreateCourseTimeRequest(
+                    1L,  // programId
                     null,
                     null,
                     "테스트 차수",
@@ -294,6 +309,10 @@ class CourseTimeServiceTest extends TenantTestSupport {
                     true
             );
 
+            // Program Mock 설정
+            Program program = createApprovedProgram();
+            given(programRepository.findByIdAndTenantId(1L, DEFAULT_TENANT_ID)).willReturn(Optional.of(program));
+
             // when & then
             assertThatThrownBy(() -> courseTimeService.createCourseTime(request, 1L))
                     .isInstanceOf(InvalidDateRangeException.class)
@@ -306,6 +325,7 @@ class CourseTimeServiceTest extends TenantTestSupport {
             // given
             LocalDate today = LocalDate.now();
             CreateCourseTimeRequest request = new CreateCourseTimeRequest(
+                    1L,  // programId
                     null,
                     null,
                     "테스트 차수",
@@ -324,6 +344,10 @@ class CourseTimeServiceTest extends TenantTestSupport {
                     true
             );
 
+            // Program Mock 설정
+            Program program = createApprovedProgram();
+            given(programRepository.findByIdAndTenantId(1L, DEFAULT_TENANT_ID)).willReturn(Optional.of(program));
+
             // when & then
             assertThatThrownBy(() -> courseTimeService.createCourseTime(request, 1L))
                     .isInstanceOf(InvalidDateRangeException.class)
@@ -336,6 +360,7 @@ class CourseTimeServiceTest extends TenantTestSupport {
             // given
             LocalDate today = LocalDate.now();
             CreateCourseTimeRequest request = new CreateCourseTimeRequest(
+                    1L,  // programId
                     null,
                     null,
                     "테스트 차수",
@@ -353,6 +378,10 @@ class CourseTimeServiceTest extends TenantTestSupport {
                     null,
                     true
             );
+
+            // Program Mock 설정
+            Program program = createApprovedProgram();
+            given(programRepository.findByIdAndTenantId(1L, DEFAULT_TENANT_ID)).willReturn(Optional.of(program));
 
             CourseTime savedCourseTime = createTestCourseTime(30, 0);
             given(courseTimeRepository.save(org.mockito.ArgumentMatchers.any(CourseTime.class)))


### PR DESCRIPTION
## Summary

CourseTime 생성 시 승인된 Program과 연결하고, 오픈 시 Program 승인 상태를 검증하는 로직 구현

## Related Issue

- Closes #179

## Changes

- `CreateCourseTimeRequest`에 `@NotNull Long programId` 필드 추가
- `CourseTimeServiceImpl`에 `ProgramRepository` 의존성 주입
- `createCourseTime()`: Program 조회 → `canCreateTime()` 검증 → `linkProgram()` 연결
- `openCourseTime()`: Program 연결 여부 및 `isApproved()` 검증
- `ProgramNotApprovedException` 예외 클래스 생성 (ErrorCode: PG004)
- 테스트 코드에 승인된 Program fixture 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Test plan

- [x] 전체 테스트 통과 (528 tests)
- [x] 승인된 Program으로 차수 생성 성공
- [x] 미승인 Program으로 차수 생성 시 PG004 에러
- [x] Program 미연결 차수 오픈 시 PG001 에러
- [x] Program 미승인 상태에서 차수 오픈 시 PG004 에러

## Additional Notes

- `cmCourseId`, `cmCourseVersionId`는 `@Deprecated` 처리하여 하위 호환성 유지
- `cloneFrom()`은 원본 차수의 Program을 자동 복사하므로 별도 처리 불필요