### PR TITLE
feat: 운영 대시보드 API 추가 (#196)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/dashboard/controller/OperatorDashboardController.java
+++ b/src/main/java/com/mzc/lp/domain/dashboard/controller/OperatorDashboardController.java
@@ -1,0 +1,27 @@
+package com.mzc.lp.domain.dashboard.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.domain.dashboard.dto.response.OperatorTasksResponse;
+import com.mzc.lp.domain.dashboard.service.OperatorDashboardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class OperatorDashboardController {
+
+    private final OperatorDashboardService operatorDashboardService;
+
+    /**
+     * OPERATOR 운영 대시보드 조회
+     */
+    @GetMapping("/api/operator/dashboard/tasks")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<OperatorTasksResponse>> getOperatorTasks() {
+        OperatorTasksResponse response = operatorDashboardService.getOperatorTasks();
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/dashboard/dto/response/OperatorTasksResponse.java
+++ b/src/main/java/com/mzc/lp/domain/dashboard/dto/response/OperatorTasksResponse.java
@@ -1,0 +1,273 @@
+package com.mzc.lp.domain.dashboard.dto.response;
+
+import com.mzc.lp.common.dto.stats.BooleanCountProjection;
+import com.mzc.lp.common.dto.stats.DailyCountProjection;
+import com.mzc.lp.common.dto.stats.StatusCountProjection;
+import com.mzc.lp.common.dto.stats.TypeCountProjection;
+import com.mzc.lp.domain.student.constant.EnrollmentStatus;
+import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+import com.mzc.lp.domain.ts.constant.DeliveryType;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * OPERATOR 운영 대시보드 Response
+ */
+public record OperatorTasksResponse(
+        PendingTasks pendingTasks,
+        CourseTimeStats courseTimeStats,
+        EnrollmentStats enrollmentStats,
+        List<DailyEnrollment> dailyTrend
+) {
+    /**
+     * 대기 중인 작업 통계
+     */
+    public record PendingTasks(
+            Long programsPendingApproval,
+            Long courseTimesNeedingInstructor
+    ) {
+        public static PendingTasks of(Long programsPendingApproval, Long courseTimesNeedingInstructor) {
+            return new PendingTasks(
+                    programsPendingApproval != null ? programsPendingApproval : 0L,
+                    courseTimesNeedingInstructor != null ? courseTimesNeedingInstructor : 0L
+            );
+        }
+    }
+
+    /**
+     * 차수 통계
+     */
+    public record CourseTimeStats(
+            ByStatus byStatus,
+            ByDeliveryType byDeliveryType,
+            FreeVsPaid freeVsPaid,
+            Long total
+    ) {
+        /**
+         * 상태별 통계
+         */
+        public record ByStatus(
+                Long draft,
+                Long recruiting,
+                Long ongoing,
+                Long closed,
+                Long archived
+        ) {
+            public static ByStatus from(List<StatusCountProjection> projections) {
+                Map<String, Long> statusMap = projections.stream()
+                        .collect(Collectors.toMap(
+                                StatusCountProjection::getStatus,
+                                StatusCountProjection::getCount
+                        ));
+
+                return new ByStatus(
+                        statusMap.getOrDefault(CourseTimeStatus.DRAFT.name(), 0L),
+                        statusMap.getOrDefault(CourseTimeStatus.RECRUITING.name(), 0L),
+                        statusMap.getOrDefault(CourseTimeStatus.ONGOING.name(), 0L),
+                        statusMap.getOrDefault(CourseTimeStatus.CLOSED.name(), 0L),
+                        statusMap.getOrDefault(CourseTimeStatus.ARCHIVED.name(), 0L)
+                );
+            }
+        }
+
+        /**
+         * 운영 방식별 통계
+         */
+        public record ByDeliveryType(
+                Long online,
+                Long offline,
+                Long blended,
+                Long live
+        ) {
+            public static ByDeliveryType from(List<TypeCountProjection> projections) {
+                Map<String, Long> typeMap = projections.stream()
+                        .collect(Collectors.toMap(
+                                TypeCountProjection::getType,
+                                TypeCountProjection::getCount
+                        ));
+
+                return new ByDeliveryType(
+                        typeMap.getOrDefault(DeliveryType.ONLINE.name(), 0L),
+                        typeMap.getOrDefault(DeliveryType.OFFLINE.name(), 0L),
+                        typeMap.getOrDefault(DeliveryType.BLENDED.name(), 0L),
+                        typeMap.getOrDefault(DeliveryType.LIVE.name(), 0L)
+                );
+            }
+        }
+
+        /**
+         * 무료/유료 통계
+         */
+        public record FreeVsPaid(
+                Long free,
+                Long paid
+        ) {
+            public static FreeVsPaid from(List<BooleanCountProjection> projections) {
+                Map<Boolean, Long> freeMap = projections.stream()
+                        .collect(Collectors.toMap(
+                                BooleanCountProjection::getValue,
+                                BooleanCountProjection::getCount
+                        ));
+
+                return new FreeVsPaid(
+                        freeMap.getOrDefault(true, 0L),
+                        freeMap.getOrDefault(false, 0L)
+                );
+            }
+        }
+
+        public static CourseTimeStats of(
+                List<StatusCountProjection> statusProjections,
+                List<TypeCountProjection> deliveryTypeProjections,
+                List<BooleanCountProjection> freeProjections,
+                Long total
+        ) {
+            return new CourseTimeStats(
+                    ByStatus.from(statusProjections),
+                    ByDeliveryType.from(deliveryTypeProjections),
+                    FreeVsPaid.from(freeProjections),
+                    total != null ? total : 0L
+            );
+        }
+    }
+
+    /**
+     * 수강 통계
+     */
+    public record EnrollmentStats(
+            Long totalEnrollments,
+            ByStatus byStatus,
+            ByType byType,
+            BigDecimal completionRate,
+            BigDecimal averageCapacityUtilization
+    ) {
+        /**
+         * 상태별 통계
+         */
+        public record ByStatus(
+                Long enrolled,
+                Long completed,
+                Long dropped,
+                Long failed
+        ) {
+            public static ByStatus from(List<StatusCountProjection> projections) {
+                Map<String, Long> statusMap = projections.stream()
+                        .collect(Collectors.toMap(
+                                StatusCountProjection::getStatus,
+                                StatusCountProjection::getCount
+                        ));
+
+                return new ByStatus(
+                        statusMap.getOrDefault(EnrollmentStatus.ENROLLED.name(), 0L),
+                        statusMap.getOrDefault(EnrollmentStatus.COMPLETED.name(), 0L),
+                        statusMap.getOrDefault(EnrollmentStatus.DROPPED.name(), 0L),
+                        statusMap.getOrDefault(EnrollmentStatus.FAILED.name(), 0L)
+                );
+            }
+        }
+
+        /**
+         * 유형별 통계
+         */
+        public record ByType(
+                Long voluntary,
+                Long mandatory
+        ) {
+            public static ByType from(List<TypeCountProjection> projections) {
+                Map<String, Long> typeMap = projections.stream()
+                        .collect(Collectors.toMap(
+                                TypeCountProjection::getType,
+                                TypeCountProjection::getCount
+                        ));
+
+                return new ByType(
+                        typeMap.getOrDefault("VOLUNTARY", 0L),
+                        typeMap.getOrDefault("MANDATORY", 0L)
+                );
+            }
+        }
+
+        public static EnrollmentStats of(
+                Long totalEnrollments,
+                List<StatusCountProjection> statusProjections,
+                List<TypeCountProjection> typeProjections,
+                Double completionRate,
+                Double averageCapacityUtilization
+        ) {
+            BigDecimal completionRateBd = completionRate != null
+                    ? BigDecimal.valueOf(completionRate).setScale(1, RoundingMode.HALF_UP)
+                    : BigDecimal.ZERO;
+
+            BigDecimal capacityUtilBd = averageCapacityUtilization != null
+                    ? BigDecimal.valueOf(averageCapacityUtilization).setScale(1, RoundingMode.HALF_UP)
+                    : BigDecimal.ZERO;
+
+            return new EnrollmentStats(
+                    totalEnrollments != null ? totalEnrollments : 0L,
+                    ByStatus.from(statusProjections),
+                    ByType.from(typeProjections),
+                    completionRateBd,
+                    capacityUtilBd
+            );
+        }
+    }
+
+    /**
+     * 일별 수강신청 추이
+     */
+    public record DailyEnrollment(
+            LocalDate date,
+            Long enrollments
+    ) {
+        public static DailyEnrollment from(DailyCountProjection projection) {
+            return new DailyEnrollment(
+                    projection.getDate(),
+                    projection.getCount() != null ? projection.getCount() : 0L
+            );
+        }
+
+        public static List<DailyEnrollment> fromList(List<DailyCountProjection> projections) {
+            return projections.stream()
+                    .map(DailyEnrollment::from)
+                    .toList();
+        }
+    }
+
+    public static OperatorTasksResponse of(
+            Long programsPendingApproval,
+            Long courseTimesNeedingInstructor,
+            List<StatusCountProjection> courseTimeStatusProjections,
+            List<TypeCountProjection> courseTimeDeliveryTypeProjections,
+            List<BooleanCountProjection> courseTimeFreeProjections,
+            Long totalCourseTimes,
+            Long totalEnrollments,
+            List<StatusCountProjection> enrollmentStatusProjections,
+            List<TypeCountProjection> enrollmentTypeProjections,
+            Double completionRate,
+            Double averageCapacityUtilization,
+            List<DailyCountProjection> dailyEnrollments
+    ) {
+        return new OperatorTasksResponse(
+                PendingTasks.of(programsPendingApproval, courseTimesNeedingInstructor),
+                CourseTimeStats.of(
+                        courseTimeStatusProjections,
+                        courseTimeDeliveryTypeProjections,
+                        courseTimeFreeProjections,
+                        totalCourseTimes
+                ),
+                EnrollmentStats.of(
+                        totalEnrollments,
+                        enrollmentStatusProjections,
+                        enrollmentTypeProjections,
+                        completionRate,
+                        averageCapacityUtilization
+                ),
+                DailyEnrollment.fromList(dailyEnrollments)
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/dashboard/service/OperatorDashboardService.java
+++ b/src/main/java/com/mzc/lp/domain/dashboard/service/OperatorDashboardService.java
@@ -1,0 +1,16 @@
+package com.mzc.lp.domain.dashboard.service;
+
+import com.mzc.lp.domain.dashboard.dto.response.OperatorTasksResponse;
+
+/**
+ * OPERATOR 운영 대시보드 서비스 인터페이스
+ */
+public interface OperatorDashboardService {
+
+    /**
+     * 운영 대시보드 통계 조회
+     *
+     * @return 운영 대시보드 통계
+     */
+    OperatorTasksResponse getOperatorTasks();
+}

--- a/src/main/java/com/mzc/lp/domain/dashboard/service/OperatorDashboardServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/dashboard/service/OperatorDashboardServiceImpl.java
@@ -1,0 +1,104 @@
+package com.mzc.lp.domain.dashboard.service;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.common.dto.stats.BooleanCountProjection;
+import com.mzc.lp.common.dto.stats.DailyCountProjection;
+import com.mzc.lp.common.dto.stats.StatusCountProjection;
+import com.mzc.lp.common.dto.stats.TypeCountProjection;
+import com.mzc.lp.domain.dashboard.dto.response.OperatorTasksResponse;
+import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.constant.InstructorRole;
+import com.mzc.lp.domain.program.repository.ProgramRepository;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OperatorDashboardServiceImpl implements OperatorDashboardService {
+
+    private final ProgramRepository programRepository;
+    private final CourseTimeRepository courseTimeRepository;
+    private final EnrollmentRepository enrollmentRepository;
+
+    private static final int DAILY_TREND_DAYS = 30;
+
+    @Override
+    public OperatorTasksResponse getOperatorTasks() {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 대기 중인 작업
+        long programsPendingApproval = programRepository.countPendingPrograms(tenantId);
+        long courseTimesNeedingInstructor = courseTimeRepository.countCourseTimesNeedingInstructor(
+                tenantId,
+                List.of(CourseTimeStatus.RECRUITING, CourseTimeStatus.ONGOING),
+                InstructorRole.MAIN,
+                AssignmentStatus.ACTIVE
+        );
+
+        // 차수 통계
+        List<StatusCountProjection> courseTimeStatusProjections =
+                courseTimeRepository.countByTenantIdGroupByStatus(tenantId);
+        List<TypeCountProjection> courseTimeDeliveryTypeProjections =
+                courseTimeRepository.countByTenantIdGroupByDeliveryType(tenantId);
+        List<BooleanCountProjection> courseTimeFreeProjections =
+                courseTimeRepository.countByTenantIdGroupByFree(tenantId);
+        long totalCourseTimes = courseTimeRepository.countByTenantId(tenantId);
+
+        // 수강 통계
+        long totalEnrollments = enrollmentRepository.countByTenantId(tenantId);
+        List<StatusCountProjection> enrollmentStatusProjections =
+                enrollmentRepository.countByTenantIdGroupByStatus(tenantId);
+        List<TypeCountProjection> enrollmentTypeProjections =
+                enrollmentRepository.countByTenantIdGroupByType(tenantId);
+        Double completionRate = enrollmentRepository.getCompletionRateByTenantId(tenantId);
+        Double averageCapacityUtilization = courseTimeRepository.getAverageCapacityUtilization(tenantId);
+
+        // 일별 수강신청 추이 (최근 30일)
+        List<DailyCountProjection> dailyEnrollments = getDailyEnrollments(tenantId);
+
+        log.debug("운영 대시보드 조회 - 테넌트 ID: {}, 승인 대기: {}, 강사 미배정: {}, 전체 차수: {}, 전체 수강: {}",
+                tenantId, programsPendingApproval, courseTimesNeedingInstructor,
+                totalCourseTimes, totalEnrollments);
+
+        return OperatorTasksResponse.of(
+                programsPendingApproval,
+                courseTimesNeedingInstructor,
+                courseTimeStatusProjections,
+                courseTimeDeliveryTypeProjections,
+                courseTimeFreeProjections,
+                totalCourseTimes,
+                totalEnrollments,
+                enrollmentStatusProjections,
+                enrollmentTypeProjections,
+                completionRate,
+                averageCapacityUtilization,
+                dailyEnrollments
+        );
+    }
+
+    private List<DailyCountProjection> getDailyEnrollments(Long tenantId) {
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = endDate.minusDays(DAILY_TREND_DAYS - 1);
+
+        Instant startInstant = startDate.atStartOfDay(ZoneId.systemDefault()).toInstant();
+        Instant endInstant = endDate.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant();
+
+        List<DailyCountProjection> dailyEnrollments =
+                enrollmentRepository.countDailyEnrollments(tenantId, startInstant, endInstant);
+
+        return dailyEnrollments != null ? dailyEnrollments : Collections.emptyList();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/student/repository/EnrollmentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/student/repository/EnrollmentRepository.java
@@ -117,13 +117,13 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     /**
      * 테넌트별 일별 수강신청 카운트 (기간 내)
      */
-    @Query("SELECT FUNCTION('DATE', e.enrolledAt) AS date, COUNT(e) AS count " +
+    @Query("SELECT CAST(e.enrolledAt AS DATE) AS date, COUNT(e) AS count " +
             "FROM Enrollment e " +
             "WHERE e.tenantId = :tenantId " +
             "AND e.enrolledAt >= :startDate " +
             "AND e.enrolledAt < :endDate " +
-            "GROUP BY FUNCTION('DATE', e.enrolledAt) " +
-            "ORDER BY FUNCTION('DATE', e.enrolledAt)")
+            "GROUP BY CAST(e.enrolledAt AS DATE) " +
+            "ORDER BY CAST(e.enrolledAt AS DATE)")
     List<DailyCountProjection> countDailyEnrollments(
             @Param("tenantId") Long tenantId,
             @Param("startDate") Instant startDate,
@@ -164,7 +164,7 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     /**
      * 테넌트별 수료율 (COMPLETED / 전체 * 100)
      */
-    @Query("SELECT COUNT(CASE WHEN e.status = 'COMPLETED' THEN 1 END) * 100.0 / COUNT(e) " +
+    @Query("SELECT COUNT(CASE WHEN e.status = 'COMPLETED' THEN 1 END) * 100.0 / NULLIF(COUNT(e), 0) " +
             "FROM Enrollment e " +
             "WHERE e.tenantId = :tenantId")
     Double getCompletionRateByTenantId(@Param("tenantId") Long tenantId);

--- a/src/test/java/com/mzc/lp/domain/dashboard/controller/OperatorDashboardControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/dashboard/controller/OperatorDashboardControllerTest.java
@@ -1,0 +1,301 @@
+package com.mzc.lp.domain.dashboard.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.iis.constant.InstructorRole;
+import com.mzc.lp.domain.iis.entity.InstructorAssignment;
+import com.mzc.lp.domain.iis.repository.InstructorAssignmentRepository;
+import com.mzc.lp.domain.program.entity.Program;
+import com.mzc.lp.domain.program.repository.ProgramRepository;
+import com.mzc.lp.domain.student.entity.Enrollment;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.ts.constant.DeliveryType;
+import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OperatorDashboardControllerTest extends TenantTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ProgramRepository programRepository;
+
+    @Autowired
+    private CourseTimeRepository courseTimeRepository;
+
+    @Autowired
+    private EnrollmentRepository enrollmentRepository;
+
+    @Autowired
+    private InstructorAssignmentRepository instructorAssignmentRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        instructorAssignmentRepository.deleteAll();
+        enrollmentRepository.deleteAll();
+        courseTimeRepository.deleteAll();
+        programRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ========== Helper Methods ==========
+
+    private User createOperatorUser() {
+        User user = User.create("operator@example.com", "운영자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.OPERATOR);
+        return userRepository.save(user);
+    }
+
+    private User createNormalUser() {
+        User user = User.create("user@example.com", "일반사용자", passwordEncoder.encode("Password123!"));
+        return userRepository.save(user);
+    }
+
+    private String loginAndGetAccessToken(String email, String password) throws Exception {
+        LoginRequest request = new LoginRequest(email, password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("data").get("accessToken").asText();
+    }
+
+    private Program createPendingProgram() {
+        Program program = Program.create("테스트 프로그램", 1L);
+        program.submit();
+        return programRepository.save(program);
+    }
+
+    private CourseTime createRecruitingCourseTime() {
+        CourseTime courseTime = CourseTime.create(
+                "모집중 차수",
+                DeliveryType.ONLINE,
+                LocalDate.now().minusDays(1),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(30),
+                30,
+                5,
+                EnrollmentMethod.FIRST_COME,
+                80,
+                new BigDecimal("100000"),
+                false,
+                null,
+                true,
+                1L
+        );
+        courseTime.open();
+        return courseTimeRepository.save(courseTime);
+    }
+
+    private CourseTime createOngoingCourseTime() {
+        CourseTime courseTime = CourseTime.create(
+                "진행중 차수",
+                DeliveryType.OFFLINE,
+                LocalDate.now().minusDays(10),
+                LocalDate.now().minusDays(1),
+                LocalDate.now().minusDays(1),
+                LocalDate.now().plusDays(30),
+                30,
+                5,
+                EnrollmentMethod.FIRST_COME,
+                80,
+                BigDecimal.ZERO,
+                true,
+                "{\"address\": \"서울시\"}",
+                true,
+                1L
+        );
+        courseTime.open();
+        courseTime.startClass();
+        return courseTimeRepository.save(courseTime);
+    }
+
+    private CourseTime createDraftCourseTime() {
+        CourseTime courseTime = CourseTime.create(
+                "Draft 차수",
+                DeliveryType.BLENDED,
+                LocalDate.now(),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(30),
+                30,
+                5,
+                EnrollmentMethod.FIRST_COME,
+                80,
+                new BigDecimal("50000"),
+                false,
+                null,
+                true,
+                1L
+        );
+        return courseTimeRepository.save(courseTime);
+    }
+
+    private InstructorAssignment createInstructorAssignment(Long courseTimeId, Long userId) {
+        InstructorAssignment assignment = InstructorAssignment.create(
+                userId,
+                courseTimeId,
+                InstructorRole.MAIN,
+                userId
+        );
+        return instructorAssignmentRepository.save(assignment);
+    }
+
+    private Enrollment createEnrollment(Long userId, Long courseTimeId) {
+        Enrollment enrollment = Enrollment.createVoluntary(userId, courseTimeId);
+        return enrollmentRepository.save(enrollment);
+    }
+
+    // ==================== 운영 대시보드 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/operator/dashboard/tasks - 운영 대시보드 조회")
+    class GetOperatorTasks {
+
+        @Test
+        @DisplayName("성공 - 운영 대시보드 전체 통계 조회")
+        void getOperatorTasks_success() throws Exception {
+            // given
+            User operator = createOperatorUser();
+            User user = createNormalUser();
+
+            // 승인 대기 프로그램 생성
+            createPendingProgram();
+            createPendingProgram();
+
+            // 차수 생성 (강사 미배정 포함)
+            CourseTime recruiting1 = createRecruitingCourseTime();
+            CourseTime recruiting2 = createRecruitingCourseTime();
+            createOngoingCourseTime();
+            createDraftCourseTime();
+
+            // recruiting1에만 강사 배정 (recruiting2, ongoing은 강사 미배정)
+            createInstructorAssignment(recruiting1.getId(), operator.getId());
+
+            // 수강 생성
+            createEnrollment(user.getId(), recruiting1.getId());
+            Enrollment completedEnrollment = createEnrollment(user.getId(), recruiting2.getId());
+            completedEnrollment.complete(90);
+            enrollmentRepository.save(completedEnrollment);
+
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/operator/dashboard/tasks")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    // PendingTasks
+                    .andExpect(jsonPath("$.data.pendingTasks.programsPendingApproval").value(2))
+                    .andExpect(jsonPath("$.data.pendingTasks.courseTimesNeedingInstructor").value(2))
+                    // CourseTimeStats
+                    .andExpect(jsonPath("$.data.courseTimeStats.total").value(4))
+                    .andExpect(jsonPath("$.data.courseTimeStats.byStatus.draft").value(1))
+                    .andExpect(jsonPath("$.data.courseTimeStats.byStatus.recruiting").value(2))
+                    .andExpect(jsonPath("$.data.courseTimeStats.byStatus.ongoing").value(1))
+                    .andExpect(jsonPath("$.data.courseTimeStats.byDeliveryType.online").value(2))
+                    .andExpect(jsonPath("$.data.courseTimeStats.byDeliveryType.offline").value(1))
+                    .andExpect(jsonPath("$.data.courseTimeStats.byDeliveryType.blended").value(1))
+                    .andExpect(jsonPath("$.data.courseTimeStats.freeVsPaid.free").value(1))
+                    .andExpect(jsonPath("$.data.courseTimeStats.freeVsPaid.paid").value(3))
+                    // EnrollmentStats
+                    .andExpect(jsonPath("$.data.enrollmentStats.totalEnrollments").value(2))
+                    .andExpect(jsonPath("$.data.enrollmentStats.byStatus.enrolled").value(1))
+                    .andExpect(jsonPath("$.data.enrollmentStats.byStatus.completed").value(1))
+                    .andExpect(jsonPath("$.data.enrollmentStats.byType.voluntary").value(2))
+                    .andExpect(jsonPath("$.data.enrollmentStats.byType.mandatory").value(0))
+                    // DailyTrend
+                    .andExpect(jsonPath("$.data.dailyTrend").isArray());
+        }
+
+        @Test
+        @DisplayName("성공 - 데이터 없는 경우")
+        void getOperatorTasks_success_noData() throws Exception {
+            // given
+            createOperatorUser();
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            MvcResult result = mockMvc.perform(get("/api/operator/dashboard/tasks")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andReturn();
+
+            System.out.println("Response Body: " + result.getResponse().getContentAsString());
+            System.out.println("Status: " + result.getResponse().getStatus());
+
+            assertThat(result.getResponse().getStatus()).isEqualTo(200);
+        }
+
+        @Test
+        @DisplayName("실패 - 일반 사용자 접근 불가")
+        void getOperatorTasks_fail_unauthorized() throws Exception {
+            // given
+            createNormalUser();
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/operator/dashboard/tasks")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("실패 - 인증 없이 접근")
+        void getOperatorTasks_fail_noAuth() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/operator/dashboard/tasks"))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/dashboard/service/OperatorDashboardServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/dashboard/service/OperatorDashboardServiceTest.java
@@ -1,0 +1,335 @@
+package com.mzc.lp.domain.dashboard.service;
+
+import com.mzc.lp.common.dto.stats.BooleanCountProjection;
+import com.mzc.lp.common.dto.stats.DailyCountProjection;
+import com.mzc.lp.common.dto.stats.StatusCountProjection;
+import com.mzc.lp.common.dto.stats.TypeCountProjection;
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.dashboard.dto.response.OperatorTasksResponse;
+import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.constant.InstructorRole;
+import com.mzc.lp.domain.program.repository.ProgramRepository;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class OperatorDashboardServiceTest extends TenantTestSupport {
+
+    @InjectMocks
+    private OperatorDashboardServiceImpl operatorDashboardService;
+
+    @Mock
+    private ProgramRepository programRepository;
+
+    @Mock
+    private CourseTimeRepository courseTimeRepository;
+
+    @Mock
+    private EnrollmentRepository enrollmentRepository;
+
+    private static final Long TENANT_ID = 1L;
+
+    @Nested
+    @DisplayName("getOperatorTasks - 운영 대시보드 조회")
+    class GetOperatorTasks {
+
+        @Test
+        @DisplayName("성공 - 전체 통계 조회")
+        void getOperatorTasks_success() {
+            // given
+            given(programRepository.countPendingPrograms(TENANT_ID))
+                    .willReturn(5L);
+            given(courseTimeRepository.countCourseTimesNeedingInstructor(
+                    eq(TENANT_ID), anyList(), any(InstructorRole.class), any(AssignmentStatus.class)))
+                    .willReturn(3L);
+
+            given(courseTimeRepository.countByTenantIdGroupByStatus(TENANT_ID))
+                    .willReturn(List.of(
+                            createStatusCountProjection("DRAFT", 5L),
+                            createStatusCountProjection("RECRUITING", 10L),
+                            createStatusCountProjection("ONGOING", 15L),
+                            createStatusCountProjection("CLOSED", 20L),
+                            createStatusCountProjection("ARCHIVED", 5L)
+                    ));
+            given(courseTimeRepository.countByTenantIdGroupByDeliveryType(TENANT_ID))
+                    .willReturn(List.of(
+                            createTypeCountProjection("ONLINE", 20L),
+                            createTypeCountProjection("OFFLINE", 15L),
+                            createTypeCountProjection("BLENDED", 10L),
+                            createTypeCountProjection("LIVE", 10L)
+                    ));
+            given(courseTimeRepository.countByTenantIdGroupByFree(TENANT_ID))
+                    .willReturn(List.of(
+                            createBooleanCountProjection(true, 15L),
+                            createBooleanCountProjection(false, 40L)
+                    ));
+            given(courseTimeRepository.countByTenantId(TENANT_ID))
+                    .willReturn(55L);
+
+            given(enrollmentRepository.countByTenantId(TENANT_ID))
+                    .willReturn(1000L);
+            given(enrollmentRepository.countByTenantIdGroupByStatus(TENANT_ID))
+                    .willReturn(List.of(
+                            createStatusCountProjection("ENROLLED", 400L),
+                            createStatusCountProjection("COMPLETED", 500L),
+                            createStatusCountProjection("DROPPED", 50L),
+                            createStatusCountProjection("FAILED", 50L)
+                    ));
+            given(enrollmentRepository.countByTenantIdGroupByType(TENANT_ID))
+                    .willReturn(List.of(
+                            createTypeCountProjection("VOLUNTARY", 800L),
+                            createTypeCountProjection("MANDATORY", 200L)
+                    ));
+            given(enrollmentRepository.getCompletionRateByTenantId(TENANT_ID))
+                    .willReturn(50.0);
+            given(courseTimeRepository.getAverageCapacityUtilization(TENANT_ID))
+                    .willReturn(75.5);
+            given(enrollmentRepository.countDailyEnrollments(eq(TENANT_ID), any(Instant.class), any(Instant.class)))
+                    .willReturn(List.of(
+                            createDailyCountProjection(LocalDate.now().minusDays(1), 12L),
+                            createDailyCountProjection(LocalDate.now(), 15L)
+                    ));
+
+            // when
+            OperatorTasksResponse response = operatorDashboardService.getOperatorTasks();
+
+            // then
+            assertThat(response).isNotNull();
+
+            // PendingTasks 검증
+            assertThat(response.pendingTasks().programsPendingApproval()).isEqualTo(5L);
+            assertThat(response.pendingTasks().courseTimesNeedingInstructor()).isEqualTo(3L);
+
+            // CourseTimeStats 검증
+            assertThat(response.courseTimeStats().total()).isEqualTo(55L);
+            assertThat(response.courseTimeStats().byStatus().draft()).isEqualTo(5L);
+            assertThat(response.courseTimeStats().byStatus().recruiting()).isEqualTo(10L);
+            assertThat(response.courseTimeStats().byStatus().ongoing()).isEqualTo(15L);
+            assertThat(response.courseTimeStats().byStatus().closed()).isEqualTo(20L);
+            assertThat(response.courseTimeStats().byStatus().archived()).isEqualTo(5L);
+            assertThat(response.courseTimeStats().byDeliveryType().online()).isEqualTo(20L);
+            assertThat(response.courseTimeStats().byDeliveryType().offline()).isEqualTo(15L);
+            assertThat(response.courseTimeStats().byDeliveryType().blended()).isEqualTo(10L);
+            assertThat(response.courseTimeStats().byDeliveryType().live()).isEqualTo(10L);
+            assertThat(response.courseTimeStats().freeVsPaid().free()).isEqualTo(15L);
+            assertThat(response.courseTimeStats().freeVsPaid().paid()).isEqualTo(40L);
+
+            // EnrollmentStats 검증
+            assertThat(response.enrollmentStats().totalEnrollments()).isEqualTo(1000L);
+            assertThat(response.enrollmentStats().byStatus().enrolled()).isEqualTo(400L);
+            assertThat(response.enrollmentStats().byStatus().completed()).isEqualTo(500L);
+            assertThat(response.enrollmentStats().byStatus().dropped()).isEqualTo(50L);
+            assertThat(response.enrollmentStats().byStatus().failed()).isEqualTo(50L);
+            assertThat(response.enrollmentStats().byType().voluntary()).isEqualTo(800L);
+            assertThat(response.enrollmentStats().byType().mandatory()).isEqualTo(200L);
+            assertThat(response.enrollmentStats().completionRate()).isEqualTo(new BigDecimal("50.0"));
+            assertThat(response.enrollmentStats().averageCapacityUtilization()).isEqualTo(new BigDecimal("75.5"));
+
+            // DailyTrend 검증
+            assertThat(response.dailyTrend()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("성공 - 데이터 없는 경우")
+        void getOperatorTasks_success_noData() {
+            // given
+            given(programRepository.countPendingPrograms(TENANT_ID))
+                    .willReturn(0L);
+            given(courseTimeRepository.countCourseTimesNeedingInstructor(
+                    eq(TENANT_ID), anyList(), any(InstructorRole.class), any(AssignmentStatus.class)))
+                    .willReturn(0L);
+            given(courseTimeRepository.countByTenantIdGroupByStatus(TENANT_ID))
+                    .willReturn(Collections.emptyList());
+            given(courseTimeRepository.countByTenantIdGroupByDeliveryType(TENANT_ID))
+                    .willReturn(Collections.emptyList());
+            given(courseTimeRepository.countByTenantIdGroupByFree(TENANT_ID))
+                    .willReturn(Collections.emptyList());
+            given(courseTimeRepository.countByTenantId(TENANT_ID))
+                    .willReturn(0L);
+            given(enrollmentRepository.countByTenantId(TENANT_ID))
+                    .willReturn(0L);
+            given(enrollmentRepository.countByTenantIdGroupByStatus(TENANT_ID))
+                    .willReturn(Collections.emptyList());
+            given(enrollmentRepository.countByTenantIdGroupByType(TENANT_ID))
+                    .willReturn(Collections.emptyList());
+            given(enrollmentRepository.getCompletionRateByTenantId(TENANT_ID))
+                    .willReturn(null);
+            given(courseTimeRepository.getAverageCapacityUtilization(TENANT_ID))
+                    .willReturn(null);
+            given(enrollmentRepository.countDailyEnrollments(eq(TENANT_ID), any(Instant.class), any(Instant.class)))
+                    .willReturn(Collections.emptyList());
+
+            // when
+            OperatorTasksResponse response = operatorDashboardService.getOperatorTasks();
+
+            // then
+            assertThat(response).isNotNull();
+
+            // PendingTasks 검증
+            assertThat(response.pendingTasks().programsPendingApproval()).isEqualTo(0L);
+            assertThat(response.pendingTasks().courseTimesNeedingInstructor()).isEqualTo(0L);
+
+            // CourseTimeStats 검증
+            assertThat(response.courseTimeStats().total()).isEqualTo(0L);
+            assertThat(response.courseTimeStats().byStatus().draft()).isEqualTo(0L);
+            assertThat(response.courseTimeStats().byDeliveryType().online()).isEqualTo(0L);
+            assertThat(response.courseTimeStats().freeVsPaid().free()).isEqualTo(0L);
+
+            // EnrollmentStats 검증
+            assertThat(response.enrollmentStats().totalEnrollments()).isEqualTo(0L);
+            assertThat(response.enrollmentStats().completionRate()).isEqualTo(BigDecimal.ZERO);
+            assertThat(response.enrollmentStats().averageCapacityUtilization()).isEqualTo(BigDecimal.ZERO);
+
+            // DailyTrend 검증
+            assertThat(response.dailyTrend()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("성공 - 일부 상태만 존재하는 경우")
+        void getOperatorTasks_success_partialData() {
+            // given
+            given(programRepository.countPendingPrograms(TENANT_ID))
+                    .willReturn(2L);
+            given(courseTimeRepository.countCourseTimesNeedingInstructor(
+                    eq(TENANT_ID), anyList(), any(InstructorRole.class), any(AssignmentStatus.class)))
+                    .willReturn(1L);
+            given(courseTimeRepository.countByTenantIdGroupByStatus(TENANT_ID))
+                    .willReturn(List.of(
+                            createStatusCountProjection("RECRUITING", 5L),
+                            createStatusCountProjection("ONGOING", 3L)
+                    ));
+            given(courseTimeRepository.countByTenantIdGroupByDeliveryType(TENANT_ID))
+                    .willReturn(List.of(
+                            createTypeCountProjection("ONLINE", 8L)
+                    ));
+            given(courseTimeRepository.countByTenantIdGroupByFree(TENANT_ID))
+                    .willReturn(List.of(
+                            createBooleanCountProjection(true, 8L)
+                    ));
+            given(courseTimeRepository.countByTenantId(TENANT_ID))
+                    .willReturn(8L);
+            given(enrollmentRepository.countByTenantId(TENANT_ID))
+                    .willReturn(100L);
+            given(enrollmentRepository.countByTenantIdGroupByStatus(TENANT_ID))
+                    .willReturn(List.of(
+                            createStatusCountProjection("ENROLLED", 80L),
+                            createStatusCountProjection("COMPLETED", 20L)
+                    ));
+            given(enrollmentRepository.countByTenantIdGroupByType(TENANT_ID))
+                    .willReturn(List.of(
+                            createTypeCountProjection("VOLUNTARY", 100L)
+                    ));
+            given(enrollmentRepository.getCompletionRateByTenantId(TENANT_ID))
+                    .willReturn(20.0);
+            given(courseTimeRepository.getAverageCapacityUtilization(TENANT_ID))
+                    .willReturn(60.0);
+            given(enrollmentRepository.countDailyEnrollments(eq(TENANT_ID), any(Instant.class), any(Instant.class)))
+                    .willReturn(List.of(
+                            createDailyCountProjection(LocalDate.now(), 5L)
+                    ));
+
+            // when
+            OperatorTasksResponse response = operatorDashboardService.getOperatorTasks();
+
+            // then
+            assertThat(response).isNotNull();
+
+            // CourseTimeStats - 없는 상태는 0
+            assertThat(response.courseTimeStats().byStatus().draft()).isEqualTo(0L);
+            assertThat(response.courseTimeStats().byStatus().recruiting()).isEqualTo(5L);
+            assertThat(response.courseTimeStats().byStatus().ongoing()).isEqualTo(3L);
+            assertThat(response.courseTimeStats().byStatus().closed()).isEqualTo(0L);
+            assertThat(response.courseTimeStats().byStatus().archived()).isEqualTo(0L);
+
+            // ByDeliveryType - 없는 타입은 0
+            assertThat(response.courseTimeStats().byDeliveryType().online()).isEqualTo(8L);
+            assertThat(response.courseTimeStats().byDeliveryType().offline()).isEqualTo(0L);
+            assertThat(response.courseTimeStats().byDeliveryType().blended()).isEqualTo(0L);
+            assertThat(response.courseTimeStats().byDeliveryType().live()).isEqualTo(0L);
+
+            // FreeVsPaid - 유료 없음
+            assertThat(response.courseTimeStats().freeVsPaid().free()).isEqualTo(8L);
+            assertThat(response.courseTimeStats().freeVsPaid().paid()).isEqualTo(0L);
+
+            // EnrollmentStats - 없는 상태는 0
+            assertThat(response.enrollmentStats().byStatus().dropped()).isEqualTo(0L);
+            assertThat(response.enrollmentStats().byStatus().failed()).isEqualTo(0L);
+            assertThat(response.enrollmentStats().byType().mandatory()).isEqualTo(0L);
+        }
+    }
+
+    private StatusCountProjection createStatusCountProjection(String status, Long count) {
+        return new StatusCountProjection() {
+            @Override
+            public String getStatus() {
+                return status;
+            }
+
+            @Override
+            public Long getCount() {
+                return count;
+            }
+        };
+    }
+
+    private TypeCountProjection createTypeCountProjection(String type, Long count) {
+        return new TypeCountProjection() {
+            @Override
+            public String getType() {
+                return type;
+            }
+
+            @Override
+            public Long getCount() {
+                return count;
+            }
+        };
+    }
+
+    private BooleanCountProjection createBooleanCountProjection(Boolean value, Long count) {
+        return new BooleanCountProjection() {
+            @Override
+            public Boolean getValue() {
+                return value;
+            }
+
+            @Override
+            public Long getCount() {
+                return count;
+            }
+        };
+    }
+
+    private DailyCountProjection createDailyCountProjection(LocalDate date, Long count) {
+        return new DailyCountProjection() {
+            @Override
+            public LocalDate getDate() {
+                return date;
+            }
+
+            @Override
+            public Long getCount() {
+                return count;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

운영자 대시보드 통계 API 구현. pendingTasks(승인 대기 프로그램, 강사 미배정 차수), courseTimeStats(상태별, 운영방식별, 유무료별), enrollmentStats(상태별, 유형별, 수료율, 정원활용률), dailyTrend(최근 30일 수강신청 추이) 제공

## Related Issue

- Closes #196

## Changes

- `OperatorTasksResponse.java`: 운영 대시보드 Response DTO (pendingTasks, courseTimeStats, enrollmentStats, dailyTrend 중첩)
- `CourseTimeRepository.java`: countCourseTimesNeedingInstructor 쿼리 추가
- `EnrollmentRepository.java`: countDailyEnrollments CAST 함수 수정, getCompletionRateByTenantId NULLIF 적용
- `OperatorDashboardService.java`: 인터페이스 생성
- `OperatorDashboardServiceImpl.java`: 서비스 구현체 생성
- `OperatorDashboardController.java`: GET /api/operator/dashboard/tasks 엔드포인트 추가
- `OperatorDashboardServiceTest.java`: 신규 생성 (3개 테스트)
- `OperatorDashboardControllerTest.java`: 신규 생성 (4개 테스트)

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Test plan

- [x] OPERATOR 권한으로 대시보드 조회 → 성공 (200)
- [x] 데이터 없는 경우 조회 → 성공 (빈 데이터)
- [x] 일반 사용자 접근 → 실패 (403)
- [x] 인증 없이 접근 → 실패 (403)
- [x] 전체 테스트 통과
