### PR TITLE
feat: Course 삭제 시 소유권 검증 추가 (#164)

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     CM_SNAPSHOT_STATE_ERROR(HttpStatus.BAD_REQUEST, "CM007", "Invalid snapshot state"),
     CM_LEARNING_OBJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "CM008", "LearningObject not found"),
     CM_SNAPSHOT_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "CM009", "SnapshotItem not found"),
+    CM_UNAUTHORIZED_COURSE_ACCESS(HttpStatus.FORBIDDEN, "CM010", "Not authorized to access this course"),
 
     // Content (CMS)
     CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CT001", "Content not found"),

--- a/src/main/java/com/mzc/lp/domain/course/controller/CourseController.java
+++ b/src/main/java/com/mzc/lp/domain/course/controller/CourseController.java
@@ -38,7 +38,7 @@ public class CourseController {
             @Valid @RequestBody CreateCourseRequest request,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        CourseResponse response = courseService.createCourse(request);
+        CourseResponse response = courseService.createCourse(request, principal.id());
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 
@@ -95,7 +95,8 @@ public class CourseController {
             @PathVariable @Positive Long courseId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        courseService.deleteCourse(courseId);
+        boolean isTenantAdmin = "TENANT_ADMIN".equals(principal.role());
+        courseService.deleteCourse(courseId, principal.id(), isTenantAdmin);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/mzc/lp/domain/course/entity/Course.java
+++ b/src/main/java/com/mzc/lp/domain/course/entity/Course.java
@@ -46,6 +46,9 @@ public class Course extends TenantEntity {
     private Long categoryId;
 
     @Column
+    private Long createdBy;
+
+    @Column
     private LocalDate startDate;
 
     @Column
@@ -60,16 +63,18 @@ public class Course extends TenantEntity {
     private List<CourseItem> items = new ArrayList<>();
 
     // ===== 정적 팩토리 메서드 =====
-    public static Course create(String title) {
+    public static Course create(String title, Long createdBy) {
         Course course = new Course();
         course.title = title;
+        course.createdBy = createdBy;
         return course;
     }
 
     public static Course create(String title, String description, CourseLevel level,
                                 CourseType type, Integer estimatedHours,
                                 Long categoryId, String thumbnailUrl,
-                                LocalDate startDate, LocalDate endDate, List<String> tags) {
+                                LocalDate startDate, LocalDate endDate, List<String> tags,
+                                Long createdBy) {
         Course course = new Course();
         course.title = title;
         course.description = description;
@@ -81,6 +86,7 @@ public class Course extends TenantEntity {
         course.startDate = startDate;
         course.endDate = endDate;
         course.tags = tags != null ? new ArrayList<>(tags) : new ArrayList<>();
+        course.createdBy = createdBy;
         return course;
     }
 

--- a/src/main/java/com/mzc/lp/domain/course/exception/CourseOwnershipException.java
+++ b/src/main/java/com/mzc/lp/domain/course/exception/CourseOwnershipException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.course.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class CourseOwnershipException extends BusinessException {
+
+    public CourseOwnershipException() {
+        super(ErrorCode.CM_UNAUTHORIZED_COURSE_ACCESS);
+    }
+
+    public CourseOwnershipException(String message) {
+        super(ErrorCode.CM_UNAUTHORIZED_COURSE_ACCESS, message);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseService.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseService.java
@@ -12,9 +12,10 @@ public interface CourseService {
     /**
      * 강의 생성
      * @param request 생성 요청 DTO
+     * @param createdBy 생성자 ID
      * @return 생성된 강의 정보
      */
-    CourseResponse createCourse(CreateCourseRequest request);
+    CourseResponse createCourse(CreateCourseRequest request, Long createdBy);
 
     /**
      * 강의 목록 조회 (페이징, 키워드 검색, 카테고리 필터)
@@ -43,6 +44,8 @@ public interface CourseService {
     /**
      * 강의 삭제
      * @param courseId 강의 ID
+     * @param currentUserId 현재 사용자 ID
+     * @param isTenantAdmin 테넌트 관리자 여부
      */
-    void deleteCourse(Long courseId);
+    void deleteCourse(Long courseId, Long currentUserId, boolean isTenantAdmin);
 }

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseItemControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseItemControllerTest.java
@@ -108,6 +108,7 @@ class CourseItemControllerTest extends TenantTestSupport {
                 null,
                 null,
                 null,
+                null,
                 null
         );
         return courseRepository.save(course);

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseRelationControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseRelationControllerTest.java
@@ -115,6 +115,7 @@ class CourseRelationControllerTest extends TenantTestSupport {
                 null,
                 null,
                 null,
+                null,
                 null
         );
         return courseRepository.save(course);

--- a/src/test/java/com/mzc/lp/domain/snapshot/controller/SnapshotControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/snapshot/controller/SnapshotControllerTest.java
@@ -131,6 +131,7 @@ class SnapshotControllerTest extends TenantTestSupport {
                 null,
                 null,
                 null,
+                null,
                 null
         );
         return courseRepository.save(course);


### PR DESCRIPTION
## Summary

Course 삭제 API에 소유권 검증 로직을 추가하여 본인이 생성한 Course 또는 TENANT_ADMIN만 삭제할 수 있도록 변경

## Related Issue

- Closes #164

## Changes

- `ErrorCode.java`: CM_UNAUTHORIZED_COURSE_ACCESS (CM010) 추가
- `CourseOwnershipException.java`: 신규 생성
- `Course.java`: createdBy 필드 및 create() 메서드 수정
- `CourseService.java`: deleteCourse 시그니처 변경
- `CourseServiceImpl.java`: 소유권 검증 로직 추가
- `CourseController.java`: isTenantAdmin 파라미터 전달
- `*ControllerTest.java`: 테스트 케이스 추가/수정

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Test plan

- [x] OPERATOR가 본인의 강의 삭제 → 성공 (204)
- [x] TENANT_ADMIN이 타인의 강의 삭제 → 성공 (204)
- [x] OPERATOR가 타인의 강의 삭제 → 실패 (403, CM010)
- [x] 존재하지 않는 강의 삭제 → 실패 (404)
- [x] 인증 없이 삭제 시도 → 실패 (403)

## Additional Notes

Program 모듈(#165)과 동일한 소유권 검증 패턴 적용