### PR TITLE
feat: 강사 가용성 확인 API 추가 (#172)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
+++ b/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
@@ -5,10 +5,12 @@ import com.mzc.lp.common.security.UserPrincipal;
 import com.mzc.lp.domain.iis.constant.AssignmentAction;
 import com.mzc.lp.domain.iis.constant.AssignmentStatus;
 import com.mzc.lp.domain.iis.dto.request.CancelAssignmentRequest;
+import com.mzc.lp.domain.iis.dto.request.InstructorAvailabilityCheckRequest;
 import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
 import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
 import com.mzc.lp.domain.iis.dto.response.AssignmentHistoryResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
+import com.mzc.lp.domain.iis.dto.response.InstructorAvailabilityResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorDetailStatResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorStatResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorStatisticsResponse;
@@ -148,6 +150,29 @@ public class InstructorAssignmentController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
     ) {
         InstructorDetailStatResponse response = assignmentService.getInstructorDetailStatistics(userId, startDate, endDate);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // ========== 가용성 확인 API ==========
+
+    @GetMapping("/api/users/{userId}/availability")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<InstructorAvailabilityResponse>> checkAvailability(
+            @PathVariable Long userId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    ) {
+        InstructorAvailabilityResponse response = assignmentService.checkAvailability(userId, startDate, endDate);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/api/instructors/availability/check")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<InstructorAvailabilityResponse>>> checkAvailabilityBulk(
+            @Valid @RequestBody InstructorAvailabilityCheckRequest request
+    ) {
+        List<InstructorAvailabilityResponse> response = assignmentService.checkAvailabilityBulk(
+                request.userIds(), request.startDate(), request.endDate());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/iis/dto/request/InstructorAvailabilityCheckRequest.java
+++ b/src/main/java/com/mzc/lp/domain/iis/dto/request/InstructorAvailabilityCheckRequest.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.domain.iis.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record InstructorAvailabilityCheckRequest(
+        @NotEmpty(message = "userIds must not be empty")
+        List<Long> userIds,
+
+        @NotNull(message = "startDate is required")
+        LocalDate startDate,
+
+        @NotNull(message = "endDate is required")
+        LocalDate endDate
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/iis/dto/response/ConflictingAssignmentInfo.java
+++ b/src/main/java/com/mzc/lp/domain/iis/dto/response/ConflictingAssignmentInfo.java
@@ -1,0 +1,29 @@
+package com.mzc.lp.domain.iis.dto.response;
+
+import com.mzc.lp.domain.iis.constant.InstructorRole;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+
+import java.time.LocalDate;
+
+public record ConflictingAssignmentInfo(
+        Long timeId,
+        String courseName,
+        String timeName,
+        LocalDate startDate,
+        LocalDate endDate,
+        InstructorRole role
+) {
+    public static ConflictingAssignmentInfo of(
+            CourseTime courseTime,
+            InstructorRole role
+    ) {
+        return new ConflictingAssignmentInfo(
+                courseTime.getId(),
+                courseTime.getTitle(),
+                courseTime.getTitle(),
+                courseTime.getClassStartDate(),
+                courseTime.getClassEndDate(),
+                role
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/iis/dto/response/InstructorAvailabilityResponse.java
+++ b/src/main/java/com/mzc/lp/domain/iis/dto/response/InstructorAvailabilityResponse.java
@@ -1,0 +1,17 @@
+package com.mzc.lp.domain.iis.dto.response;
+
+import java.util.List;
+
+public record InstructorAvailabilityResponse(
+        Long userId,
+        boolean available,
+        List<ConflictingAssignmentInfo> conflictingAssignments
+) {
+    public static InstructorAvailabilityResponse available(Long userId) {
+        return new InstructorAvailabilityResponse(userId, true, List.of());
+    }
+
+    public static InstructorAvailabilityResponse unavailable(Long userId, List<ConflictingAssignmentInfo> conflicts) {
+        return new InstructorAvailabilityResponse(userId, false, conflicts);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/iis/repository/InstructorAssignmentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/iis/repository/InstructorAssignmentRepository.java
@@ -229,4 +229,15 @@ public interface InstructorAssignmentRepository extends JpaRepository<Instructor
             @Param("userKey") Long userKey,
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate);
+
+    // ========== 가용성 확인 API용 메서드 ==========
+
+    // 여러 강사의 ACTIVE 배정 목록 Bulk 조회
+    @Query("SELECT ia FROM InstructorAssignment ia " +
+            "WHERE ia.tenantId = :tenantId " +
+            "AND ia.userKey IN :userKeys " +
+            "AND ia.status = 'ACTIVE'")
+    List<InstructorAssignment> findActiveByUserKeyIn(
+            @Param("tenantId") Long tenantId,
+            @Param("userKeys") List<Long> userKeys);
 }

--- a/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentService.java
+++ b/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentService.java
@@ -8,6 +8,7 @@ import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
 import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
 import com.mzc.lp.domain.iis.dto.response.AssignmentHistoryResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
+import com.mzc.lp.domain.iis.dto.response.InstructorAvailabilityResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorDetailStatResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorStatResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorStatisticsResponse;
@@ -95,4 +96,24 @@ public interface InstructorAssignmentService {
      * @return 강사 개인 상세 통계 (차수별 통계 포함)
      */
     InstructorDetailStatResponse getInstructorDetailStatistics(Long userId, LocalDate startDate, LocalDate endDate);
+
+    // ========== 가용성 확인 API ==========
+
+    /**
+     * 특정 강사의 가용성 확인
+     * @param userId 강사 ID
+     * @param startDate 확인할 기간 시작일
+     * @param endDate 확인할 기간 종료일
+     * @return 가용성 정보 (충돌 배정 목록 포함)
+     */
+    InstructorAvailabilityResponse checkAvailability(Long userId, LocalDate startDate, LocalDate endDate);
+
+    /**
+     * 여러 강사의 가용성 일괄 확인
+     * @param userIds 강사 ID 목록
+     * @param startDate 확인할 기간 시작일
+     * @param endDate 확인할 기간 종료일
+     * @return 강사별 가용성 정보 목록
+     */
+    List<InstructorAvailabilityResponse> checkAvailabilityBulk(List<Long> userIds, LocalDate startDate, LocalDate endDate);
 }


### PR DESCRIPTION
## Summary

강사 배정 전에 해당 강사의 가용성을 미리 확인할 수 있는 API를 추가합니다.

## Related Issue

Closes #172

## Changes

- 단건 조회 API: `GET /api/users/{userId}/availability`
- 벌크 조회 API: `POST /api/instructors/availability/check`
- 기간 겹침 시 충돌하는 배정 정보 반환 (차수명, 과정명, 기간, 역할)

## New Files

- `ConflictingAssignmentInfo.java` - 충돌 배정 상세 정보 DTO
- `InstructorAvailabilityResponse.java` - 가용성 응답 DTO
- `InstructorAvailabilityCheckRequest.java` - 벌크 조회 요청 DTO

## Test Plan

- [x] 가용 시 available=true 반환
- [x] 충돌 시 available=false 및 충돌 목록 반환
- [x] 벌크 조회 정상 동작
- [x] 전체 테스트 통과