### PR TITLE
feat: 통계 집계 쿼리 인프라 구축 (#194)

### DIFF
--- a/src/main/java/com/mzc/lp/common/dto/stats/BooleanCountProjection.java
+++ b/src/main/java/com/mzc/lp/common/dto/stats/BooleanCountProjection.java
@@ -1,0 +1,12 @@
+package com.mzc.lp.common.dto.stats;
+
+/**
+ * Boolean 값별 카운트 통계 Projection
+ * GROUP BY boolean_column 쿼리 결과 매핑용 (예: 무료/유료 구분)
+ */
+public interface BooleanCountProjection {
+
+    Boolean getValue();
+
+    Long getCount();
+}

--- a/src/main/java/com/mzc/lp/common/dto/stats/DailyCountProjection.java
+++ b/src/main/java/com/mzc/lp/common/dto/stats/DailyCountProjection.java
@@ -1,0 +1,14 @@
+package com.mzc.lp.common.dto.stats;
+
+import java.time.LocalDate;
+
+/**
+ * 일별 카운트 통계 Projection
+ * GROUP BY date 쿼리 결과 매핑용
+ */
+public interface DailyCountProjection {
+
+    LocalDate getDate();
+
+    Long getCount();
+}

--- a/src/main/java/com/mzc/lp/common/dto/stats/MonthlyCountProjection.java
+++ b/src/main/java/com/mzc/lp/common/dto/stats/MonthlyCountProjection.java
@@ -1,0 +1,14 @@
+package com.mzc.lp.common.dto.stats;
+
+/**
+ * 월별 카운트 통계 Projection
+ * GROUP BY year, month 쿼리 결과 매핑용
+ */
+public interface MonthlyCountProjection {
+
+    Integer getYear();
+
+    Integer getMonth();
+
+    Long getCount();
+}

--- a/src/main/java/com/mzc/lp/common/dto/stats/StatusCountProjection.java
+++ b/src/main/java/com/mzc/lp/common/dto/stats/StatusCountProjection.java
@@ -1,0 +1,12 @@
+package com.mzc.lp.common.dto.stats;
+
+/**
+ * 상태별 카운트 통계 Projection
+ * GROUP BY status 쿼리 결과 매핑용
+ */
+public interface StatusCountProjection {
+
+    String getStatus();
+
+    Long getCount();
+}

--- a/src/main/java/com/mzc/lp/common/dto/stats/TypeCountProjection.java
+++ b/src/main/java/com/mzc/lp/common/dto/stats/TypeCountProjection.java
@@ -1,0 +1,12 @@
+package com.mzc.lp.common.dto.stats;
+
+/**
+ * 타입별 카운트 통계 Projection
+ * GROUP BY type 쿼리 결과 매핑용
+ */
+public interface TypeCountProjection {
+
+    String getType();
+
+    Long getCount();
+}


### PR DESCRIPTION
## Summary

통계 API를 위한 Repository 레이어 집계 쿼리 인프라 구축. GROUP BY 쿼리 결과 매핑을 위한 Projection 인터페이스 5개와 CourseTime, Enrollment, User Repository에 통계 쿼리 23개 추가

## Related Issue

- Closes #194

## Changes

- `StatusCountProjection.java`: 상태별 카운트 Projection 인터페이스
- `TypeCountProjection.java`: 타입별 카운트 Projection 인터페이스
- `DailyCountProjection.java`: 일별 카운트 Projection 인터페이스
- `MonthlyCountProjection.java`: 월별 카운트 Projection 인터페이스
- `BooleanCountProjection.java`: Boolean 값별 카운트 Projection 인터페이스
- `CourseTimeRepository.java`: 7개 통계 쿼리 추가
- `EnrollmentRepository.java`: 11개 통계 쿼리 추가
- `UserRepository.java`: 5개 통계 쿼리 추가
- `CourseTimeRepositoryTest.java`: 10개 테스트 케이스 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Test plan

- [x] 상태별 차수 카운트 → 성공
- [x] 운영 방식별 차수 카운트 → 성공
- [x] 무료/유료 차수 카운트 → 성공
- [x] 전체 차수 카운트 → 성공
- [x] 평균 정원 활용률 → 성공
- [x] 과정별 상태별 차수 카운트 → 성공
- [x] 과정별 전체 차수 카운트 → 성공
- [x] 데이터 없을 때 빈 리스트 반환 → 성공
- [x] 데이터 없을 때 null 반환 (평균 활용률) → 성공
- [x] 전체 테스트 통과 (567 tests passed)

## Additional Notes

향후 통계 API Service/Controller 레이어에서 활용할 Repository 쿼리 인프라