### PR TITLE
feat: OWNER 내 강의 통계 API 추가 (#197)

### DIFF
--- a/src/main/java/com/mzc/lp/common/dto/stats/ProgramStatsProjection.java
+++ b/src/main/java/com/mzc/lp/common/dto/stats/ProgramStatsProjection.java
@@ -1,0 +1,18 @@
+package com.mzc.lp.common.dto.stats;
+
+/**
+ * 프로그램별 통계 Projection
+ * OWNER 통계에서 프로그램별 차수 수, 수강생 수, 수료율 조회용
+ */
+public interface ProgramStatsProjection {
+
+    Long getProgramId();
+
+    String getTitle();
+
+    Long getCourseTimeCount();
+
+    Long getTotalStudents();
+
+    Double getCompletionRate();
+}

--- a/src/main/java/com/mzc/lp/domain/dashboard/controller/OwnerStatsController.java
+++ b/src/main/java/com/mzc/lp/domain/dashboard/controller/OwnerStatsController.java
@@ -1,0 +1,34 @@
+package com.mzc.lp.domain.dashboard.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.dashboard.dto.response.OwnerStatsResponse;
+import com.mzc.lp.domain.dashboard.service.OwnerStatsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/owners/me")
+@RequiredArgsConstructor
+public class OwnerStatsController {
+
+    private final OwnerStatsService ownerStatsService;
+
+    /**
+     * OWNER 내 강의 통계 조회
+     * - OWNER 역할이 있거나, OPERATOR/TENANT_ADMIN 권한이 있으면 접근 가능
+     */
+    @GetMapping("/stats")
+    @PreAuthorize("hasRole('OWNER') or hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<OwnerStatsResponse>> getMyStats(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        OwnerStatsResponse response = ownerStatsService.getMyStats(principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/dashboard/dto/response/OwnerStatsResponse.java
+++ b/src/main/java/com/mzc/lp/domain/dashboard/dto/response/OwnerStatsResponse.java
@@ -1,0 +1,133 @@
+package com.mzc.lp.domain.dashboard.dto.response;
+
+import com.mzc.lp.common.dto.stats.StatusCountProjection;
+import com.mzc.lp.domain.student.constant.EnrollmentStatus;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * OWNER 내 강의 통계 Response
+ */
+public record OwnerStatsResponse(
+        Overview overview,
+        EnrollmentStats enrollmentStats,
+        List<ProgramStat> programStats
+) {
+    /**
+     * 전체 개요
+     */
+    public record Overview(
+            Long totalPrograms,
+            Long totalCourseTimes,
+            Long totalStudents
+    ) {
+        public static Overview of(Long totalPrograms, Long totalCourseTimes, Long totalStudents) {
+            return new Overview(
+                    totalPrograms != null ? totalPrograms : 0L,
+                    totalCourseTimes != null ? totalCourseTimes : 0L,
+                    totalStudents != null ? totalStudents : 0L
+            );
+        }
+    }
+
+    /**
+     * 수강 통계
+     */
+    public record EnrollmentStats(
+            Long totalEnrollments,
+            ByStatus byStatus,
+            BigDecimal completionRate
+    ) {
+        /**
+         * 상태별 통계
+         */
+        public record ByStatus(
+                Long enrolled,
+                Long completed,
+                Long dropped,
+                Long failed
+        ) {
+            public static ByStatus from(List<StatusCountProjection> projections) {
+                Map<String, Long> statusMap = projections.stream()
+                        .collect(Collectors.toMap(
+                                StatusCountProjection::getStatus,
+                                StatusCountProjection::getCount
+                        ));
+
+                return new ByStatus(
+                        statusMap.getOrDefault(EnrollmentStatus.ENROLLED.name(), 0L),
+                        statusMap.getOrDefault(EnrollmentStatus.COMPLETED.name(), 0L),
+                        statusMap.getOrDefault(EnrollmentStatus.DROPPED.name(), 0L),
+                        statusMap.getOrDefault(EnrollmentStatus.FAILED.name(), 0L)
+                );
+            }
+        }
+
+        public static EnrollmentStats of(
+                Long totalEnrollments,
+                List<StatusCountProjection> statusProjections,
+                Double completionRate
+        ) {
+            BigDecimal completionRateBd = completionRate != null
+                    ? BigDecimal.valueOf(completionRate).setScale(1, RoundingMode.HALF_UP)
+                    : BigDecimal.ZERO;
+
+            return new EnrollmentStats(
+                    totalEnrollments != null ? totalEnrollments : 0L,
+                    ByStatus.from(statusProjections),
+                    completionRateBd
+            );
+        }
+    }
+
+    /**
+     * 프로그램별 통계
+     */
+    public record ProgramStat(
+            Long programId,
+            String title,
+            Long courseTimeCount,
+            Long totalStudents,
+            BigDecimal completionRate
+    ) {
+        public static ProgramStat of(
+                Long programId,
+                String title,
+                Long courseTimeCount,
+                Long totalStudents,
+                Double completionRate
+        ) {
+            BigDecimal completionRateBd = completionRate != null
+                    ? BigDecimal.valueOf(completionRate).setScale(1, RoundingMode.HALF_UP)
+                    : BigDecimal.ZERO;
+
+            return new ProgramStat(
+                    programId,
+                    title,
+                    courseTimeCount != null ? courseTimeCount : 0L,
+                    totalStudents != null ? totalStudents : 0L,
+                    completionRateBd
+            );
+        }
+    }
+
+    public static OwnerStatsResponse of(
+            Long totalPrograms,
+            Long totalCourseTimes,
+            Long totalStudents,
+            Long totalEnrollments,
+            List<StatusCountProjection> enrollmentStatusProjections,
+            Double completionRate,
+            List<ProgramStat> programStats
+    ) {
+        return new OwnerStatsResponse(
+                Overview.of(totalPrograms, totalCourseTimes, totalStudents),
+                EnrollmentStats.of(totalEnrollments, enrollmentStatusProjections, completionRate),
+                programStats
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/dashboard/service/OwnerStatsService.java
+++ b/src/main/java/com/mzc/lp/domain/dashboard/service/OwnerStatsService.java
@@ -1,0 +1,17 @@
+package com.mzc.lp.domain.dashboard.service;
+
+import com.mzc.lp.domain.dashboard.dto.response.OwnerStatsResponse;
+
+/**
+ * OWNER 내 강의 통계 서비스 인터페이스
+ */
+public interface OwnerStatsService {
+
+    /**
+     * 내 강의 통계 조회
+     *
+     * @param userId 사용자 ID
+     * @return 내 강의 통계
+     */
+    OwnerStatsResponse getMyStats(Long userId);
+}

--- a/src/main/java/com/mzc/lp/domain/dashboard/service/OwnerStatsServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/dashboard/service/OwnerStatsServiceImpl.java
@@ -1,0 +1,95 @@
+package com.mzc.lp.domain.dashboard.service;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.common.dto.stats.ProgramStatsProjection;
+import com.mzc.lp.common.dto.stats.StatusCountProjection;
+import com.mzc.lp.domain.dashboard.dto.response.OwnerStatsResponse;
+import com.mzc.lp.domain.program.repository.ProgramRepository;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OwnerStatsServiceImpl implements OwnerStatsService {
+
+    private final ProgramRepository programRepository;
+    private final CourseTimeRepository courseTimeRepository;
+    private final EnrollmentRepository enrollmentRepository;
+
+    @Override
+    public OwnerStatsResponse getMyStats(Long userId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 소유 프로그램 ID 목록 조회
+        List<Long> programIds = programRepository.findIdsByCreatedByAndTenantId(userId, tenantId);
+
+        if (programIds.isEmpty()) {
+            log.debug("OWNER 통계 조회 - 사용자 ID: {}, 소유 프로그램 없음", userId);
+            return createEmptyResponse();
+        }
+
+        // 차수 ID 목록 조회
+        List<Long> courseTimeIds = courseTimeRepository.findIdsByProgramIdInAndTenantId(programIds, tenantId);
+
+        // 전체 개요
+        long totalPrograms = programIds.size();
+        long totalCourseTimes = courseTimeIds.size();
+        long totalStudents = courseTimeIds.isEmpty() ? 0L :
+                enrollmentRepository.countByCourseTimeIdInAndTenantId(courseTimeIds, tenantId);
+
+        // 수강 통계
+        long totalEnrollments = totalStudents;
+        List<StatusCountProjection> enrollmentStatusProjections = courseTimeIds.isEmpty() ?
+                Collections.emptyList() :
+                enrollmentRepository.countByCourseTimeIdInGroupByStatus(courseTimeIds, tenantId);
+        Double completionRate = courseTimeIds.isEmpty() ? null :
+                enrollmentRepository.getCompletionRateByCourseTimeIds(courseTimeIds, tenantId);
+
+        // 프로그램별 통계
+        List<ProgramStatsProjection> programStatsProjections =
+                programRepository.findProgramStatsByOwner(userId, tenantId);
+        List<OwnerStatsResponse.ProgramStat> programStats = programStatsProjections.stream()
+                .map(p -> OwnerStatsResponse.ProgramStat.of(
+                        p.getProgramId(),
+                        p.getTitle(),
+                        p.getCourseTimeCount(),
+                        p.getTotalStudents(),
+                        p.getCompletionRate()
+                ))
+                .toList();
+
+        log.debug("OWNER 통계 조회 - 사용자 ID: {}, 전체 프로그램: {}, 전체 차수: {}, 전체 수강생: {}",
+                userId, totalPrograms, totalCourseTimes, totalStudents);
+
+        return OwnerStatsResponse.of(
+                totalPrograms,
+                totalCourseTimes,
+                totalStudents,
+                totalEnrollments,
+                enrollmentStatusProjections,
+                completionRate,
+                programStats
+        );
+    }
+
+    private OwnerStatsResponse createEmptyResponse() {
+        return OwnerStatsResponse.of(
+                0L,
+                0L,
+                0L,
+                0L,
+                Collections.emptyList(),
+                null,
+                Collections.emptyList()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/student/repository/EnrollmentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/student/repository/EnrollmentRepository.java
@@ -222,4 +222,39 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
             @Param("tenantId") Long tenantId,
             @Param("startDate") Instant startDate,
             @Param("endDate") Instant endDate);
+
+    // ===== OWNER 통계 쿼리 =====
+
+    /**
+     * 차수 ID 목록에 속한 수강 카운트
+     */
+    @Query("SELECT COUNT(e) FROM Enrollment e " +
+            "WHERE e.courseTimeId IN :courseTimeIds " +
+            "AND e.tenantId = :tenantId")
+    long countByCourseTimeIdInAndTenantId(
+            @Param("courseTimeIds") List<Long> courseTimeIds,
+            @Param("tenantId") Long tenantId);
+
+    /**
+     * 차수 ID 목록에 속한 상태별 수강 카운트
+     */
+    @Query("SELECT e.status AS status, COUNT(e) AS count " +
+            "FROM Enrollment e " +
+            "WHERE e.courseTimeId IN :courseTimeIds " +
+            "AND e.tenantId = :tenantId " +
+            "GROUP BY e.status")
+    List<StatusCountProjection> countByCourseTimeIdInGroupByStatus(
+            @Param("courseTimeIds") List<Long> courseTimeIds,
+            @Param("tenantId") Long tenantId);
+
+    /**
+     * 차수 ID 목록에 속한 수료율
+     */
+    @Query("SELECT COUNT(CASE WHEN e.status = 'COMPLETED' THEN 1 END) * 100.0 / NULLIF(COUNT(e), 0) " +
+            "FROM Enrollment e " +
+            "WHERE e.courseTimeId IN :courseTimeIds " +
+            "AND e.tenantId = :tenantId")
+    Double getCompletionRateByCourseTimeIds(
+            @Param("courseTimeIds") List<Long> courseTimeIds,
+            @Param("tenantId") Long tenantId);
 }

--- a/src/main/java/com/mzc/lp/domain/ts/repository/CourseTimeRepository.java
+++ b/src/main/java/com/mzc/lp/domain/ts/repository/CourseTimeRepository.java
@@ -171,4 +171,16 @@ public interface CourseTimeRepository extends JpaRepository<CourseTime, Long> {
             @Param("statuses") List<CourseTimeStatus> statuses,
             @Param("role") InstructorRole role,
             @Param("assignmentStatus") AssignmentStatus assignmentStatus);
+
+    // ===== OWNER 통계 쿼리 =====
+
+    /**
+     * 프로그램 ID 목록에 속한 차수 ID 목록 조회
+     */
+    @Query("SELECT ct.id FROM CourseTime ct " +
+            "WHERE ct.program.id IN :programIds " +
+            "AND ct.tenantId = :tenantId")
+    List<Long> findIdsByProgramIdInAndTenantId(
+            @Param("programIds") List<Long> programIds,
+            @Param("tenantId") Long tenantId);
 }

--- a/src/test/java/com/mzc/lp/domain/dashboard/controller/OwnerStatsControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/dashboard/controller/OwnerStatsControllerTest.java
@@ -1,0 +1,303 @@
+package com.mzc.lp.domain.dashboard.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.program.entity.Program;
+import com.mzc.lp.domain.program.repository.ProgramRepository;
+import com.mzc.lp.domain.student.entity.Enrollment;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.ts.constant.DeliveryType;
+import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.entity.UserCourseRole;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OwnerStatsControllerTest extends TenantTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserCourseRoleRepository userCourseRoleRepository;
+
+    @Autowired
+    private ProgramRepository programRepository;
+
+    @Autowired
+    private CourseTimeRepository courseTimeRepository;
+
+    @Autowired
+    private EnrollmentRepository enrollmentRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        enrollmentRepository.deleteAll();
+        courseTimeRepository.deleteAll();
+        programRepository.deleteAll();
+        userCourseRoleRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ========== Helper Methods ==========
+
+    private User createOwnerUser() {
+        User user = User.create("owner@example.com", "강의소유자", passwordEncoder.encode("Password123!"));
+        return userRepository.save(user);
+    }
+
+    private User createOperatorUser() {
+        User user = User.create("operator@example.com", "운영자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.OPERATOR);
+        return userRepository.save(user);
+    }
+
+    private User createNormalUser() {
+        User user = User.create("user@example.com", "일반사용자", passwordEncoder.encode("Password123!"));
+        return userRepository.save(user);
+    }
+
+    private void grantOwnerRole(User user, Long courseId) {
+        UserCourseRole ownerRole = UserCourseRole.createOwner(user, courseId);
+        userCourseRoleRepository.save(ownerRole);
+    }
+
+    private String loginAndGetAccessToken(String email, String password) throws Exception {
+        LoginRequest request = new LoginRequest(email, password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("data").get("accessToken").asText();
+    }
+
+    private Program createApprovedProgram(Long createdBy) {
+        Program program = Program.create("테스트 프로그램", createdBy);
+        program.submit();
+        program.approve(1L, "승인");
+        return programRepository.save(program);
+    }
+
+    private CourseTime createCourseTime(Program program) {
+        CourseTime courseTime = CourseTime.create(
+                "테스트 차수",
+                DeliveryType.ONLINE,
+                LocalDate.now().minusDays(1),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(30),
+                30,
+                5,
+                EnrollmentMethod.FIRST_COME,
+                80,
+                new BigDecimal("100000"),
+                false,
+                null,
+                true,
+                program.getCreatedBy()
+        );
+        courseTime.linkProgram(program);
+        courseTime.open();
+        return courseTimeRepository.save(courseTime);
+    }
+
+    private Enrollment createEnrollment(Long userId, Long courseTimeId) {
+        Enrollment enrollment = Enrollment.createVoluntary(userId, courseTimeId);
+        return enrollmentRepository.save(enrollment);
+    }
+
+    // ==================== OWNER 통계 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("GET /api/owners/me/stats - OWNER 내 강의 통계 조회")
+    class GetOwnerStats {
+
+        @Test
+        @DisplayName("성공 - OWNER 권한으로 전체 통계 조회")
+        void getOwnerStats_success() throws Exception {
+            // given
+            User owner = createOwnerUser();
+            User student = createNormalUser();
+
+            // 프로그램 생성 (owner가 생성자)
+            Program program1 = createApprovedProgram(owner.getId());
+            Program program2 = createApprovedProgram(owner.getId());
+
+            // OWNER 역할 부여
+            grantOwnerRole(owner, program1.getId());
+            grantOwnerRole(owner, program2.getId());
+
+            // 차수 생성
+            CourseTime courseTime1 = createCourseTime(program1);
+            CourseTime courseTime2 = createCourseTime(program1);
+            CourseTime courseTime3 = createCourseTime(program2);
+
+            // 수강 생성
+            createEnrollment(student.getId(), courseTime1.getId());
+            Enrollment completedEnrollment = createEnrollment(student.getId(), courseTime2.getId());
+            completedEnrollment.complete(90);
+            enrollmentRepository.save(completedEnrollment);
+            createEnrollment(student.getId(), courseTime3.getId());
+
+            String accessToken = loginAndGetAccessToken("owner@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/owners/me/stats")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    // Overview
+                    .andExpect(jsonPath("$.data.overview.totalPrograms").value(2))
+                    .andExpect(jsonPath("$.data.overview.totalCourseTimes").value(3))
+                    .andExpect(jsonPath("$.data.overview.totalStudents").value(3))
+                    // EnrollmentStats
+                    .andExpect(jsonPath("$.data.enrollmentStats.totalEnrollments").value(3))
+                    .andExpect(jsonPath("$.data.enrollmentStats.byStatus.enrolled").value(2))
+                    .andExpect(jsonPath("$.data.enrollmentStats.byStatus.completed").value(1))
+                    // ProgramStats
+                    .andExpect(jsonPath("$.data.programStats").isArray())
+                    .andExpect(jsonPath("$.data.programStats.length()").value(2));
+        }
+
+        @Test
+        @DisplayName("성공 - OPERATOR 권한으로 통계 조회 (본인 소유 프로그램)")
+        void getOwnerStats_success_operatorAccess() throws Exception {
+            // given
+            User operator = createOperatorUser();
+
+            // OPERATOR가 프로그램 생성
+            Program program = createApprovedProgram(operator.getId());
+            createCourseTime(program);
+
+            String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/owners/me/stats")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.overview.totalPrograms").value(1))
+                    .andExpect(jsonPath("$.data.overview.totalCourseTimes").value(1));
+        }
+
+        @Test
+        @DisplayName("성공 - 소유 프로그램 없는 경우")
+        void getOwnerStats_success_noPrograms() throws Exception {
+            // given
+            User owner = createOwnerUser();
+            grantOwnerRole(owner, 999L);  // 존재하지 않는 프로그램 ID
+
+            String accessToken = loginAndGetAccessToken("owner@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/owners/me/stats")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.overview.totalPrograms").value(0))
+                    .andExpect(jsonPath("$.data.overview.totalCourseTimes").value(0))
+                    .andExpect(jsonPath("$.data.overview.totalStudents").value(0))
+                    .andExpect(jsonPath("$.data.programStats").isEmpty());
+        }
+
+        @Test
+        @DisplayName("성공 - 다른 사람이 생성한 프로그램은 조회 안됨")
+        void getOwnerStats_success_onlyOwnPrograms() throws Exception {
+            // given
+            User owner = createOwnerUser();
+            User otherUser = createNormalUser();
+
+            // owner가 생성한 프로그램
+            Program myProgram = createApprovedProgram(owner.getId());
+            grantOwnerRole(owner, myProgram.getId());
+            createCourseTime(myProgram);
+
+            // 다른 사용자가 생성한 프로그램
+            Program otherProgram = createApprovedProgram(otherUser.getId());
+            createCourseTime(otherProgram);
+            createCourseTime(otherProgram);
+
+            String accessToken = loginAndGetAccessToken("owner@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/owners/me/stats")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    // 내 프로그램만 조회됨
+                    .andExpect(jsonPath("$.data.overview.totalPrograms").value(1))
+                    .andExpect(jsonPath("$.data.overview.totalCourseTimes").value(1))
+                    .andExpect(jsonPath("$.data.programStats.length()").value(1));
+        }
+
+        @Test
+        @DisplayName("실패 - OWNER 역할 없는 일반 사용자 접근 불가")
+        void getOwnerStats_fail_unauthorized() throws Exception {
+            // given
+            createNormalUser();
+            String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
+
+            // when & then
+            mockMvc.perform(get("/api/owners/me/stats")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("실패 - 인증 없이 접근")
+        void getOwnerStats_fail_noAuth() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/owners/me/stats"))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/dashboard/service/OwnerStatsServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/dashboard/service/OwnerStatsServiceTest.java
@@ -1,0 +1,253 @@
+package com.mzc.lp.domain.dashboard.service;
+
+import com.mzc.lp.common.dto.stats.ProgramStatsProjection;
+import com.mzc.lp.common.dto.stats.StatusCountProjection;
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.dashboard.dto.response.OwnerStatsResponse;
+import com.mzc.lp.domain.program.repository.ProgramRepository;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class OwnerStatsServiceTest extends TenantTestSupport {
+
+    @InjectMocks
+    private OwnerStatsServiceImpl ownerStatsService;
+
+    @Mock
+    private ProgramRepository programRepository;
+
+    @Mock
+    private CourseTimeRepository courseTimeRepository;
+
+    @Mock
+    private EnrollmentRepository enrollmentRepository;
+
+    private static final Long TENANT_ID = 1L;
+    private static final Long USER_ID = 100L;
+
+    @Nested
+    @DisplayName("getMyStats - OWNER 내 강의 통계 조회")
+    class GetMyStats {
+
+        @Test
+        @DisplayName("성공 - 전체 통계 조회")
+        void getMyStats_success() {
+            // given
+            List<Long> programIds = List.of(1L, 2L);
+            List<Long> courseTimeIds = List.of(10L, 11L, 12L);
+
+            given(programRepository.findIdsByCreatedByAndTenantId(USER_ID, TENANT_ID))
+                    .willReturn(programIds);
+            given(courseTimeRepository.findIdsByProgramIdInAndTenantId(programIds, TENANT_ID))
+                    .willReturn(courseTimeIds);
+            given(enrollmentRepository.countByCourseTimeIdInAndTenantId(courseTimeIds, TENANT_ID))
+                    .willReturn(50L);
+            given(enrollmentRepository.countByCourseTimeIdInGroupByStatus(courseTimeIds, TENANT_ID))
+                    .willReturn(List.of(
+                            createStatusCountProjection("ENROLLED", 30L),
+                            createStatusCountProjection("COMPLETED", 15L),
+                            createStatusCountProjection("DROPPED", 3L),
+                            createStatusCountProjection("FAILED", 2L)
+                    ));
+            given(enrollmentRepository.getCompletionRateByCourseTimeIds(courseTimeIds, TENANT_ID))
+                    .willReturn(30.0);
+            given(programRepository.findProgramStatsByOwner(USER_ID, TENANT_ID))
+                    .willReturn(List.of(
+                            createProgramStatsProjection(1L, "프로그램 A", 2L, 30L, 25.0),
+                            createProgramStatsProjection(2L, "프로그램 B", 1L, 20L, 40.0)
+                    ));
+
+            // when
+            OwnerStatsResponse response = ownerStatsService.getMyStats(USER_ID);
+
+            // then
+            assertThat(response).isNotNull();
+
+            // Overview 검증
+            assertThat(response.overview().totalPrograms()).isEqualTo(2L);
+            assertThat(response.overview().totalCourseTimes()).isEqualTo(3L);
+            assertThat(response.overview().totalStudents()).isEqualTo(50L);
+
+            // EnrollmentStats 검증
+            assertThat(response.enrollmentStats().totalEnrollments()).isEqualTo(50L);
+            assertThat(response.enrollmentStats().byStatus().enrolled()).isEqualTo(30L);
+            assertThat(response.enrollmentStats().byStatus().completed()).isEqualTo(15L);
+            assertThat(response.enrollmentStats().byStatus().dropped()).isEqualTo(3L);
+            assertThat(response.enrollmentStats().byStatus().failed()).isEqualTo(2L);
+            assertThat(response.enrollmentStats().completionRate()).isEqualTo(new BigDecimal("30.0"));
+
+            // ProgramStats 검증
+            assertThat(response.programStats()).hasSize(2);
+            assertThat(response.programStats().get(0).programId()).isEqualTo(1L);
+            assertThat(response.programStats().get(0).title()).isEqualTo("프로그램 A");
+            assertThat(response.programStats().get(0).courseTimeCount()).isEqualTo(2L);
+            assertThat(response.programStats().get(0).totalStudents()).isEqualTo(30L);
+            assertThat(response.programStats().get(0).completionRate()).isEqualTo(new BigDecimal("25.0"));
+        }
+
+        @Test
+        @DisplayName("성공 - 소유 프로그램 없는 경우")
+        void getMyStats_success_noPrograms() {
+            // given
+            given(programRepository.findIdsByCreatedByAndTenantId(USER_ID, TENANT_ID))
+                    .willReturn(Collections.emptyList());
+
+            // when
+            OwnerStatsResponse response = ownerStatsService.getMyStats(USER_ID);
+
+            // then
+            assertThat(response).isNotNull();
+
+            // Overview 검증 - 모두 0
+            assertThat(response.overview().totalPrograms()).isEqualTo(0L);
+            assertThat(response.overview().totalCourseTimes()).isEqualTo(0L);
+            assertThat(response.overview().totalStudents()).isEqualTo(0L);
+
+            // EnrollmentStats 검증 - 모두 0
+            assertThat(response.enrollmentStats().totalEnrollments()).isEqualTo(0L);
+            assertThat(response.enrollmentStats().byStatus().enrolled()).isEqualTo(0L);
+            assertThat(response.enrollmentStats().byStatus().completed()).isEqualTo(0L);
+            assertThat(response.enrollmentStats().byStatus().dropped()).isEqualTo(0L);
+            assertThat(response.enrollmentStats().byStatus().failed()).isEqualTo(0L);
+            assertThat(response.enrollmentStats().completionRate()).isEqualTo(BigDecimal.ZERO);
+
+            // ProgramStats 검증 - 빈 리스트
+            assertThat(response.programStats()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("성공 - 프로그램은 있지만 차수 없는 경우")
+        void getMyStats_success_noCourseTime() {
+            // given
+            List<Long> programIds = List.of(1L);
+
+            given(programRepository.findIdsByCreatedByAndTenantId(USER_ID, TENANT_ID))
+                    .willReturn(programIds);
+            given(courseTimeRepository.findIdsByProgramIdInAndTenantId(programIds, TENANT_ID))
+                    .willReturn(Collections.emptyList());
+            given(programRepository.findProgramStatsByOwner(USER_ID, TENANT_ID))
+                    .willReturn(List.of(
+                            createProgramStatsProjection(1L, "프로그램 A", 0L, 0L, null)
+                    ));
+
+            // when
+            OwnerStatsResponse response = ownerStatsService.getMyStats(USER_ID);
+
+            // then
+            assertThat(response).isNotNull();
+
+            // Overview 검증
+            assertThat(response.overview().totalPrograms()).isEqualTo(1L);
+            assertThat(response.overview().totalCourseTimes()).isEqualTo(0L);
+            assertThat(response.overview().totalStudents()).isEqualTo(0L);
+
+            // EnrollmentStats 검증 - 차수가 없으므로 수강도 없음
+            assertThat(response.enrollmentStats().totalEnrollments()).isEqualTo(0L);
+            assertThat(response.enrollmentStats().completionRate()).isEqualTo(BigDecimal.ZERO);
+
+            // ProgramStats 검증
+            assertThat(response.programStats()).hasSize(1);
+            assertThat(response.programStats().get(0).courseTimeCount()).isEqualTo(0L);
+            assertThat(response.programStats().get(0).totalStudents()).isEqualTo(0L);
+            assertThat(response.programStats().get(0).completionRate()).isEqualTo(BigDecimal.ZERO);
+        }
+
+        @Test
+        @DisplayName("성공 - 차수는 있지만 수강생 없는 경우")
+        void getMyStats_success_noStudents() {
+            // given
+            List<Long> programIds = List.of(1L);
+            List<Long> courseTimeIds = List.of(10L);
+
+            given(programRepository.findIdsByCreatedByAndTenantId(USER_ID, TENANT_ID))
+                    .willReturn(programIds);
+            given(courseTimeRepository.findIdsByProgramIdInAndTenantId(programIds, TENANT_ID))
+                    .willReturn(courseTimeIds);
+            given(enrollmentRepository.countByCourseTimeIdInAndTenantId(courseTimeIds, TENANT_ID))
+                    .willReturn(0L);
+            given(enrollmentRepository.countByCourseTimeIdInGroupByStatus(courseTimeIds, TENANT_ID))
+                    .willReturn(Collections.emptyList());
+            given(enrollmentRepository.getCompletionRateByCourseTimeIds(courseTimeIds, TENANT_ID))
+                    .willReturn(null);
+            given(programRepository.findProgramStatsByOwner(USER_ID, TENANT_ID))
+                    .willReturn(List.of(
+                            createProgramStatsProjection(1L, "프로그램 A", 1L, 0L, null)
+                    ));
+
+            // when
+            OwnerStatsResponse response = ownerStatsService.getMyStats(USER_ID);
+
+            // then
+            assertThat(response).isNotNull();
+
+            // Overview 검증
+            assertThat(response.overview().totalPrograms()).isEqualTo(1L);
+            assertThat(response.overview().totalCourseTimes()).isEqualTo(1L);
+            assertThat(response.overview().totalStudents()).isEqualTo(0L);
+
+            // EnrollmentStats 검증 - 수강생 없음
+            assertThat(response.enrollmentStats().totalEnrollments()).isEqualTo(0L);
+            assertThat(response.enrollmentStats().byStatus().enrolled()).isEqualTo(0L);
+            assertThat(response.enrollmentStats().completionRate()).isEqualTo(BigDecimal.ZERO);
+        }
+    }
+
+    private StatusCountProjection createStatusCountProjection(String status, Long count) {
+        return new StatusCountProjection() {
+            @Override
+            public String getStatus() {
+                return status;
+            }
+
+            @Override
+            public Long getCount() {
+                return count;
+            }
+        };
+    }
+
+    private ProgramStatsProjection createProgramStatsProjection(
+            Long programId, String title, Long courseTimeCount, Long totalStudents, Double completionRate) {
+        return new ProgramStatsProjection() {
+            @Override
+            public Long getProgramId() {
+                return programId;
+            }
+
+            @Override
+            public String getTitle() {
+                return title;
+            }
+
+            @Override
+            public Long getCourseTimeCount() {
+                return courseTimeCount;
+            }
+
+            @Override
+            public Long getTotalStudents() {
+                return totalStudents;
+            }
+
+            @Override
+            public Double getCompletionRate() {
+                return completionRate;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

OWNER(B2C 크리에이터)가 본인 소유 프로그램의 통계를 조회하는 API 구현. overview(전체 프로그램/차수/수강생), enrollmentStats(상태별 수강, 수료율), programStats(프로그램별 차수/수강생/수료율) 제공

## Related Issue

- Closes #197

## Changes

- `ProgramStatsProjection.java`: 프로그램별 통계 Projection 인터페이스 추가
- `OwnerStatsResponse.java`: OWNER 통계 Response DTO (overview, enrollmentStats, programStats 중첩)
- `ProgramRepository.java`: findIdsByCreatedByAndTenantId, findProgramStatsByOwner 쿼리 추가
- `CourseTimeRepository.java`: findIdsByProgramIdInAndTenantId 쿼리 추가
- `EnrollmentRepository.java`: countByCourseTimeIdInAndTenantId, countByCourseTimeIdInGroupByStatus, getCompletionRateByCourseTimeIds 쿼리 추가
- `OwnerStatsService.java`: 인터페이스 생성
- `OwnerStatsServiceImpl.java`: 서비스 구현체 생성
- `OwnerStatsController.java`: GET /api/owners/me/stats 엔드포인트 추가
- `OwnerStatsServiceTest.java`: 신규 생성 (4개 테스트)
- `OwnerStatsControllerTest.java`: 신규 생성 (6개 테스트)

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Test plan

- [x] OWNER 권한으로 통계 조회 → 성공 (200)
- [x] OPERATOR 권한으로 본인 프로그램 조회 → 성공 (200)
- [x] 소유 프로그램 없는 경우 → 빈 응답 (200)
- [x] 다른 사용자 프로그램은 조회 안됨 확인
- [x] OWNER 역할 없는 일반 사용자 → 실패 (403)
- [x] 인증 없이 접근 → 실패 (403)
- [x] 전체 테스트 통과