### PR TITLE
refactor: Program creatorId → createdBy 네이밍 통일

### DIFF
--- a/src/main/java/com/mzc/lp/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/mzc/lp/domain/program/controller/ProgramController.java
@@ -53,11 +53,11 @@ public class ProgramController {
     @GetMapping
     public ResponseEntity<ApiResponse<Page<ProgramResponse>>> getPrograms(
             @RequestParam(required = false) ProgramStatus status,
-            @RequestParam(required = false) Long creatorId,
+            @RequestParam(required = false) Long createdBy,
             @PageableDefault(size = 20) Pageable pageable,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Page<ProgramResponse> response = programService.getPrograms(status, creatorId, pageable);
+        Page<ProgramResponse> response = programService.getPrograms(status, createdBy, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/mzc/lp/domain/program/dto/response/PendingProgramResponse.java
+++ b/src/main/java/com/mzc/lp/domain/program/dto/response/PendingProgramResponse.java
@@ -12,7 +12,7 @@ public record PendingProgramResponse(
         String thumbnailUrl,
         ProgramLevel level,
         ProgramType type,
-        Long creatorId,
+        Long createdBy,
         Instant submittedAt,
         Long snapshotId
 ) {
@@ -23,7 +23,7 @@ public record PendingProgramResponse(
                 program.getThumbnailUrl(),
                 program.getLevel(),
                 program.getType(),
-                program.getCreatorId(),
+                program.getCreatedBy(),
                 program.getSubmittedAt(),
                 program.getSnapshot() != null ? program.getSnapshot().getId() : null
         );

--- a/src/main/java/com/mzc/lp/domain/program/dto/response/ProgramDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/program/dto/response/ProgramDetailResponse.java
@@ -16,7 +16,7 @@ public record ProgramDetailResponse(
         ProgramType type,
         Integer estimatedHours,
         ProgramStatus status,
-        Long creatorId,
+        Long createdBy,
         Long snapshotId,
         String snapshotName,
         // 승인 정보
@@ -41,7 +41,7 @@ public record ProgramDetailResponse(
                 program.getType(),
                 program.getEstimatedHours(),
                 program.getStatus(),
-                program.getCreatorId(),
+                program.getCreatedBy(),
                 program.getSnapshot() != null ? program.getSnapshot().getId() : null,
                 program.getSnapshot() != null ? program.getSnapshot().getSnapshotName() : null,
                 program.getApprovedBy(),

--- a/src/main/java/com/mzc/lp/domain/program/dto/response/ProgramResponse.java
+++ b/src/main/java/com/mzc/lp/domain/program/dto/response/ProgramResponse.java
@@ -16,7 +16,7 @@ public record ProgramResponse(
         ProgramType type,
         Integer estimatedHours,
         ProgramStatus status,
-        Long creatorId,
+        Long createdBy,
         Long snapshotId,
         Instant createdAt,
         Instant updatedAt
@@ -31,7 +31,7 @@ public record ProgramResponse(
                 program.getType(),
                 program.getEstimatedHours(),
                 program.getStatus(),
-                program.getCreatorId(),
+                program.getCreatedBy(),
                 program.getSnapshot() != null ? program.getSnapshot().getId() : null,
                 program.getCreatedAt(),
                 program.getUpdatedAt()

--- a/src/main/java/com/mzc/lp/domain/program/entity/Program.java
+++ b/src/main/java/com/mzc/lp/domain/program/entity/Program.java
@@ -18,7 +18,7 @@ import java.time.Instant;
 @Table(name = "cm_programs", indexes = {
         @Index(name = "idx_program_tenant", columnList = "tenant_id"),
         @Index(name = "idx_program_status", columnList = "status"),
-        @Index(name = "idx_program_creator", columnList = "creator_id"),
+        @Index(name = "idx_program_created_by", columnList = "created_by"),
         @Index(name = "idx_program_snapshot", columnList = "snapshot_id")
 })
 @Getter
@@ -57,8 +57,8 @@ public class Program extends TenantEntity {
     @Column(nullable = false, length = 20)
     private ProgramStatus status;
 
-    @Column(name = "creator_id", nullable = false)
-    private Long creatorId;
+    @Column(name = "created_by", nullable = false)
+    private Long createdBy;
 
     // 승인 정보
     @Column(name = "approved_by")
@@ -82,17 +82,17 @@ public class Program extends TenantEntity {
     private Instant submittedAt;
 
     // ===== 정적 팩토리 메서드 =====
-    public static Program create(String title, Long creatorId) {
+    public static Program create(String title, Long createdBy) {
         Program program = new Program();
         program.title = title;
-        program.creatorId = creatorId;
+        program.createdBy = createdBy;
         program.status = ProgramStatus.DRAFT;
         return program;
     }
 
     public static Program create(String title, String description, String thumbnailUrl,
                                   ProgramLevel level, ProgramType type, Integer estimatedHours,
-                                  Long creatorId) {
+                                  Long createdBy) {
         Program program = new Program();
         program.title = title;
         program.description = description;
@@ -100,7 +100,7 @@ public class Program extends TenantEntity {
         program.level = level;
         program.type = type;
         program.estimatedHours = estimatedHours;
-        program.creatorId = creatorId;
+        program.createdBy = createdBy;
         program.status = ProgramStatus.DRAFT;
         return program;
     }

--- a/src/main/java/com/mzc/lp/domain/program/repository/ProgramRepository.java
+++ b/src/main/java/com/mzc/lp/domain/program/repository/ProgramRepository.java
@@ -20,9 +20,9 @@ public interface ProgramRepository extends JpaRepository<Program, Long> {
 
     Page<Program> findByTenantIdAndStatus(Long tenantId, ProgramStatus status, Pageable pageable);
 
-    Page<Program> findByTenantIdAndCreatorId(Long tenantId, Long creatorId, Pageable pageable);
+    Page<Program> findByTenantIdAndCreatedBy(Long tenantId, Long createdBy, Pageable pageable);
 
-    Page<Program> findByTenantIdAndStatusAndCreatorId(Long tenantId, ProgramStatus status, Long creatorId, Pageable pageable);
+    Page<Program> findByTenantIdAndStatusAndCreatedBy(Long tenantId, ProgramStatus status, Long createdBy, Pageable pageable);
 
     @Query("SELECT p FROM Program p WHERE p.tenantId = :tenantId AND p.status = 'PENDING' ORDER BY p.submittedAt ASC")
     Page<Program> findPendingPrograms(@Param("tenantId") Long tenantId, Pageable pageable);

--- a/src/main/java/com/mzc/lp/domain/program/service/ProgramService.java
+++ b/src/main/java/com/mzc/lp/domain/program/service/ProgramService.java
@@ -18,7 +18,7 @@ public interface ProgramService {
 
     ProgramDetailResponse getProgram(Long programId);
 
-    Page<ProgramResponse> getPrograms(ProgramStatus status, Long creatorId, Pageable pageable);
+    Page<ProgramResponse> getPrograms(ProgramStatus status, Long createdBy, Pageable pageable);
 
     ProgramResponse updateProgram(Long programId, UpdateProgramRequest request);
 

--- a/src/main/java/com/mzc/lp/domain/program/service/ProgramServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/program/service/ProgramServiceImpl.java
@@ -71,17 +71,17 @@ public class ProgramServiceImpl implements ProgramService {
     }
 
     @Override
-    public Page<ProgramResponse> getPrograms(ProgramStatus status, Long creatorId, Pageable pageable) {
-        log.debug("Getting programs: status={}, creatorId={}", status, creatorId);
+    public Page<ProgramResponse> getPrograms(ProgramStatus status, Long createdBy, Pageable pageable) {
+        log.debug("Getting programs: status={}, createdBy={}", status, createdBy);
 
         Page<Program> programs;
 
-        if (status != null && creatorId != null) {
-            programs = programRepository.findByTenantIdAndStatusAndCreatorId(TenantContext.getCurrentTenantId(), status, creatorId, pageable);
+        if (status != null && createdBy != null) {
+            programs = programRepository.findByTenantIdAndStatusAndCreatedBy(TenantContext.getCurrentTenantId(), status, createdBy, pageable);
         } else if (status != null) {
             programs = programRepository.findByTenantIdAndStatus(TenantContext.getCurrentTenantId(), status, pageable);
-        } else if (creatorId != null) {
-            programs = programRepository.findByTenantIdAndCreatorId(TenantContext.getCurrentTenantId(), creatorId, pageable);
+        } else if (createdBy != null) {
+            programs = programRepository.findByTenantIdAndCreatedBy(TenantContext.getCurrentTenantId(), createdBy, pageable);
         } else {
             programs = programRepository.findByTenantId(TenantContext.getCurrentTenantId(), pageable);
         }
@@ -119,7 +119,7 @@ public class ProgramServiceImpl implements ProgramService {
                 .orElseThrow(() -> new ProgramNotFoundException(programId));
 
         // 소유권 검증: 본인이 생성한 프로그램 또는 TENANT_ADMIN만 삭제 가능
-        if (!isTenantAdmin && !currentUserId.equals(program.getCreatorId())) {
+        if (!isTenantAdmin && !currentUserId.equals(program.getCreatedBy())) {
             throw new ProgramOwnershipException("본인이 생성한 프로그램만 삭제할 수 있습니다");
         }
 

--- a/src/test/java/com/mzc/lp/domain/program/controller/ProgramControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/program/controller/ProgramControllerTest.java
@@ -104,7 +104,7 @@ class ProgramControllerTest extends TenantTestSupport {
         return objectMapper.readTree(response).get("data").get("accessToken").asText();
     }
 
-    private Program createTestProgram(String title, Long creatorId) {
+    private Program createTestProgram(String title, Long createdBy) {
         Program program = Program.create(
                 title,
                 "테스트 프로그램 설명",
@@ -112,13 +112,13 @@ class ProgramControllerTest extends TenantTestSupport {
                 ProgramLevel.BEGINNER,
                 ProgramType.ONLINE,
                 10,
-                creatorId
+                createdBy
         );
         return programRepository.save(program);
     }
 
-    private Program createTestProgramWithStatus(String title, Long creatorId, ProgramStatus status) {
-        Program program = createTestProgram(title, creatorId);
+    private Program createTestProgramWithStatus(String title, Long createdBy, ProgramStatus status) {
+        Program program = createTestProgram(title, createdBy);
 
         if (status == ProgramStatus.PENDING) {
             program.submit();
@@ -169,7 +169,7 @@ class ProgramControllerTest extends TenantTestSupport {
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.data.title").value("Spring Boot 기초"))
                     .andExpect(jsonPath("$.data.status").value("DRAFT"))
-                    .andExpect(jsonPath("$.data.creatorId").value(designer.getId()));
+                    .andExpect(jsonPath("$.data.createdBy").value(designer.getId()));
         }
 
         @Test
@@ -313,7 +313,7 @@ class ProgramControllerTest extends TenantTestSupport {
             // when & then
             mockMvc.perform(get("/api/programs")
                             .header("Authorization", "Bearer " + accessToken)
-                            .param("creatorId", designer.getId().toString()))
+                            .param("createdBy", designer.getId().toString()))
                     .andDo(print())
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))


### PR DESCRIPTION
## Summary

Program 엔티티의 `creatorId` 필드를 `createdBy`로 변경하여 다른 5개 엔티티와 네이밍 일관성 확보

## Related Issue

- Closes #

## Changes

- Entity: `creatorId` → `createdBy`, DB 컬럼 `creator_id` → `created_by`
- Repository: 쿼리 메서드명 변경 (`findByTenantIdAndCreatedBy` 등)
- Service: getter 호출 및 파라미터명 변경
- Controller: `@RequestParam` 파라미터명 변경
- DTO: record 필드명 변경 (3개 파일)
- Test: 테스트 코드 업데이트

## Type of Change

- [ ] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [x] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)