### PR TITLE
refactor: Program 삭제 시 소유권 검증 추가 (#165)

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -100,6 +100,7 @@ public enum ErrorCode {
     PROGRAM_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST, "PG003", "Program is not modifiable in current status"),
     PROGRAM_NOT_APPROVED(HttpStatus.BAD_REQUEST, "PG004", "Program is not approved"),
     REJECTION_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "PG005", "Rejection reason is required"),
+    UNAUTHORIZED_PROGRAM_ACCESS(HttpStatus.FORBIDDEN, "PG006", "Not authorized to access this program"),
 
     // Category (CAT)
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CAT001", "Category not found"),

--- a/src/main/java/com/mzc/lp/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/mzc/lp/domain/program/controller/ProgramController.java
@@ -99,7 +99,8 @@ public class ProgramController {
             @PathVariable @Positive Long programId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        programService.deleteProgram(programId);
+        boolean isTenantAdmin = "TENANT_ADMIN".equals(principal.role());
+        programService.deleteProgram(programId, principal.id(), isTenantAdmin);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/mzc/lp/domain/program/exception/ProgramOwnershipException.java
+++ b/src/main/java/com/mzc/lp/domain/program/exception/ProgramOwnershipException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.program.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class ProgramOwnershipException extends BusinessException {
+
+    public ProgramOwnershipException() {
+        super(ErrorCode.UNAUTHORIZED_PROGRAM_ACCESS);
+    }
+
+    public ProgramOwnershipException(String message) {
+        super(ErrorCode.UNAUTHORIZED_PROGRAM_ACCESS, message);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/program/service/ProgramService.java
+++ b/src/main/java/com/mzc/lp/domain/program/service/ProgramService.java
@@ -22,7 +22,7 @@ public interface ProgramService {
 
     ProgramResponse updateProgram(Long programId, UpdateProgramRequest request);
 
-    void deleteProgram(Long programId);
+    void deleteProgram(Long programId, Long currentUserId, boolean isTenantAdmin);
 
     // 워크플로우
     ProgramResponse submitProgram(Long programId);


### PR DESCRIPTION
## Summary

Program 삭제 API에 소유권 검증 로직을 추가하여 보안 취약점을 해결합니다.
- DESIGNER/OPERATOR는 본인이 생성한 Program만 삭제 가능
- TENANT_ADMIN은 테넌트 내 모든 Program 삭제 가능

## Related Issue

- Closes #165

## Changes

- `ErrorCode.java` - UNAUTHORIZED_PROGRAM_ACCESS (PG006) 추가
- `ProgramOwnershipException.java` - 소유권 검증 실패 예외 클래스 신규 생성
- `ProgramService.java` - deleteProgram 시그니처 변경
- `ProgramServiceImpl.java` - 소유권 검증 로직 추가
- `ProgramController.java` - currentUserId, isTenantAdmin 파라미터 전달
- `ProgramControllerTest.java` - 소유권 검증 테스트 케이스 추가

## Type of Change

- [ ] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [x] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 기존 TS 모듈의 소유권 검증 패턴(Phase 8)과 동일한 방식으로 구현
- Program Entity에 이미 `creatorId` 필드가 존재하여 Entity 수정 불필요