### PR TITLE
feat: 수강생 학습 통계 API 추가 (#132)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/student/controller/EnrollmentController.java
+++ b/src/main/java/com/mzc/lp/domain/student/controller/EnrollmentController.java
@@ -11,6 +11,7 @@ import com.mzc.lp.domain.student.dto.response.CourseTimeEnrollmentStatsResponse;
 import com.mzc.lp.domain.student.dto.response.EnrollmentDetailResponse;
 import com.mzc.lp.domain.student.dto.response.EnrollmentResponse;
 import com.mzc.lp.domain.student.dto.response.ForceEnrollResultResponse;
+import com.mzc.lp.domain.student.dto.response.MyLearningStatsResponse;
 import com.mzc.lp.domain.student.dto.response.UserEnrollmentStatsResponse;
 import com.mzc.lp.domain.student.service.EnrollmentService;
 import com.mzc.lp.domain.student.service.EnrollmentStatsService;
@@ -199,6 +200,18 @@ public class EnrollmentController {
             @PathVariable Long userId
     ) {
         UserEnrollmentStatsResponse response = enrollmentStatsService.getUserStats(userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 내 학습 통계 조회 (마이페이지용)
+     */
+    @GetMapping("/api/users/me/learning-stats")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<MyLearningStatsResponse>> getMyLearningStats(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        MyLearningStatsResponse response = enrollmentStatsService.getMyLearningStats(principal.id());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/mzc/lp/domain/student/dto/response/MyLearningStatsResponse.java
+++ b/src/main/java/com/mzc/lp/domain/student/dto/response/MyLearningStatsResponse.java
@@ -1,0 +1,102 @@
+package com.mzc.lp.domain.student.dto.response;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * 내 학습 통계 Response (마이페이지용)
+ */
+public record MyLearningStatsResponse(
+        Overview overview,
+        Progress progress
+) {
+    /**
+     * 학습 개요 통계
+     */
+    public record Overview(
+            Long totalCourses,
+            Long inProgress,
+            Long completed,
+            Long dropped,
+            Long failed,
+            BigDecimal completionRate,
+            ByType byType
+    ) {
+        /**
+         * 수강 유형별 통계
+         */
+        public record ByType(
+                Long voluntary,
+                Long mandatory
+        ) {
+            public static ByType of(Long voluntary, Long mandatory) {
+                return new ByType(
+                        voluntary != null ? voluntary : 0L,
+                        mandatory != null ? mandatory : 0L
+                );
+            }
+        }
+
+        public static Overview of(
+                Long totalCourses,
+                Long inProgress,
+                Long completed,
+                Long dropped,
+                Long failed,
+                Long voluntary,
+                Long mandatory
+        ) {
+            BigDecimal completionRate = totalCourses > 0
+                    ? BigDecimal.valueOf(completed * 100.0 / totalCourses)
+                        .setScale(1, RoundingMode.HALF_UP)
+                    : BigDecimal.ZERO;
+
+            return new Overview(
+                    totalCourses,
+                    inProgress,
+                    completed,
+                    dropped,
+                    failed,
+                    completionRate,
+                    ByType.of(voluntary, mandatory)
+            );
+        }
+    }
+
+    /**
+     * 학습 진행 통계
+     */
+    public record Progress(
+            BigDecimal averageProgress,
+            BigDecimal averageScore
+    ) {
+        public static Progress of(Double averageProgress, Double averageScore) {
+            BigDecimal avgProgress = averageProgress != null
+                    ? BigDecimal.valueOf(averageProgress).setScale(1, RoundingMode.HALF_UP)
+                    : BigDecimal.ZERO;
+
+            BigDecimal avgScore = averageScore != null
+                    ? BigDecimal.valueOf(averageScore).setScale(1, RoundingMode.HALF_UP)
+                    : null;
+
+            return new Progress(avgProgress, avgScore);
+        }
+    }
+
+    public static MyLearningStatsResponse of(
+            Long totalCourses,
+            Long inProgress,
+            Long completed,
+            Long dropped,
+            Long failed,
+            Long voluntary,
+            Long mandatory,
+            Double averageProgress,
+            Double averageScore
+    ) {
+        return new MyLearningStatsResponse(
+                Overview.of(totalCourses, inProgress, completed, dropped, failed, voluntary, mandatory),
+                Progress.of(averageProgress, averageScore)
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/student/repository/EnrollmentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/student/repository/EnrollmentRepository.java
@@ -192,4 +192,16 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     List<StatusCountProjection> countByCourseTimeIdGroupByStatus(
             @Param("courseTimeId") Long courseTimeId,
             @Param("tenantId") Long tenantId);
+
+    /**
+     * 사용자별 수강 유형별 카운트 (VOLUNTARY/MANDATORY)
+     */
+    @Query("SELECT e.type AS type, COUNT(e) AS count " +
+            "FROM Enrollment e " +
+            "WHERE e.userId = :userId " +
+            "AND e.tenantId = :tenantId " +
+            "GROUP BY e.type")
+    List<TypeCountProjection> countByUserIdGroupByType(
+            @Param("userId") Long userId,
+            @Param("tenantId") Long tenantId);
 }

--- a/src/main/java/com/mzc/lp/domain/student/service/EnrollmentStatsService.java
+++ b/src/main/java/com/mzc/lp/domain/student/service/EnrollmentStatsService.java
@@ -1,6 +1,7 @@
 package com.mzc.lp.domain.student.service;
 
 import com.mzc.lp.domain.student.dto.response.CourseTimeEnrollmentStatsResponse;
+import com.mzc.lp.domain.student.dto.response.MyLearningStatsResponse;
 import com.mzc.lp.domain.student.dto.response.UserEnrollmentStatsResponse;
 
 /**
@@ -23,4 +24,12 @@ public interface EnrollmentStatsService {
      * @return 사용자별 수강 통계
      */
     UserEnrollmentStatsResponse getUserStats(Long userId);
+
+    /**
+     * 내 학습 통계 조회 (마이페이지용)
+     *
+     * @param userId 사용자 ID
+     * @return 내 학습 통계
+     */
+    MyLearningStatsResponse getMyLearningStats(Long userId);
 }

--- a/src/test/java/com/mzc/lp/domain/student/service/EnrollmentStatsServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/student/service/EnrollmentStatsServiceTest.java
@@ -1,0 +1,196 @@
+package com.mzc.lp.domain.student.service;
+
+import com.mzc.lp.common.dto.stats.TypeCountProjection;
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.student.constant.EnrollmentStatus;
+import com.mzc.lp.domain.student.dto.response.MyLearningStatsResponse;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class EnrollmentStatsServiceTest extends TenantTestSupport {
+
+    @InjectMocks
+    private EnrollmentStatsServiceImpl enrollmentStatsService;
+
+    @Mock
+    private EnrollmentRepository enrollmentRepository;
+
+    @Mock
+    private CourseTimeRepository courseTimeRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private static final Long TENANT_ID = 1L;
+
+    @Nested
+    @DisplayName("getMyLearningStats - 내 학습 통계 조회")
+    class GetMyLearningStats {
+
+        @Test
+        @DisplayName("성공 - 학습 통계 조회")
+        void getMyLearningStats_success() {
+            // given
+            Long userId = 1L;
+
+            given(enrollmentRepository.countByUserIdAndTenantId(userId, TENANT_ID))
+                    .willReturn(10L);
+            given(enrollmentRepository.countByUserIdAndStatusAndTenantId(userId, EnrollmentStatus.COMPLETED, TENANT_ID))
+                    .willReturn(6L);
+            given(enrollmentRepository.countByUserIdAndStatusAndTenantId(userId, EnrollmentStatus.ENROLLED, TENANT_ID))
+                    .willReturn(3L);
+            given(enrollmentRepository.countByUserIdAndStatusAndTenantId(userId, EnrollmentStatus.DROPPED, TENANT_ID))
+                    .willReturn(1L);
+            given(enrollmentRepository.countByUserIdAndStatusAndTenantId(userId, EnrollmentStatus.FAILED, TENANT_ID))
+                    .willReturn(0L);
+
+            List<TypeCountProjection> typeCounts = List.of(
+                    createTypeCountProjection("VOLUNTARY", 8L),
+                    createTypeCountProjection("MANDATORY", 2L)
+            );
+            given(enrollmentRepository.countByUserIdGroupByType(userId, TENANT_ID))
+                    .willReturn(typeCounts);
+
+            given(enrollmentRepository.findAverageProgressByUserId(userId, TENANT_ID))
+                    .willReturn(75.5);
+            given(enrollmentRepository.findAverageScoreByUserId(userId, TENANT_ID))
+                    .willReturn(85.2);
+
+            // when
+            MyLearningStatsResponse response = enrollmentStatsService.getMyLearningStats(userId);
+
+            // then
+            assertThat(response).isNotNull();
+
+            // Overview 검증
+            assertThat(response.overview().totalCourses()).isEqualTo(10L);
+            assertThat(response.overview().inProgress()).isEqualTo(3L);
+            assertThat(response.overview().completed()).isEqualTo(6L);
+            assertThat(response.overview().dropped()).isEqualTo(1L);
+            assertThat(response.overview().failed()).isEqualTo(0L);
+            assertThat(response.overview().completionRate()).isEqualTo(new BigDecimal("60.0"));
+
+            // ByType 검증
+            assertThat(response.overview().byType().voluntary()).isEqualTo(8L);
+            assertThat(response.overview().byType().mandatory()).isEqualTo(2L);
+
+            // Progress 검증
+            assertThat(response.progress().averageProgress()).isEqualTo(new BigDecimal("75.5"));
+            assertThat(response.progress().averageScore()).isEqualTo(new BigDecimal("85.2"));
+        }
+
+        @Test
+        @DisplayName("성공 - 수강 이력 없는 경우")
+        void getMyLearningStats_success_noEnrollments() {
+            // given
+            Long userId = 1L;
+
+            given(enrollmentRepository.countByUserIdAndTenantId(userId, TENANT_ID))
+                    .willReturn(0L);
+            given(enrollmentRepository.countByUserIdAndStatusAndTenantId(userId, EnrollmentStatus.COMPLETED, TENANT_ID))
+                    .willReturn(0L);
+            given(enrollmentRepository.countByUserIdAndStatusAndTenantId(userId, EnrollmentStatus.ENROLLED, TENANT_ID))
+                    .willReturn(0L);
+            given(enrollmentRepository.countByUserIdAndStatusAndTenantId(userId, EnrollmentStatus.DROPPED, TENANT_ID))
+                    .willReturn(0L);
+            given(enrollmentRepository.countByUserIdAndStatusAndTenantId(userId, EnrollmentStatus.FAILED, TENANT_ID))
+                    .willReturn(0L);
+
+            given(enrollmentRepository.countByUserIdGroupByType(userId, TENANT_ID))
+                    .willReturn(Collections.emptyList());
+
+            given(enrollmentRepository.findAverageProgressByUserId(userId, TENANT_ID))
+                    .willReturn(null);
+            given(enrollmentRepository.findAverageScoreByUserId(userId, TENANT_ID))
+                    .willReturn(null);
+
+            // when
+            MyLearningStatsResponse response = enrollmentStatsService.getMyLearningStats(userId);
+
+            // then
+            assertThat(response).isNotNull();
+
+            // Overview 검증
+            assertThat(response.overview().totalCourses()).isEqualTo(0L);
+            assertThat(response.overview().inProgress()).isEqualTo(0L);
+            assertThat(response.overview().completed()).isEqualTo(0L);
+            assertThat(response.overview().dropped()).isEqualTo(0L);
+            assertThat(response.overview().failed()).isEqualTo(0L);
+            assertThat(response.overview().completionRate()).isEqualTo(BigDecimal.ZERO);
+
+            // ByType 검증
+            assertThat(response.overview().byType().voluntary()).isEqualTo(0L);
+            assertThat(response.overview().byType().mandatory()).isEqualTo(0L);
+
+            // Progress 검증
+            assertThat(response.progress().averageProgress()).isEqualTo(BigDecimal.ZERO);
+            assertThat(response.progress().averageScore()).isNull();
+        }
+
+        @Test
+        @DisplayName("성공 - 자발적 수강만 있는 경우")
+        void getMyLearningStats_success_onlyVoluntary() {
+            // given
+            Long userId = 1L;
+
+            given(enrollmentRepository.countByUserIdAndTenantId(userId, TENANT_ID))
+                    .willReturn(5L);
+            given(enrollmentRepository.countByUserIdAndStatusAndTenantId(userId, EnrollmentStatus.COMPLETED, TENANT_ID))
+                    .willReturn(3L);
+            given(enrollmentRepository.countByUserIdAndStatusAndTenantId(userId, EnrollmentStatus.ENROLLED, TENANT_ID))
+                    .willReturn(2L);
+            given(enrollmentRepository.countByUserIdAndStatusAndTenantId(userId, EnrollmentStatus.DROPPED, TENANT_ID))
+                    .willReturn(0L);
+            given(enrollmentRepository.countByUserIdAndStatusAndTenantId(userId, EnrollmentStatus.FAILED, TENANT_ID))
+                    .willReturn(0L);
+
+            List<TypeCountProjection> typeCounts = List.of(
+                    createTypeCountProjection("VOLUNTARY", 5L)
+            );
+            given(enrollmentRepository.countByUserIdGroupByType(userId, TENANT_ID))
+                    .willReturn(typeCounts);
+
+            given(enrollmentRepository.findAverageProgressByUserId(userId, TENANT_ID))
+                    .willReturn(60.0);
+            given(enrollmentRepository.findAverageScoreByUserId(userId, TENANT_ID))
+                    .willReturn(90.0);
+
+            // when
+            MyLearningStatsResponse response = enrollmentStatsService.getMyLearningStats(userId);
+
+            // then
+            assertThat(response.overview().byType().voluntary()).isEqualTo(5L);
+            assertThat(response.overview().byType().mandatory()).isEqualTo(0L);
+        }
+    }
+
+    private TypeCountProjection createTypeCountProjection(String type, Long count) {
+        return new TypeCountProjection() {
+            @Override
+            public String getType() {
+                return type;
+            }
+
+            @Override
+            public Long getCount() {
+                return count;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

수강생 본인의 학습 통계 조회 API 구현 (마이페이지용). overview 통계(총 수강, 진행 중, 수료, 중도탈락, 미수료, 수료율, 유형별), progress 통계(평균 진도율, 평균 점수) 제공

## Related Issue

- Closes #132

## Changes

- `MyLearningStatsResponse.java`: 내 학습 통계 Response DTO (overview, progress, byType 중첩)
- `EnrollmentRepository.java`: countByUserIdGroupByType 쿼리 추가
- `EnrollmentStatsService.java`: getMyLearningStats 인터페이스 추가
- `EnrollmentStatsServiceImpl.java`: getMyLearningStats 구현
- `EnrollmentController.java`: GET /api/users/me/learning-stats 엔드포인트 추가
- `EnrollmentStatsServiceTest.java`: 신규 생성 (3개 테스트)
- `EnrollmentControllerTest.java`: 내 학습 통계 조회 테스트 추가 (3개)

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Test plan

- [x] 인증된 사용자가 내 학습 통계 조회 → 성공 (200)
- [x] 수강 이력 없는 사용자 통계 조회 → 성공 (빈 데이터)
- [x] 인증 없이 접근 → 실패 (403)
- [x] 전체 테스트 통과 (573 tests)

## Additional Notes

Phase 1 범위 구현. Phase 2 (lastAccessedAt, recentActivity)와 Phase 3 (Certificate, 월별 추이)는 별도 이슈로 분리 예정
