### PR TITLE
fix: 콘텐츠 목록 조회 시 보관된 콘텐츠 제외 및 필터 개선

### DIFF
--- a/src/main/java/com/mzc/lp/domain/content/controller/ContentController.java
+++ b/src/main/java/com/mzc/lp/domain/content/controller/ContentController.java
@@ -180,6 +180,7 @@ public class ContentController {
     @GetMapping("/my")
     @PreAuthorize("hasRole('DESIGNER')")
     public ResponseEntity<ApiResponse<Page<ContentListResponse>>> getMyContents(
+            @RequestParam(required = false) ContentType contentType,
             @RequestParam(required = false) ContentStatus status,
             @RequestParam(required = false) String keyword,
             @PageableDefault(size = 20) Pageable pageable,
@@ -188,7 +189,7 @@ public class ContentController {
         Long tenantId = TenantContext.getCurrentTenantId();
         Long userId = principal.id();
         Page<ContentListResponse> response = contentService.getMyContents(
-                tenantId, userId, status, keyword, pageable);
+                tenantId, userId, contentType, status, keyword, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/mzc/lp/domain/content/repository/ContentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/content/repository/ContentRepository.java
@@ -19,7 +19,12 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
 
     Page<Content> findByTenantId(Long tenantId, Pageable pageable);
 
+    Page<Content> findByTenantIdAndStatus(Long tenantId, ContentStatus status, Pageable pageable);
+
     Page<Content> findByTenantIdAndContentType(Long tenantId, ContentType contentType, Pageable pageable);
+
+    Page<Content> findByTenantIdAndStatusAndContentType(Long tenantId, ContentStatus status,
+                                                         ContentType contentType, Pageable pageable);
 
     @Query("SELECT c FROM Content c WHERE c.tenantId = :tenantId AND " +
            "(LOWER(c.originalFileName) LIKE LOWER(CONCAT('%', :keyword, '%')))")
@@ -27,12 +32,27 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
                                            @Param("keyword") String keyword,
                                            Pageable pageable);
 
+    @Query("SELECT c FROM Content c WHERE c.tenantId = :tenantId AND c.status = :status AND " +
+           "(LOWER(c.originalFileName) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+    Page<Content> findByTenantIdAndStatusAndKeyword(@Param("tenantId") Long tenantId,
+                                                     @Param("status") ContentStatus status,
+                                                     @Param("keyword") String keyword,
+                                                     Pageable pageable);
+
     @Query("SELECT c FROM Content c WHERE c.tenantId = :tenantId AND c.contentType = :contentType AND " +
            "(LOWER(c.originalFileName) LIKE LOWER(CONCAT('%', :keyword, '%')))")
     Page<Content> findByTenantIdAndContentTypeAndKeyword(@Param("tenantId") Long tenantId,
                                                          @Param("contentType") ContentType contentType,
                                                          @Param("keyword") String keyword,
                                                          Pageable pageable);
+
+    @Query("SELECT c FROM Content c WHERE c.tenantId = :tenantId AND c.status = :status AND c.contentType = :contentType AND " +
+           "(LOWER(c.originalFileName) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+    Page<Content> findByTenantIdAndStatusAndContentTypeAndKeyword(@Param("tenantId") Long tenantId,
+                                                                   @Param("status") ContentStatus status,
+                                                                   @Param("contentType") ContentType contentType,
+                                                                   @Param("keyword") String keyword,
+                                                                   Pageable pageable);
 
     // createdBy 기반 조회 (DESIGNER용)
     Page<Content> findByTenantIdAndCreatedBy(Long tenantId, Long createdBy, Pageable pageable);

--- a/src/main/java/com/mzc/lp/domain/content/repository/ContentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/content/repository/ContentRepository.java
@@ -60,6 +60,13 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
     Page<Content> findByTenantIdAndCreatedByAndStatus(Long tenantId, Long createdBy,
                                                        ContentStatus status, Pageable pageable);
 
+    Page<Content> findByTenantIdAndCreatedByAndContentType(Long tenantId, Long createdBy,
+                                                            ContentType contentType, Pageable pageable);
+
+    Page<Content> findByTenantIdAndCreatedByAndContentTypeAndStatus(Long tenantId, Long createdBy,
+                                                                     ContentType contentType,
+                                                                     ContentStatus status, Pageable pageable);
+
     @Query("SELECT c FROM Content c WHERE c.tenantId = :tenantId AND c.createdBy = :createdBy " +
            "AND LOWER(c.originalFileName) LIKE LOWER(CONCAT('%', :keyword, '%'))")
     Page<Content> findByTenantIdAndCreatedByAndKeyword(@Param("tenantId") Long tenantId,
@@ -74,4 +81,22 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
                                                                  @Param("status") ContentStatus status,
                                                                  @Param("keyword") String keyword,
                                                                  Pageable pageable);
+
+    @Query("SELECT c FROM Content c WHERE c.tenantId = :tenantId AND c.createdBy = :createdBy " +
+           "AND c.contentType = :contentType AND LOWER(c.originalFileName) LIKE LOWER(CONCAT('%', :keyword, '%'))")
+    Page<Content> findByTenantIdAndCreatedByAndContentTypeAndKeyword(@Param("tenantId") Long tenantId,
+                                                                      @Param("createdBy") Long createdBy,
+                                                                      @Param("contentType") ContentType contentType,
+                                                                      @Param("keyword") String keyword,
+                                                                      Pageable pageable);
+
+    @Query("SELECT c FROM Content c WHERE c.tenantId = :tenantId AND c.createdBy = :createdBy " +
+           "AND c.contentType = :contentType AND c.status = :status " +
+           "AND LOWER(c.originalFileName) LIKE LOWER(CONCAT('%', :keyword, '%'))")
+    Page<Content> findByTenantIdAndCreatedByAndContentTypeAndStatusAndKeyword(@Param("tenantId") Long tenantId,
+                                                                               @Param("createdBy") Long createdBy,
+                                                                               @Param("contentType") ContentType contentType,
+                                                                               @Param("status") ContentStatus status,
+                                                                               @Param("keyword") String keyword,
+                                                                               Pageable pageable);
 }

--- a/src/main/java/com/mzc/lp/domain/content/service/ContentService.java
+++ b/src/main/java/com/mzc/lp/domain/content/service/ContentService.java
@@ -71,7 +71,7 @@ public interface ContentService {
     /**
      * 내 콘텐츠 목록 조회 (DESIGNER용)
      */
-    Page<ContentListResponse> getMyContents(Long tenantId, Long userId, ContentStatus status, String keyword, Pageable pageable);
+    Page<ContentListResponse> getMyContents(Long tenantId, Long userId, ContentType contentType, ContentStatus status, String keyword, Pageable pageable);
 
     /**
      * 콘텐츠 보관 (Archive)

--- a/src/main/java/com/mzc/lp/domain/content/service/ContentServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/content/service/ContentServiceImpl.java
@@ -138,15 +138,20 @@ public class ContentServiceImpl implements ContentService {
                                                   String keyword, Pageable pageable) {
         Page<Content> contents;
 
+        // 기본적으로 ACTIVE 상태만 조회 (ARCHIVED 콘텐츠 제외)
+        ContentStatus activeStatus = ContentStatus.ACTIVE;
+
         if (contentType != null && keyword != null && !keyword.isBlank()) {
-            contents = contentRepository.findByTenantIdAndContentTypeAndKeyword(
-                    tenantId, contentType, keyword, pageable);
+            contents = contentRepository.findByTenantIdAndStatusAndContentTypeAndKeyword(
+                    tenantId, activeStatus, contentType, keyword, pageable);
         } else if (contentType != null) {
-            contents = contentRepository.findByTenantIdAndContentType(tenantId, contentType, pageable);
+            contents = contentRepository.findByTenantIdAndStatusAndContentType(
+                    tenantId, activeStatus, contentType, pageable);
         } else if (keyword != null && !keyword.isBlank()) {
-            contents = contentRepository.findByTenantIdAndKeyword(tenantId, keyword, pageable);
+            contents = contentRepository.findByTenantIdAndStatusAndKeyword(
+                    tenantId, activeStatus, keyword, pageable);
         } else {
-            contents = contentRepository.findByTenantId(tenantId, pageable);
+            contents = contentRepository.findByTenantIdAndStatus(tenantId, activeStatus, pageable);
         }
 
         return contents.map(ContentListResponse::from);
@@ -378,6 +383,7 @@ public class ContentServiceImpl implements ContentService {
                                                     Pageable pageable) {
         Page<Content> contents;
 
+        // status가 null이면 전체 조회 (all 탭), 지정되면 해당 상태만 조회
         if (status != null && keyword != null && !keyword.isBlank()) {
             contents = contentRepository.findByTenantIdAndCreatedByAndStatusAndKeyword(
                     tenantId, userId, status, keyword, pageable);

--- a/src/main/java/com/mzc/lp/domain/content/service/ContentServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/content/service/ContentServiceImpl.java
@@ -379,18 +379,34 @@ public class ContentServiceImpl implements ContentService {
 
     @Override
     public Page<ContentListResponse> getMyContents(Long tenantId, Long userId,
-                                                    ContentStatus status, String keyword,
-                                                    Pageable pageable) {
+                                                    ContentType contentType, ContentStatus status,
+                                                    String keyword, Pageable pageable) {
         Page<Content> contents;
 
-        // status가 null이면 전체 조회 (all 탭), 지정되면 해당 상태만 조회
-        if (status != null && keyword != null && !keyword.isBlank()) {
+        boolean hasType = contentType != null;
+        boolean hasStatus = status != null;
+        boolean hasKeyword = keyword != null && !keyword.isBlank();
+
+        // 조합별 쿼리 호출
+        if (hasType && hasStatus && hasKeyword) {
+            contents = contentRepository.findByTenantIdAndCreatedByAndContentTypeAndStatusAndKeyword(
+                    tenantId, userId, contentType, status, keyword, pageable);
+        } else if (hasType && hasStatus) {
+            contents = contentRepository.findByTenantIdAndCreatedByAndContentTypeAndStatus(
+                    tenantId, userId, contentType, status, pageable);
+        } else if (hasType && hasKeyword) {
+            contents = contentRepository.findByTenantIdAndCreatedByAndContentTypeAndKeyword(
+                    tenantId, userId, contentType, keyword, pageable);
+        } else if (hasStatus && hasKeyword) {
             contents = contentRepository.findByTenantIdAndCreatedByAndStatusAndKeyword(
                     tenantId, userId, status, keyword, pageable);
-        } else if (status != null) {
+        } else if (hasType) {
+            contents = contentRepository.findByTenantIdAndCreatedByAndContentType(
+                    tenantId, userId, contentType, pageable);
+        } else if (hasStatus) {
             contents = contentRepository.findByTenantIdAndCreatedByAndStatus(
                     tenantId, userId, status, pageable);
-        } else if (keyword != null && !keyword.isBlank()) {
+        } else if (hasKeyword) {
             contents = contentRepository.findByTenantIdAndCreatedByAndKeyword(
                     tenantId, userId, keyword, pageable);
         } else {


### PR DESCRIPTION
## Summary
- 콘텐츠 목록 조회(`GET /api/contents`) API에서 ARCHIVED 상태 콘텐츠 제외
- 내 콘텐츠 목록(`GET /api/contents/my`) API에 contentType 필터 파라미터 추가

## Changes
- `ContentRepository`: status 필터링 쿼리 메서드 4개, contentType+createdBy 조합 쿼리 메서드 4개 추가
- `ContentService`: getMyContents 메서드에 contentType 파라미터 추가
- `ContentServiceImpl`: getContents는 ACTIVE만 반환, getMyContents는 8가지 필터 조합 처리
- `ContentController`: /my 엔드포인트에 contentType 파라미터 추가

## Test plan
- [x] 프론트엔드에서 콘텐츠 목록 조회 시 보관된 콘텐츠가 표시되지 않음 확인
- [x] 내 콘텐츠 페이지에서 상태 필터(전체/활성/보관) 정상 동작 확인
- [x] 내 콘텐츠 페이지에서 콘텐츠 유형 필터(동영상/오디오/문서/이미지/외부링크) 정상 동작 확인

Closes #191