### PR TITLE
feat: CourseItem displayName/description 필드 추가 #211

### DIFF
--- a/src/main/java/com/mzc/lp/common/config/SecurityConfig.java
+++ b/src/main/java/com/mzc/lp/common/config/SecurityConfig.java
@@ -67,7 +67,7 @@ public class SecurityConfig {
         // 환경변수에서 CORS origins 읽기 (콤마로 구분된 여러 origin 지원)
         List<String> origins = Arrays.asList(allowedOrigins.split(","));
         configuration.setAllowedOrigins(origins);
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
         configuration.setMaxAge(3600L);

--- a/src/main/java/com/mzc/lp/domain/course/controller/CourseItemController.java
+++ b/src/main/java/com/mzc/lp/domain/course/controller/CourseItemController.java
@@ -5,6 +5,7 @@ import com.mzc.lp.common.security.UserPrincipal;
 import com.mzc.lp.domain.course.dto.request.CreateFolderRequest;
 import com.mzc.lp.domain.course.dto.request.CreateItemRequest;
 import com.mzc.lp.domain.course.dto.request.MoveItemRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateDisplayInfoRequest;
 import com.mzc.lp.domain.course.dto.request.UpdateItemNameRequest;
 import com.mzc.lp.domain.course.dto.request.UpdateLearningObjectRequest;
 import com.mzc.lp.domain.course.dto.response.CourseItemHierarchyResponse;
@@ -146,5 +147,21 @@ public class CourseItemController {
     ) {
         courseItemService.deleteItem(courseId, itemId);
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 표시 정보 변경 (displayName, description)
+     * PATCH /api/courses/{courseId}/items/{itemId}/display-info
+     */
+    @PatchMapping("/items/{itemId}/display-info")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseItemResponse>> updateDisplayInfo(
+            @PathVariable @Positive Long courseId,
+            @PathVariable @Positive Long itemId,
+            @Valid @RequestBody UpdateDisplayInfoRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseItemResponse response = courseItemService.updateDisplayInfo(courseId, itemId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/course/dto/request/CreateItemRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/CreateItemRequest.java
@@ -12,11 +12,23 @@ public record CreateItemRequest(
         Long parentId,
 
         @NotNull(message = "학습 객체 ID는 필수입니다")
-        Long learningObjectId
+        Long learningObjectId,
+
+        @Size(max = 255, message = "표시 이름은 255자 이하여야 합니다")
+        String displayName,
+
+        @Size(max = 1000, message = "설명은 1000자 이하여야 합니다")
+        String description
 ) {
     public CreateItemRequest {
         if (itemName != null) {
             itemName = itemName.trim();
+        }
+        if (displayName != null) {
+            displayName = displayName.trim();
+        }
+        if (description != null) {
+            description = description.trim();
         }
     }
 }

--- a/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateDisplayInfoRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateDisplayInfoRequest.java
@@ -1,0 +1,20 @@
+package com.mzc.lp.domain.course.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record UpdateDisplayInfoRequest(
+        @Size(max = 255, message = "표시 이름은 255자 이하여야 합니다")
+        String displayName,
+
+        @Size(max = 1000, message = "설명은 1000자 이하여야 합니다")
+        String description
+) {
+    public UpdateDisplayInfoRequest {
+        if (displayName != null) {
+            displayName = displayName.trim();
+        }
+        if (description != null) {
+            description = description.trim();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseItemHierarchyResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseItemHierarchyResponse.java
@@ -11,6 +11,8 @@ public record CourseItemHierarchyResponse(
         Integer depth,
         Long learningObjectId,
         boolean isFolder,
+        String displayName,
+        String description,
         List<CourseItemHierarchyResponse> children
 ) {
     public static CourseItemHierarchyResponse from(CourseItem item) {
@@ -20,6 +22,8 @@ public record CourseItemHierarchyResponse(
                 item.getDepth(),
                 item.getLearningObjectId(),
                 item.isFolder(),
+                item.getDisplayName(),
+                item.getDescription(),
                 item.getChildren().stream()
                         .map(CourseItemHierarchyResponse::from)
                         .collect(Collectors.toList())

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseItemResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseItemResponse.java
@@ -11,6 +11,8 @@ public record CourseItemResponse(
         Long parentId,
         Long learningObjectId,
         boolean isFolder,
+        String displayName,
+        String description,
         Instant createdAt,
         Instant updatedAt
 ) {
@@ -22,6 +24,8 @@ public record CourseItemResponse(
                 item.getParent() != null ? item.getParent().getId() : null,
                 item.getLearningObjectId(),
                 item.isFolder(),
+                item.getDisplayName(),
+                item.getDescription(),
                 item.getCreatedAt(),
                 item.getUpdatedAt()
         );

--- a/src/main/java/com/mzc/lp/domain/course/entity/CourseItem.java
+++ b/src/main/java/com/mzc/lp/domain/course/entity/CourseItem.java
@@ -38,6 +38,12 @@ public class CourseItem extends TenantEntity {
     @Column(name = "item_name", nullable = false, length = 255)
     private String itemName;
 
+    @Column(name = "display_name", length = 255)
+    private String displayName;
+
+    @Column(name = "description", length = 1000)
+    private String description;
+
     @Column(nullable = false)
     private Integer depth;
 
@@ -55,12 +61,20 @@ public class CourseItem extends TenantEntity {
 
     public static CourseItem createItem(Course course, String itemName,
                                         CourseItem parent, Long learningObjectId) {
+        return createItem(course, itemName, parent, learningObjectId, null, null);
+    }
+
+    public static CourseItem createItem(Course course, String itemName,
+                                        CourseItem parent, Long learningObjectId,
+                                        String displayName, String description) {
         CourseItem item = new CourseItem();
         item.course = course;
         item.itemName = itemName;
         item.parent = parent;
         item.depth = parent != null ? parent.getDepth() + 1 : 0;
         item.learningObjectId = learningObjectId;
+        item.displayName = displayName;
+        item.description = description;
         item.validateDepth();
         return item;
     }
@@ -80,6 +94,14 @@ public class CourseItem extends TenantEntity {
             throw new IllegalStateException("폴더에는 학습 객체를 연결할 수 없습니다");
         }
         this.learningObjectId = learningObjectId;
+    }
+
+    public void updateDisplayInfo(String displayName, String description) {
+        if (isFolder()) {
+            throw new IllegalStateException("폴더에는 표시 정보를 설정할 수 없습니다");
+        }
+        this.displayName = displayName;
+        this.description = description;
     }
 
     public void moveTo(CourseItem newParent) {

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseItemService.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseItemService.java
@@ -3,6 +3,7 @@ package com.mzc.lp.domain.course.service;
 import com.mzc.lp.domain.course.dto.request.CreateFolderRequest;
 import com.mzc.lp.domain.course.dto.request.CreateItemRequest;
 import com.mzc.lp.domain.course.dto.request.MoveItemRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateDisplayInfoRequest;
 import com.mzc.lp.domain.course.dto.request.UpdateItemNameRequest;
 import com.mzc.lp.domain.course.dto.request.UpdateLearningObjectRequest;
 import com.mzc.lp.domain.course.dto.response.CourseItemHierarchyResponse;
@@ -74,4 +75,13 @@ public interface CourseItemService {
      * @param itemId 항목 ID
      */
     void deleteItem(Long courseId, Long itemId);
+
+    /**
+     * 표시 정보 변경 (displayName, description)
+     * @param courseId 강의 ID
+     * @param itemId 항목 ID
+     * @param request 표시 정보 변경 요청 DTO
+     * @return 수정된 항목 정보
+     */
+    CourseItemResponse updateDisplayInfo(Long courseId, Long itemId, UpdateDisplayInfoRequest request);
 }

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseItemServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseItemServiceImpl.java
@@ -3,6 +3,7 @@ package com.mzc.lp.domain.course.service;
 import com.mzc.lp.domain.course.dto.request.CreateFolderRequest;
 import com.mzc.lp.domain.course.dto.request.CreateItemRequest;
 import com.mzc.lp.domain.course.dto.request.MoveItemRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateDisplayInfoRequest;
 import com.mzc.lp.domain.course.dto.request.UpdateItemNameRequest;
 import com.mzc.lp.domain.course.dto.request.UpdateLearningObjectRequest;
 import com.mzc.lp.domain.course.dto.response.CourseItemHierarchyResponse;
@@ -47,7 +48,9 @@ public class CourseItemServiceImpl implements CourseItemService {
                     course,
                     request.itemName(),
                     parent,
-                    request.learningObjectId()
+                    request.learningObjectId(),
+                    request.displayName(),
+                    request.description()
             );
 
             CourseItem savedItem = courseItemRepository.save(item);
@@ -196,6 +199,26 @@ public class CourseItemServiceImpl implements CourseItemService {
 
         courseItemRepository.delete(item);
         log.info("Item deleted: id={}", itemId);
+    }
+
+    @Override
+    @Transactional
+    public CourseItemResponse updateDisplayInfo(Long courseId, Long itemId, UpdateDisplayInfoRequest request) {
+        log.info("Updating display info: courseId={}, itemId={}", courseId, itemId);
+
+        validateCourseExists(courseId);
+
+        CourseItem item = findItemById(itemId);
+        validateItemBelongsToCourse(item, courseId);
+
+        if (item.isFolder()) {
+            throw new InvalidParentException("폴더에는 표시 정보를 설정할 수 없습니다");
+        }
+
+        item.updateDisplayInfo(request.displayName(), request.description());
+        log.info("Display info updated: itemId={}", itemId);
+
+        return CourseItemResponse.from(item);
     }
 
     // ===== Private Helper Methods =====

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseItemControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseItemControllerTest.java
@@ -140,7 +140,9 @@ class CourseItemControllerTest extends TenantTestSupport {
             CreateItemRequest request = new CreateItemRequest(
                     "1-1. 환경설정",
                     null,
-                    100L
+                    100L,
+                    null,
+                    null
             );
 
             // when & then
@@ -169,7 +171,9 @@ class CourseItemControllerTest extends TenantTestSupport {
             CreateItemRequest request = new CreateItemRequest(
                     "1-1. 환경설정",
                     folder.getId(),
-                    100L
+                    100L,
+                    null,
+                    null
             );
 
             // when & then
@@ -195,7 +199,9 @@ class CourseItemControllerTest extends TenantTestSupport {
             CreateItemRequest request = new CreateItemRequest(
                     "차시",
                     null,
-                    100L
+                    100L,
+                    null,
+                    null
             );
 
             // when & then
@@ -219,7 +225,9 @@ class CourseItemControllerTest extends TenantTestSupport {
             CreateItemRequest request = new CreateItemRequest(
                     null,
                     null,
-                    100L
+                    100L,
+                    null,
+                    null
             );
 
             // when & then
@@ -241,6 +249,8 @@ class CourseItemControllerTest extends TenantTestSupport {
             Course course = createTestCourse("테스트 강의");
             CreateItemRequest request = new CreateItemRequest(
                     "차시 이름",
+                    null,
+                    null,
                     null,
                     null
             );
@@ -265,7 +275,9 @@ class CourseItemControllerTest extends TenantTestSupport {
             CreateItemRequest request = new CreateItemRequest(
                     "차시",
                     null,
-                    100L
+                    100L,
+                    null,
+                    null
             );
 
             // when & then


### PR DESCRIPTION
## Summary
- CourseItem 엔티티에 displayName, description 필드 추가
- 강의에 LO 추가 시 강의별로 다른 표시 이름과 설명을 설정할 수 있도록 함

## Changes
- CourseItem 엔티티: displayName (VARCHAR 255), description (VARCHAR 1000) 필드 추가
- CreateItemRequest: displayName, description 파라미터 추가
- UpdateDisplayInfoRequest: 표시 정보 수정용 DTO 신규 생성
- CourseItemResponse, CourseItemHierarchyResponse: 응답에 필드 추가
- CourseItemService: updateDisplayInfo 메서드 추가
- CourseItemController: PATCH /items/{itemId}/display-info 엔드포인트 추가
- SecurityConfig: CORS allowedMethods에 PATCH 추가

## Test plan
- [x] POST /courses/{courseId}/items로 차시 생성 시 displayName/description 전달
- [x] PATCH /courses/{courseId}/items/{itemId}/display-info로 표시 정보 수정
- [x] GET /courses/{courseId}/items/hierarchy 응답에 displayName/description 포함 확인

Closes #211