### PR TITLE
[Feat] 내 콘텐츠 API 폴더 필터링 및 폴더 관리 개선 (#203)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/content/controller/ContentController.java
+++ b/src/main/java/com/mzc/lp/domain/content/controller/ContentController.java
@@ -183,13 +183,14 @@ public class ContentController {
             @RequestParam(required = false) ContentType contentType,
             @RequestParam(required = false) ContentStatus status,
             @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) Long folderId,
             @PageableDefault(size = 20) Pageable pageable,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
         Long tenantId = TenantContext.getCurrentTenantId();
         Long userId = principal.id();
         Page<ContentListResponse> response = contentService.getMyContents(
-                tenantId, userId, contentType, status, keyword, pageable);
+                tenantId, userId, contentType, status, keyword, folderId, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/mzc/lp/domain/content/repository/ContentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/content/repository/ContentRepository.java
@@ -100,18 +100,18 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
                                                                                @Param("keyword") String keyword,
                                                                                Pageable pageable);
 
-    // folderId 기반 조회 (LearningObject JOIN)
+    // folderIds 기반 조회 (LearningObject JOIN) - 하위 폴더 포함
     @Query("SELECT c FROM Content c JOIN LearningObject lo ON lo.content = c " +
            "WHERE c.tenantId = :tenantId AND c.createdBy = :createdBy " +
-           "AND lo.folder.id = :folderId " +
+           "AND lo.folder.id IN :folderIds " +
            "AND (:contentType IS NULL OR c.contentType = :contentType) " +
            "AND (:status IS NULL OR c.status = :status) " +
            "AND (:keyword IS NULL OR LOWER(c.originalFileName) LIKE LOWER(CONCAT('%', :keyword, '%')))")
-    Page<Content> findMyContentsByFolderId(@Param("tenantId") Long tenantId,
-                                            @Param("createdBy") Long createdBy,
-                                            @Param("contentType") ContentType contentType,
-                                            @Param("status") ContentStatus status,
-                                            @Param("keyword") String keyword,
-                                            @Param("folderId") Long folderId,
-                                            Pageable pageable);
+    Page<Content> findMyContentsByFolderIds(@Param("tenantId") Long tenantId,
+                                             @Param("createdBy") Long createdBy,
+                                             @Param("contentType") ContentType contentType,
+                                             @Param("status") ContentStatus status,
+                                             @Param("keyword") String keyword,
+                                             @Param("folderIds") java.util.List<Long> folderIds,
+                                             Pageable pageable);
 }

--- a/src/main/java/com/mzc/lp/domain/content/repository/ContentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/content/repository/ContentRepository.java
@@ -99,4 +99,19 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
                                                                                @Param("status") ContentStatus status,
                                                                                @Param("keyword") String keyword,
                                                                                Pageable pageable);
+
+    // folderId 기반 조회 (LearningObject JOIN)
+    @Query("SELECT c FROM Content c JOIN LearningObject lo ON lo.content = c " +
+           "WHERE c.tenantId = :tenantId AND c.createdBy = :createdBy " +
+           "AND lo.folder.id = :folderId " +
+           "AND (:contentType IS NULL OR c.contentType = :contentType) " +
+           "AND (:status IS NULL OR c.status = :status) " +
+           "AND (:keyword IS NULL OR LOWER(c.originalFileName) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+    Page<Content> findMyContentsByFolderId(@Param("tenantId") Long tenantId,
+                                            @Param("createdBy") Long createdBy,
+                                            @Param("contentType") ContentType contentType,
+                                            @Param("status") ContentStatus status,
+                                            @Param("keyword") String keyword,
+                                            @Param("folderId") Long folderId,
+                                            Pageable pageable);
 }

--- a/src/main/java/com/mzc/lp/domain/content/service/ContentService.java
+++ b/src/main/java/com/mzc/lp/domain/content/service/ContentService.java
@@ -71,7 +71,7 @@ public interface ContentService {
     /**
      * 내 콘텐츠 목록 조회 (DESIGNER용)
      */
-    Page<ContentListResponse> getMyContents(Long tenantId, Long userId, ContentType contentType, ContentStatus status, String keyword, Pageable pageable);
+    Page<ContentListResponse> getMyContents(Long tenantId, Long userId, ContentType contentType, ContentStatus status, String keyword, Long folderId, Pageable pageable);
 
     /**
      * 콘텐츠 보관 (Archive)

--- a/src/main/java/com/mzc/lp/domain/content/service/ContentServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/content/service/ContentServiceImpl.java
@@ -380,37 +380,44 @@ public class ContentServiceImpl implements ContentService {
     @Override
     public Page<ContentListResponse> getMyContents(Long tenantId, Long userId,
                                                     ContentType contentType, ContentStatus status,
-                                                    String keyword, Pageable pageable) {
+                                                    String keyword, Long folderId, Pageable pageable) {
         Page<Content> contents;
 
         boolean hasType = contentType != null;
         boolean hasStatus = status != null;
         boolean hasKeyword = keyword != null && !keyword.isBlank();
+        boolean hasFolder = folderId != null;
 
-        // 조합별 쿼리 호출
-        if (hasType && hasStatus && hasKeyword) {
-            contents = contentRepository.findByTenantIdAndCreatedByAndContentTypeAndStatusAndKeyword(
-                    tenantId, userId, contentType, status, keyword, pageable);
-        } else if (hasType && hasStatus) {
-            contents = contentRepository.findByTenantIdAndCreatedByAndContentTypeAndStatus(
-                    tenantId, userId, contentType, status, pageable);
-        } else if (hasType && hasKeyword) {
-            contents = contentRepository.findByTenantIdAndCreatedByAndContentTypeAndKeyword(
-                    tenantId, userId, contentType, keyword, pageable);
-        } else if (hasStatus && hasKeyword) {
-            contents = contentRepository.findByTenantIdAndCreatedByAndStatusAndKeyword(
-                    tenantId, userId, status, keyword, pageable);
-        } else if (hasType) {
-            contents = contentRepository.findByTenantIdAndCreatedByAndContentType(
-                    tenantId, userId, contentType, pageable);
-        } else if (hasStatus) {
-            contents = contentRepository.findByTenantIdAndCreatedByAndStatus(
-                    tenantId, userId, status, pageable);
-        } else if (hasKeyword) {
-            contents = contentRepository.findByTenantIdAndCreatedByAndKeyword(
-                    tenantId, userId, keyword, pageable);
+        // folderId가 있는 경우 LearningObject를 통한 JOIN 쿼리 사용
+        if (hasFolder) {
+            contents = contentRepository.findMyContentsByFolderId(
+                    tenantId, userId, contentType, status, keyword, folderId, pageable);
         } else {
-            contents = contentRepository.findByTenantIdAndCreatedBy(tenantId, userId, pageable);
+            // 기존 조합별 쿼리 호출
+            if (hasType && hasStatus && hasKeyword) {
+                contents = contentRepository.findByTenantIdAndCreatedByAndContentTypeAndStatusAndKeyword(
+                        tenantId, userId, contentType, status, keyword, pageable);
+            } else if (hasType && hasStatus) {
+                contents = contentRepository.findByTenantIdAndCreatedByAndContentTypeAndStatus(
+                        tenantId, userId, contentType, status, pageable);
+            } else if (hasType && hasKeyword) {
+                contents = contentRepository.findByTenantIdAndCreatedByAndContentTypeAndKeyword(
+                        tenantId, userId, contentType, keyword, pageable);
+            } else if (hasStatus && hasKeyword) {
+                contents = contentRepository.findByTenantIdAndCreatedByAndStatusAndKeyword(
+                        tenantId, userId, status, keyword, pageable);
+            } else if (hasType) {
+                contents = contentRepository.findByTenantIdAndCreatedByAndContentType(
+                        tenantId, userId, contentType, pageable);
+            } else if (hasStatus) {
+                contents = contentRepository.findByTenantIdAndCreatedByAndStatus(
+                        tenantId, userId, status, pageable);
+            } else if (hasKeyword) {
+                contents = contentRepository.findByTenantIdAndCreatedByAndKeyword(
+                        tenantId, userId, keyword, pageable);
+            } else {
+                contents = contentRepository.findByTenantIdAndCreatedBy(tenantId, userId, pageable);
+            }
         }
 
         return contents.map(ContentListResponse::from);

--- a/src/main/java/com/mzc/lp/domain/learning/controller/LearningObjectController.java
+++ b/src/main/java/com/mzc/lp/domain/learning/controller/LearningObjectController.java
@@ -77,7 +77,7 @@ public class LearningObjectController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @PatchMapping("/{learningObjectId}")
+    @PutMapping("/{learningObjectId}")
     @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<LearningObjectResponse>> update(
             @PathVariable Long learningObjectId,
@@ -90,7 +90,7 @@ public class LearningObjectController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @PatchMapping("/{learningObjectId}/folder")
+    @PutMapping("/{learningObjectId}/folder")
     @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<LearningObjectResponse>> moveToFolder(
             @PathVariable Long learningObjectId,

--- a/src/main/java/com/mzc/lp/domain/learning/entity/ContentFolder.java
+++ b/src/main/java/com/mzc/lp/domain/learning/entity/ContentFolder.java
@@ -98,8 +98,12 @@ public class ContentFolder extends TenantEntity {
         return children.size();
     }
 
-    // 비즈니스 메서드 - 학습객체 개수
+    // 비즈니스 메서드 - 학습객체 개수 (하위 폴더 포함)
     public int getItemCount() {
-        return learningObjects.size();
+        int count = learningObjects.size();
+        for (ContentFolder child : children) {
+            count += child.getItemCount();
+        }
+        return count;
     }
 }

--- a/src/main/java/com/mzc/lp/domain/learning/repository/LearningObjectRepository.java
+++ b/src/main/java/com/mzc/lp/domain/learning/repository/LearningObjectRepository.java
@@ -37,6 +37,19 @@ public interface LearningObjectRepository extends JpaRepository<LearningObject, 
                                                              @Param("keyword") String keyword,
                                                              Pageable pageable);
 
+    // 하위 폴더 포함 조회 (폴더 ID 목록으로)
+    @Query("SELECT lo FROM LearningObject lo WHERE lo.tenantId = :tenantId AND lo.folder.id IN :folderIds")
+    Page<LearningObject> findByTenantIdAndFolderIdIn(@Param("tenantId") Long tenantId,
+                                                      @Param("folderIds") java.util.List<Long> folderIds,
+                                                      Pageable pageable);
+
+    @Query("SELECT lo FROM LearningObject lo WHERE lo.tenantId = :tenantId AND lo.folder.id IN :folderIds AND " +
+           "(LOWER(lo.name) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+    Page<LearningObject> findByTenantIdAndFolderIdInAndKeyword(@Param("tenantId") Long tenantId,
+                                                               @Param("folderIds") java.util.List<Long> folderIds,
+                                                               @Param("keyword") String keyword,
+                                                               Pageable pageable);
+
     /**
      * 콘텐츠가 강의(LearningObject)에서 참조되고 있는지 확인
      */

--- a/src/test/java/com/mzc/lp/domain/learning/controller/LearningObjectControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/learning/controller/LearningObjectControllerTest.java
@@ -260,7 +260,7 @@ class LearningObjectControllerTest extends TenantTestSupport {
         UpdateLearningObjectRequest request = new UpdateLearningObjectRequest("수정된 이름");
 
         // When & Then
-        mockMvc.perform(patch("/api/learning-objects/{id}", lo.getId())
+        mockMvc.perform(put("/api/learning-objects/{id}", lo.getId())
                         .header("Authorization", "Bearer " + accessToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
@@ -281,7 +281,7 @@ class LearningObjectControllerTest extends TenantTestSupport {
         MoveFolderRequest request = new MoveFolderRequest(folder.getId());
 
         // When & Then
-        mockMvc.perform(patch("/api/learning-objects/{id}/folder", lo.getId())
+        mockMvc.perform(put("/api/learning-objects/{id}/folder", lo.getId())
                         .header("Authorization", "Bearer " + accessToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))


### PR DESCRIPTION
## Summary
- 내 콘텐츠 API에 folderId 필터링 추가
- 폴더 선택 시 하위 폴더 콘텐츠 포함 조회 (재귀)
- 폴더 itemCount 하위 폴더 LO 누적 계산
- 폴더 삭제 시 LO를 미분류(root)로 자동 이동

## Test plan
- [x] 내 콘텐츠 API folderId 필터링 동작 확인
- [x] 하위 폴더 콘텐츠 포함 조회 확인
- [x] itemCount 누적 계산 확인
- [x] 폴더 삭제 시 LO 미분류 이동 확인

Closes #203