### PR TITLE
feat: SA/TA 관리자 API 구현 (#213)

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -105,7 +105,14 @@ public enum ErrorCode {
 
     // Category (CAT)
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CAT001", "Category not found"),
-    DUPLICATE_CATEGORY_CODE(HttpStatus.CONFLICT, "CAT002", "Category code already exists");
+    DUPLICATE_CATEGORY_CODE(HttpStatus.CONFLICT, "CAT002", "Category code already exists"),
+
+    // User Group (UG)
+    USER_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "UG001", "User group not found"),
+    DUPLICATE_USER_GROUP_NAME(HttpStatus.CONFLICT, "UG002", "User group name already exists"),
+
+    // Notice (NT)
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NT001", "Notice not found");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/mzc/lp/domain/notice/constant/NoticeStatus.java
+++ b/src/main/java/com/mzc/lp/domain/notice/constant/NoticeStatus.java
@@ -1,0 +1,10 @@
+package com.mzc.lp.domain.notice.constant;
+
+/**
+ * 공지사항 상태
+ */
+public enum NoticeStatus {
+    DRAFT,       // 초안 (미발행)
+    PUBLISHED,   // 발행됨
+    ARCHIVED     // 보관됨
+}

--- a/src/main/java/com/mzc/lp/domain/notice/constant/NoticeType.java
+++ b/src/main/java/com/mzc/lp/domain/notice/constant/NoticeType.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.notice.constant;
+
+/**
+ * 공지사항 유형
+ */
+public enum NoticeType {
+    SYSTEM,      // 시스템 공지 (장애, 점검 등)
+    UPDATE,      // 업데이트 공지
+    EVENT,       // 이벤트 공지
+    GENERAL      // 일반 공지
+}

--- a/src/main/java/com/mzc/lp/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/mzc/lp/domain/notice/controller/NoticeController.java
@@ -1,0 +1,138 @@
+package com.mzc.lp.domain.notice.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.domain.notice.constant.NoticeStatus;
+import com.mzc.lp.domain.notice.constant.NoticeType;
+import com.mzc.lp.domain.notice.dto.request.CreateNoticeRequest;
+import com.mzc.lp.domain.notice.dto.request.DistributeNoticeRequest;
+import com.mzc.lp.domain.notice.dto.request.UpdateNoticeRequest;
+import com.mzc.lp.domain.notice.dto.response.NoticeResponse;
+import com.mzc.lp.domain.notice.service.NoticeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 공지사항 컨트롤러 (SA용)
+ * Super Admin이 시스템 공지를 관리하고 테넌트에 배포
+ */
+@Tag(name = "Notices (SA)", description = "시스템 공지사항 관리 API")
+@RestController
+@RequestMapping("/api/sa/notices")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('SUPER_ADMIN')")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @Operation(summary = "공지사항 생성", description = "새로운 공지사항을 생성합니다")
+    @PostMapping
+    public ResponseEntity<ApiResponse<NoticeResponse>> createNotice(
+            @Valid @RequestBody CreateNoticeRequest request,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        // TODO: userDetails에서 실제 userId 추출 로직 필요
+        Long createdBy = 1L; // 임시값
+        NoticeResponse response = noticeService.createNotice(request, createdBy);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "공지사항 목록 조회", description = "공지사항 목록을 조회합니다")
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<NoticeResponse>>> getNotices(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) NoticeStatus status,
+            @RequestParam(required = false) NoticeType type,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<NoticeResponse> response = noticeService.getNotices(keyword, status, type, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "공지사항 상세 조회", description = "특정 공지사항의 상세 정보를 조회합니다")
+    @GetMapping("/{noticeId}")
+    public ResponseEntity<ApiResponse<NoticeResponse>> getNotice(
+            @PathVariable Long noticeId
+    ) {
+        NoticeResponse response = noticeService.getNotice(noticeId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "공지사항 수정", description = "공지사항을 수정합니다")
+    @PutMapping("/{noticeId}")
+    public ResponseEntity<ApiResponse<NoticeResponse>> updateNotice(
+            @PathVariable Long noticeId,
+            @Valid @RequestBody UpdateNoticeRequest request
+    ) {
+        NoticeResponse response = noticeService.updateNotice(noticeId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "공지사항 삭제", description = "공지사항을 삭제합니다")
+    @DeleteMapping("/{noticeId}")
+    public ResponseEntity<Void> deleteNotice(
+            @PathVariable Long noticeId
+    ) {
+        noticeService.deleteNotice(noticeId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "공지사항 발행", description = "공지사항을 발행 상태로 변경합니다")
+    @PostMapping("/{noticeId}/publish")
+    public ResponseEntity<ApiResponse<NoticeResponse>> publishNotice(
+            @PathVariable Long noticeId
+    ) {
+        NoticeResponse response = noticeService.publishNotice(noticeId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "공지사항 보관", description = "공지사항을 보관 상태로 변경합니다")
+    @PostMapping("/{noticeId}/archive")
+    public ResponseEntity<ApiResponse<NoticeResponse>> archiveNotice(
+            @PathVariable Long noticeId
+    ) {
+        NoticeResponse response = noticeService.archiveNotice(noticeId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "공지사항 배포", description = "특정 테넌트들에게 공지사항을 배포합니다")
+    @PostMapping("/{noticeId}/distribute")
+    public ResponseEntity<Void> distributeNotice(
+            @PathVariable Long noticeId,
+            @Valid @RequestBody DistributeNoticeRequest request
+    ) {
+        noticeService.distributeNotice(noticeId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "전체 테넌트 배포", description = "모든 테넌트에게 공지사항을 배포합니다")
+    @PostMapping("/{noticeId}/distribute-all")
+    public ResponseEntity<Void> distributeToAllTenants(
+            @PathVariable Long noticeId
+    ) {
+        noticeService.distributeToAllTenants(noticeId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "배포된 테넌트 조회", description = "공지사항이 배포된 테넌트 ID 목록을 조회합니다")
+    @GetMapping("/{noticeId}/tenants")
+    public ResponseEntity<ApiResponse<List<Long>>> getDistributedTenants(
+            @PathVariable Long noticeId
+    ) {
+        List<Long> tenantIds = noticeService.getDistributedTenantIds(noticeId);
+        return ResponseEntity.ok(ApiResponse.success(tenantIds));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notice/dto/request/CreateNoticeRequest.java
+++ b/src/main/java/com/mzc/lp/domain/notice/dto/request/CreateNoticeRequest.java
@@ -1,0 +1,25 @@
+package com.mzc.lp.domain.notice.dto.request;
+
+import com.mzc.lp.domain.notice.constant.NoticeType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.Instant;
+
+public record CreateNoticeRequest(
+        @NotBlank
+        @Size(max = 200)
+        String title,
+
+        @NotBlank
+        String content,
+
+        @NotNull
+        NoticeType type,
+
+        Boolean isPinned,
+
+        Instant expiredAt
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/notice/dto/request/DistributeNoticeRequest.java
+++ b/src/main/java/com/mzc/lp/domain/notice/dto/request/DistributeNoticeRequest.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.notice.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record DistributeNoticeRequest(
+        @NotEmpty
+        List<Long> tenantIds
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/notice/dto/request/UpdateNoticeRequest.java
+++ b/src/main/java/com/mzc/lp/domain/notice/dto/request/UpdateNoticeRequest.java
@@ -1,0 +1,20 @@
+package com.mzc.lp.domain.notice.dto.request;
+
+import com.mzc.lp.domain.notice.constant.NoticeType;
+import jakarta.validation.constraints.Size;
+
+import java.time.Instant;
+
+public record UpdateNoticeRequest(
+        @Size(max = 200)
+        String title,
+
+        String content,
+
+        NoticeType type,
+
+        Boolean isPinned,
+
+        Instant expiredAt
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/notice/dto/response/NoticeResponse.java
+++ b/src/main/java/com/mzc/lp/domain/notice/dto/response/NoticeResponse.java
@@ -1,0 +1,56 @@
+package com.mzc.lp.domain.notice.dto.response;
+
+import com.mzc.lp.domain.notice.constant.NoticeStatus;
+import com.mzc.lp.domain.notice.constant.NoticeType;
+import com.mzc.lp.domain.notice.entity.Notice;
+
+import java.time.Instant;
+
+public record NoticeResponse(
+        Long id,
+        String title,
+        String content,
+        NoticeType type,
+        NoticeStatus status,
+        Boolean isPinned,
+        Instant publishedAt,
+        Instant expiredAt,
+        Long createdBy,
+        Long distributionCount,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static NoticeResponse from(Notice notice) {
+        return new NoticeResponse(
+                notice.getId(),
+                notice.getTitle(),
+                notice.getContent(),
+                notice.getType(),
+                notice.getStatus(),
+                notice.getIsPinned(),
+                notice.getPublishedAt(),
+                notice.getExpiredAt(),
+                notice.getCreatedBy(),
+                null,
+                notice.getCreatedAt(),
+                notice.getUpdatedAt()
+        );
+    }
+
+    public static NoticeResponse from(Notice notice, Long distributionCount) {
+        return new NoticeResponse(
+                notice.getId(),
+                notice.getTitle(),
+                notice.getContent(),
+                notice.getType(),
+                notice.getStatus(),
+                notice.getIsPinned(),
+                notice.getPublishedAt(),
+                notice.getExpiredAt(),
+                notice.getCreatedBy(),
+                distributionCount,
+                notice.getCreatedAt(),
+                notice.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notice/entity/Notice.java
+++ b/src/main/java/com/mzc/lp/domain/notice/entity/Notice.java
@@ -1,0 +1,105 @@
+package com.mzc.lp.domain.notice.entity;
+
+import com.mzc.lp.common.entity.BaseTimeEntity;
+import com.mzc.lp.domain.notice.constant.NoticeStatus;
+import com.mzc.lp.domain.notice.constant.NoticeType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+/**
+ * 공지사항 엔티티 (SA 전용)
+ * 시스템 전체 또는 특정 테넌트에 배포되는 공지사항
+ */
+@Entity
+@Table(name = "notices")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notice extends BaseTimeEntity {
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private NoticeType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private NoticeStatus status;
+
+    @Column(nullable = false)
+    private Boolean isPinned = false;
+
+    @Column
+    private Instant publishedAt;
+
+    @Column
+    private Instant expiredAt;
+
+    @Column(nullable = false)
+    private Long createdBy;
+
+    // 정적 팩토리 메서드
+    public static Notice create(String title, String content, NoticeType type, Long createdBy) {
+        Notice notice = new Notice();
+        notice.title = title;
+        notice.content = content;
+        notice.type = type;
+        notice.status = NoticeStatus.DRAFT;
+        notice.createdBy = createdBy;
+        return notice;
+    }
+
+    // 비즈니스 메서드
+    public void update(String title, String content, NoticeType type) {
+        if (title != null && !title.isBlank()) {
+            this.title = title;
+        }
+        if (content != null && !content.isBlank()) {
+            this.content = content;
+        }
+        if (type != null) {
+            this.type = type;
+        }
+    }
+
+    public void publish() {
+        this.status = NoticeStatus.PUBLISHED;
+        this.publishedAt = Instant.now();
+    }
+
+    public void archive() {
+        this.status = NoticeStatus.ARCHIVED;
+    }
+
+    public void setExpiration(Instant expiredAt) {
+        this.expiredAt = expiredAt;
+    }
+
+    public void pin() {
+        this.isPinned = true;
+    }
+
+    public void unpin() {
+        this.isPinned = false;
+    }
+
+    public boolean isPublished() {
+        return this.status == NoticeStatus.PUBLISHED;
+    }
+
+    public boolean isDraft() {
+        return this.status == NoticeStatus.DRAFT;
+    }
+
+    public boolean isExpired() {
+        return this.expiredAt != null && Instant.now().isAfter(this.expiredAt);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notice/entity/NoticeDistribution.java
+++ b/src/main/java/com/mzc/lp/domain/notice/entity/NoticeDistribution.java
@@ -1,0 +1,42 @@
+package com.mzc.lp.domain.notice.entity;
+
+import com.mzc.lp.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 공지사항 테넌트 배포 엔티티
+ * 특정 테넌트에 공지사항을 배포
+ */
+@Entity
+@Table(name = "notice_distributions", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"notice_id", "tenant_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoticeDistribution extends BaseTimeEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id", nullable = false)
+    private Notice notice;
+
+    @Column(name = "tenant_id", nullable = false)
+    private Long tenantId;
+
+    @Column(nullable = false)
+    private Boolean isRead = false;
+
+    // 정적 팩토리 메서드
+    public static NoticeDistribution create(Notice notice, Long tenantId) {
+        NoticeDistribution distribution = new NoticeDistribution();
+        distribution.notice = notice;
+        distribution.tenantId = tenantId;
+        return distribution;
+    }
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notice/exception/NoticeNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/notice/exception/NoticeNotFoundException.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.notice.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class NoticeNotFoundException extends BusinessException {
+
+    public NoticeNotFoundException(Long noticeId) {
+        super(ErrorCode.NOTICE_NOT_FOUND, "Notice not found: " + noticeId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notice/repository/NoticeDistributionRepository.java
+++ b/src/main/java/com/mzc/lp/domain/notice/repository/NoticeDistributionRepository.java
@@ -4,6 +4,7 @@ import com.mzc.lp.domain.notice.entity.NoticeDistribution;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -14,13 +15,16 @@ import java.util.Optional;
 @Repository
 public interface NoticeDistributionRepository extends JpaRepository<NoticeDistribution, Long> {
 
-    List<NoticeDistribution> findByNoticeId(Long noticeId);
+    @Query("SELECT nd FROM NoticeDistribution nd WHERE nd.notice.id = :noticeId")
+    List<NoticeDistribution> findByNoticeId(@Param("noticeId") Long noticeId);
 
     Page<NoticeDistribution> findByTenantId(Long tenantId, Pageable pageable);
 
-    Optional<NoticeDistribution> findByNoticeIdAndTenantId(Long noticeId, Long tenantId);
+    @Query("SELECT nd FROM NoticeDistribution nd WHERE nd.notice.id = :noticeId AND nd.tenantId = :tenantId")
+    Optional<NoticeDistribution> findByNoticeIdAndTenantId(@Param("noticeId") Long noticeId, @Param("tenantId") Long tenantId);
 
-    boolean existsByNoticeIdAndTenantId(Long noticeId, Long tenantId);
+    @Query("SELECT CASE WHEN COUNT(nd) > 0 THEN true ELSE false END FROM NoticeDistribution nd WHERE nd.notice.id = :noticeId AND nd.tenantId = :tenantId")
+    boolean existsByNoticeIdAndTenantId(@Param("noticeId") Long noticeId, @Param("tenantId") Long tenantId);
 
     @Query("SELECT nd FROM NoticeDistribution nd " +
             "JOIN nd.notice n " +
@@ -28,8 +32,10 @@ public interface NoticeDistributionRepository extends JpaRepository<NoticeDistri
             "ORDER BY n.isPinned DESC, n.publishedAt DESC")
     Page<NoticeDistribution> findPublishedByTenantId(@Param("tenantId") Long tenantId, Pageable pageable);
 
-    @Query("SELECT COUNT(nd) FROM NoticeDistribution nd WHERE nd.noticeId = :noticeId")
+    @Query("SELECT COUNT(nd) FROM NoticeDistribution nd WHERE nd.notice.id = :noticeId")
     long countByNoticeId(@Param("noticeId") Long noticeId);
 
-    void deleteByNoticeId(Long noticeId);
+    @Modifying
+    @Query("DELETE FROM NoticeDistribution nd WHERE nd.notice.id = :noticeId")
+    void deleteByNoticeId(@Param("noticeId") Long noticeId);
 }

--- a/src/main/java/com/mzc/lp/domain/notice/repository/NoticeDistributionRepository.java
+++ b/src/main/java/com/mzc/lp/domain/notice/repository/NoticeDistributionRepository.java
@@ -1,0 +1,35 @@
+package com.mzc.lp.domain.notice.repository;
+
+import com.mzc.lp.domain.notice.entity.NoticeDistribution;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface NoticeDistributionRepository extends JpaRepository<NoticeDistribution, Long> {
+
+    List<NoticeDistribution> findByNoticeId(Long noticeId);
+
+    Page<NoticeDistribution> findByTenantId(Long tenantId, Pageable pageable);
+
+    Optional<NoticeDistribution> findByNoticeIdAndTenantId(Long noticeId, Long tenantId);
+
+    boolean existsByNoticeIdAndTenantId(Long noticeId, Long tenantId);
+
+    @Query("SELECT nd FROM NoticeDistribution nd " +
+            "JOIN nd.notice n " +
+            "WHERE nd.tenantId = :tenantId AND n.status = 'PUBLISHED' " +
+            "ORDER BY n.isPinned DESC, n.publishedAt DESC")
+    Page<NoticeDistribution> findPublishedByTenantId(@Param("tenantId") Long tenantId, Pageable pageable);
+
+    @Query("SELECT COUNT(nd) FROM NoticeDistribution nd WHERE nd.noticeId = :noticeId")
+    long countByNoticeId(@Param("noticeId") Long noticeId);
+
+    void deleteByNoticeId(Long noticeId);
+}

--- a/src/main/java/com/mzc/lp/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/mzc/lp/domain/notice/repository/NoticeRepository.java
@@ -1,0 +1,38 @@
+package com.mzc.lp.domain.notice.repository;
+
+import com.mzc.lp.domain.notice.constant.NoticeStatus;
+import com.mzc.lp.domain.notice.constant.NoticeType;
+import com.mzc.lp.domain.notice.entity.Notice;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+    Page<Notice> findByStatus(NoticeStatus status, Pageable pageable);
+
+    Page<Notice> findByType(NoticeType type, Pageable pageable);
+
+    Page<Notice> findByStatusAndType(NoticeStatus status, NoticeType type, Pageable pageable);
+
+    @Query("SELECT n FROM Notice n WHERE n.status = :status AND n.isPinned = true ORDER BY n.publishedAt DESC")
+    List<Notice> findPinnedByStatus(@Param("status") NoticeStatus status);
+
+    @Query("SELECT n FROM Notice n WHERE " +
+            "(LOWER(n.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
+            "LOWER(n.content) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+    Page<Notice> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+    @Query("SELECT n FROM Notice n WHERE n.status = :status AND " +
+            "(LOWER(n.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
+            "LOWER(n.content) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+    Page<Notice> searchByKeywordAndStatus(@Param("keyword") String keyword,
+                                          @Param("status") NoticeStatus status,
+                                          Pageable pageable);
+}

--- a/src/main/java/com/mzc/lp/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/mzc/lp/domain/notice/service/NoticeService.java
@@ -1,0 +1,38 @@
+package com.mzc.lp.domain.notice.service;
+
+import com.mzc.lp.domain.notice.constant.NoticeStatus;
+import com.mzc.lp.domain.notice.constant.NoticeType;
+import com.mzc.lp.domain.notice.dto.request.CreateNoticeRequest;
+import com.mzc.lp.domain.notice.dto.request.DistributeNoticeRequest;
+import com.mzc.lp.domain.notice.dto.request.UpdateNoticeRequest;
+import com.mzc.lp.domain.notice.dto.response.NoticeResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface NoticeService {
+
+    // CRUD
+    NoticeResponse createNotice(CreateNoticeRequest request, Long createdBy);
+
+    Page<NoticeResponse> getNotices(String keyword, NoticeStatus status, NoticeType type, Pageable pageable);
+
+    NoticeResponse getNotice(Long noticeId);
+
+    NoticeResponse updateNotice(Long noticeId, UpdateNoticeRequest request);
+
+    void deleteNotice(Long noticeId);
+
+    // 상태 변경
+    NoticeResponse publishNotice(Long noticeId);
+
+    NoticeResponse archiveNotice(Long noticeId);
+
+    // 배포
+    void distributeNotice(Long noticeId, DistributeNoticeRequest request);
+
+    void distributeToAllTenants(Long noticeId);
+
+    List<Long> getDistributedTenantIds(Long noticeId);
+}

--- a/src/main/java/com/mzc/lp/domain/notice/service/NoticeServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/notice/service/NoticeServiceImpl.java
@@ -1,0 +1,187 @@
+package com.mzc.lp.domain.notice.service;
+
+import com.mzc.lp.domain.notice.constant.NoticeStatus;
+import com.mzc.lp.domain.notice.constant.NoticeType;
+import com.mzc.lp.domain.notice.dto.request.CreateNoticeRequest;
+import com.mzc.lp.domain.notice.dto.request.DistributeNoticeRequest;
+import com.mzc.lp.domain.notice.dto.request.UpdateNoticeRequest;
+import com.mzc.lp.domain.notice.dto.response.NoticeResponse;
+import com.mzc.lp.domain.notice.entity.Notice;
+import com.mzc.lp.domain.notice.entity.NoticeDistribution;
+import com.mzc.lp.domain.notice.exception.NoticeNotFoundException;
+import com.mzc.lp.domain.notice.repository.NoticeDistributionRepository;
+import com.mzc.lp.domain.notice.repository.NoticeRepository;
+import com.mzc.lp.domain.tenant.repository.TenantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeServiceImpl implements NoticeService {
+
+    private final NoticeRepository noticeRepository;
+    private final NoticeDistributionRepository noticeDistributionRepository;
+    private final TenantRepository tenantRepository;
+
+    @Override
+    @Transactional
+    public NoticeResponse createNotice(CreateNoticeRequest request, Long createdBy) {
+        Notice notice = Notice.create(
+                request.title(),
+                request.content(),
+                request.type(),
+                createdBy
+        );
+
+        if (request.isPinned() != null && request.isPinned()) {
+            notice.pin();
+        }
+
+        if (request.expiredAt() != null) {
+            notice.setExpiration(request.expiredAt());
+        }
+
+        Notice savedNotice = noticeRepository.save(notice);
+        return NoticeResponse.from(savedNotice, 0L);
+    }
+
+    @Override
+    public Page<NoticeResponse> getNotices(String keyword, NoticeStatus status, NoticeType type, Pageable pageable) {
+        Page<Notice> notices;
+
+        if (keyword != null && !keyword.isBlank()) {
+            if (status != null) {
+                notices = noticeRepository.searchByKeywordAndStatus(keyword, status, pageable);
+            } else {
+                notices = noticeRepository.searchByKeyword(keyword, pageable);
+            }
+        } else if (status != null && type != null) {
+            notices = noticeRepository.findByStatusAndType(status, type, pageable);
+        } else if (status != null) {
+            notices = noticeRepository.findByStatus(status, pageable);
+        } else if (type != null) {
+            notices = noticeRepository.findByType(type, pageable);
+        } else {
+            notices = noticeRepository.findAll(pageable);
+        }
+
+        return notices.map(notice -> {
+            long count = noticeDistributionRepository.countByNoticeId(notice.getId());
+            return NoticeResponse.from(notice, count);
+        });
+    }
+
+    @Override
+    public NoticeResponse getNotice(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new NoticeNotFoundException(noticeId));
+        long count = noticeDistributionRepository.countByNoticeId(noticeId);
+        return NoticeResponse.from(notice, count);
+    }
+
+    @Override
+    @Transactional
+    public NoticeResponse updateNotice(Long noticeId, UpdateNoticeRequest request) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new NoticeNotFoundException(noticeId));
+
+        notice.update(request.title(), request.content(), request.type());
+
+        if (request.isPinned() != null) {
+            if (request.isPinned()) {
+                notice.pin();
+            } else {
+                notice.unpin();
+            }
+        }
+
+        if (request.expiredAt() != null) {
+            notice.setExpiration(request.expiredAt());
+        }
+
+        long count = noticeDistributionRepository.countByNoticeId(noticeId);
+        return NoticeResponse.from(notice, count);
+    }
+
+    @Override
+    @Transactional
+    public void deleteNotice(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new NoticeNotFoundException(noticeId));
+
+        // 배포 정보도 함께 삭제
+        noticeDistributionRepository.deleteByNoticeId(noticeId);
+        noticeRepository.delete(notice);
+    }
+
+    @Override
+    @Transactional
+    public NoticeResponse publishNotice(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new NoticeNotFoundException(noticeId));
+
+        notice.publish();
+
+        long count = noticeDistributionRepository.countByNoticeId(noticeId);
+        return NoticeResponse.from(notice, count);
+    }
+
+    @Override
+    @Transactional
+    public NoticeResponse archiveNotice(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new NoticeNotFoundException(noticeId));
+
+        notice.archive();
+
+        long count = noticeDistributionRepository.countByNoticeId(noticeId);
+        return NoticeResponse.from(notice, count);
+    }
+
+    @Override
+    @Transactional
+    public void distributeNotice(Long noticeId, DistributeNoticeRequest request) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new NoticeNotFoundException(noticeId));
+
+        for (Long tenantId : request.tenantIds()) {
+            if (!noticeDistributionRepository.existsByNoticeIdAndTenantId(noticeId, tenantId)) {
+                NoticeDistribution distribution = NoticeDistribution.create(notice, tenantId);
+                noticeDistributionRepository.save(distribution);
+            }
+        }
+    }
+
+    @Override
+    @Transactional
+    public void distributeToAllTenants(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new NoticeNotFoundException(noticeId));
+
+        List<Long> allTenantIds = tenantRepository.findAll()
+                .stream()
+                .map(t -> t.getId())
+                .toList();
+
+        for (Long tenantId : allTenantIds) {
+            if (!noticeDistributionRepository.existsByNoticeIdAndTenantId(noticeId, tenantId)) {
+                NoticeDistribution distribution = NoticeDistribution.create(notice, tenantId);
+                noticeDistributionRepository.save(distribution);
+            }
+        }
+    }
+
+    @Override
+    public List<Long> getDistributedTenantIds(Long noticeId) {
+        return noticeDistributionRepository.findByNoticeId(noticeId)
+                .stream()
+                .map(NoticeDistribution::getTenantId)
+                .toList();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
@@ -1,0 +1,88 @@
+package com.mzc.lp.domain.tenant.controller;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.domain.tenant.dto.request.UpdateTenantSettingsRequest;
+import com.mzc.lp.domain.tenant.dto.response.TenantSettingsResponse;
+import com.mzc.lp.domain.tenant.service.TenantSettingsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 테넌트 설정 컨트롤러
+ * TA(Tenant Admin)가 자신의 테넌트 설정을 관리
+ */
+@Tag(name = "Tenant Settings", description = "테넌트 설정 관리 API")
+@RestController
+@RequestMapping("/api/tenant/settings")
+@RequiredArgsConstructor
+public class TenantSettingsController {
+
+    private final TenantSettingsService tenantSettingsService;
+
+    @Operation(summary = "테넌트 설정 조회", description = "현재 테넌트의 설정을 조회합니다")
+    @GetMapping
+    @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'OPERATOR')")
+    public ResponseEntity<ApiResponse<TenantSettingsResponse>> getSettings() {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        TenantSettingsResponse response = tenantSettingsService.getSettings(tenantId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "테넌트 설정 업데이트", description = "현재 테넌트의 설정을 업데이트합니다")
+    @PutMapping
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<TenantSettingsResponse>> updateSettings(
+            @Valid @RequestBody UpdateTenantSettingsRequest request
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        TenantSettingsResponse response = tenantSettingsService.updateSettings(tenantId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "브랜딩 설정 업데이트", description = "로고, 색상 등 브랜딩 설정만 업데이트합니다")
+    @PatchMapping("/branding")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<TenantSettingsResponse>> updateBranding(
+            @Valid @RequestBody UpdateTenantSettingsRequest request
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        // 브랜딩 관련 필드만 포함된 요청 처리
+        UpdateTenantSettingsRequest brandingRequest = new UpdateTenantSettingsRequest(
+                request.logoUrl(),
+                request.faviconUrl(),
+                request.primaryColor(),
+                request.secondaryColor(),
+                request.fontFamily(),
+                null, null, null, null, null, null,
+                null, null, null, null, null, null, null
+        );
+        TenantSettingsResponse response = tenantSettingsService.updateSettings(tenantId, brandingRequest);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "사용자 관리 설정 업데이트", description = "사용자 가입, 인증 관련 설정만 업데이트합니다")
+    @PatchMapping("/user-management")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<TenantSettingsResponse>> updateUserManagement(
+            @Valid @RequestBody UpdateTenantSettingsRequest request
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        // 사용자 관리 관련 필드만 포함된 요청 처리
+        UpdateTenantSettingsRequest userManagementRequest = new UpdateTenantSettingsRequest(
+                null, null, null, null, null, null, null,
+                request.allowSelfRegistration(),
+                request.requireEmailVerification(),
+                request.requireApproval(),
+                request.allowedEmailDomains(),
+                null, null, null, null, null, null, null
+        );
+        TenantSettingsResponse response = tenantSettingsService.updateSettings(tenantId, userManagementRequest);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateTenantSettingsRequest.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateTenantSettingsRequest.java
@@ -1,0 +1,58 @@
+package com.mzc.lp.domain.tenant.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+/**
+ * 테넌트 설정 업데이트 요청 DTO
+ */
+public record UpdateTenantSettingsRequest(
+        // 브랜딩 설정
+        @Size(max = 500)
+        String logoUrl,
+
+        @Size(max = 500)
+        String faviconUrl,
+
+        @Size(max = 7)
+        String primaryColor,
+
+        @Size(max = 7)
+        String secondaryColor,
+
+        @Size(max = 100)
+        String fontFamily,
+
+        // 일반 설정
+        @Size(max = 10)
+        String defaultLanguage,
+
+        @Size(max = 50)
+        String timezone,
+
+        // 사용자 관리 설정
+        Boolean allowSelfRegistration,
+
+        Boolean requireEmailVerification,
+
+        Boolean requireApproval,
+
+        @Size(max = 500)
+        String allowedEmailDomains,
+
+        // 제한 설정
+        Integer maxUsersCount,
+
+        Integer maxStorageGB,
+
+        Integer maxCourses,
+
+        // 기능 활성화 설정
+        Boolean allowCustomDomain,
+
+        Boolean allowCustomBranding,
+
+        Boolean ssoEnabled,
+
+        Boolean apiAccessEnabled
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/response/TenantSettingsResponse.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/response/TenantSettingsResponse.java
@@ -1,0 +1,71 @@
+package com.mzc.lp.domain.tenant.dto.response;
+
+import com.mzc.lp.domain.tenant.entity.TenantSettings;
+
+import java.time.Instant;
+
+/**
+ * 테넌트 설정 응답 DTO
+ */
+public record TenantSettingsResponse(
+        Long id,
+        Long tenantId,
+
+        // 브랜딩 설정
+        String logoUrl,
+        String faviconUrl,
+        String primaryColor,
+        String secondaryColor,
+        String fontFamily,
+
+        // 일반 설정
+        String defaultLanguage,
+        String timezone,
+
+        // 사용자 관리 설정
+        Boolean allowSelfRegistration,
+        Boolean requireEmailVerification,
+        Boolean requireApproval,
+        String allowedEmailDomains,
+
+        // 제한 설정
+        Integer maxUsersCount,
+        Integer maxStorageGB,
+        Integer maxCourses,
+
+        // 기능 활성화 설정
+        Boolean allowCustomDomain,
+        Boolean allowCustomBranding,
+        Boolean ssoEnabled,
+        Boolean apiAccessEnabled,
+
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static TenantSettingsResponse from(TenantSettings settings) {
+        return new TenantSettingsResponse(
+                settings.getId(),
+                settings.getTenant().getId(),
+                settings.getLogoUrl(),
+                settings.getFaviconUrl(),
+                settings.getPrimaryColor(),
+                settings.getSecondaryColor(),
+                settings.getFontFamily(),
+                settings.getDefaultLanguage(),
+                settings.getTimezone(),
+                settings.getAllowSelfRegistration(),
+                settings.getRequireEmailVerification(),
+                settings.getRequireApproval(),
+                settings.getAllowedEmailDomains(),
+                settings.getMaxUsersCount(),
+                settings.getMaxStorageGB(),
+                settings.getMaxCourses(),
+                settings.getAllowCustomDomain(),
+                settings.getAllowCustomBranding(),
+                settings.getSsoEnabled(),
+                settings.getApiAccessEnabled(),
+                settings.getCreatedAt(),
+                settings.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/entity/TenantSettings.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/entity/TenantSettings.java
@@ -1,0 +1,148 @@
+package com.mzc.lp.domain.tenant.entity;
+
+import com.mzc.lp.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 테넌트 설정 엔티티
+ * 브랜딩, 사용자 관리, 기능 활성화 등의 설정을 관리
+ */
+@Entity
+@Table(name = "tenant_settings")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TenantSettings extends BaseTimeEntity {
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tenant_id", nullable = false, unique = true)
+    private Tenant tenant;
+
+    // ============================================
+    // 브랜딩 설정
+    // ============================================
+
+    @Column(length = 500)
+    private String logoUrl;
+
+    @Column(length = 500)
+    private String faviconUrl;
+
+    @Column(length = 7)
+    private String primaryColor;
+
+    @Column(length = 7)
+    private String secondaryColor;
+
+    @Column(length = 100)
+    private String fontFamily;
+
+    // ============================================
+    // 일반 설정
+    // ============================================
+
+    @Column(length = 10, nullable = false)
+    private String defaultLanguage = "ko";
+
+    @Column(length = 50, nullable = false)
+    private String timezone = "Asia/Seoul";
+
+    // ============================================
+    // 사용자 관리 설정
+    // ============================================
+
+    @Column(nullable = false)
+    private Boolean allowSelfRegistration = true;
+
+    @Column(nullable = false)
+    private Boolean requireEmailVerification = true;
+
+    @Column(nullable = false)
+    private Boolean requireApproval = false;
+
+    @Column(length = 500)
+    private String allowedEmailDomains;
+
+    // ============================================
+    // 제한 설정
+    // ============================================
+
+    @Column(nullable = false)
+    private Integer maxUsersCount = 100;
+
+    @Column(nullable = false)
+    private Integer maxStorageGB = 10;
+
+    @Column(nullable = false)
+    private Integer maxCourses = 50;
+
+    // ============================================
+    // 기능 활성화 설정
+    // ============================================
+
+    @Column(nullable = false)
+    private Boolean allowCustomDomain = false;
+
+    @Column(nullable = false)
+    private Boolean allowCustomBranding = false;
+
+    @Column(nullable = false)
+    private Boolean ssoEnabled = false;
+
+    @Column(nullable = false)
+    private Boolean apiAccessEnabled = false;
+
+    // 정적 팩토리 메서드
+    public static TenantSettings createDefault(Tenant tenant) {
+        TenantSettings settings = new TenantSettings();
+        settings.tenant = tenant;
+        settings.primaryColor = "#3B82F6";
+        settings.secondaryColor = "#1E40AF";
+        return settings;
+    }
+
+    // 브랜딩 업데이트
+    public void updateBranding(String logoUrl, String faviconUrl,
+                               String primaryColor, String secondaryColor, String fontFamily) {
+        this.logoUrl = logoUrl;
+        this.faviconUrl = faviconUrl;
+        if (primaryColor != null) this.primaryColor = primaryColor;
+        if (secondaryColor != null) this.secondaryColor = secondaryColor;
+        this.fontFamily = fontFamily;
+    }
+
+    // 일반 설정 업데이트
+    public void updateGeneralSettings(String defaultLanguage, String timezone) {
+        if (defaultLanguage != null) this.defaultLanguage = defaultLanguage;
+        if (timezone != null) this.timezone = timezone;
+    }
+
+    // 사용자 관리 설정 업데이트
+    public void updateUserManagementSettings(Boolean allowSelfRegistration,
+                                             Boolean requireEmailVerification,
+                                             Boolean requireApproval,
+                                             String allowedEmailDomains) {
+        if (allowSelfRegistration != null) this.allowSelfRegistration = allowSelfRegistration;
+        if (requireEmailVerification != null) this.requireEmailVerification = requireEmailVerification;
+        if (requireApproval != null) this.requireApproval = requireApproval;
+        this.allowedEmailDomains = allowedEmailDomains;
+    }
+
+    // 제한 설정 업데이트
+    public void updateLimits(Integer maxUsersCount, Integer maxStorageGB, Integer maxCourses) {
+        if (maxUsersCount != null) this.maxUsersCount = maxUsersCount;
+        if (maxStorageGB != null) this.maxStorageGB = maxStorageGB;
+        if (maxCourses != null) this.maxCourses = maxCourses;
+    }
+
+    // 기능 활성화 설정 업데이트
+    public void updateFeatures(Boolean allowCustomDomain, Boolean allowCustomBranding,
+                               Boolean ssoEnabled, Boolean apiAccessEnabled) {
+        if (allowCustomDomain != null) this.allowCustomDomain = allowCustomDomain;
+        if (allowCustomBranding != null) this.allowCustomBranding = allowCustomBranding;
+        if (ssoEnabled != null) this.ssoEnabled = ssoEnabled;
+        if (apiAccessEnabled != null) this.apiAccessEnabled = apiAccessEnabled;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/repository/TenantSettingsRepository.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/repository/TenantSettingsRepository.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.tenant.repository;
+
+import com.mzc.lp.domain.tenant.entity.TenantSettings;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TenantSettingsRepository extends JpaRepository<TenantSettings, Long> {
+
+    Optional<TenantSettings> findByTenantId(Long tenantId);
+
+    boolean existsByTenantId(Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsService.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsService.java
@@ -1,0 +1,32 @@
+package com.mzc.lp.domain.tenant.service;
+
+import com.mzc.lp.domain.tenant.dto.request.UpdateTenantSettingsRequest;
+import com.mzc.lp.domain.tenant.dto.response.TenantSettingsResponse;
+
+/**
+ * 테넌트 설정 서비스 인터페이스
+ */
+public interface TenantSettingsService {
+
+    /**
+     * 테넌트 설정 조회
+     * @param tenantId 테넌트 ID
+     * @return 테넌트 설정
+     */
+    TenantSettingsResponse getSettings(Long tenantId);
+
+    /**
+     * 테넌트 설정 업데이트
+     * @param tenantId 테넌트 ID
+     * @param request 업데이트 요청
+     * @return 업데이트된 설정
+     */
+    TenantSettingsResponse updateSettings(Long tenantId, UpdateTenantSettingsRequest request);
+
+    /**
+     * 테넌트 설정 초기화 (기본값으로 생성)
+     * @param tenantId 테넌트 ID
+     * @return 생성된 설정
+     */
+    TenantSettingsResponse initializeSettings(Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsServiceImpl.java
@@ -1,0 +1,94 @@
+package com.mzc.lp.domain.tenant.service;
+
+import com.mzc.lp.domain.tenant.dto.request.UpdateTenantSettingsRequest;
+import com.mzc.lp.domain.tenant.dto.response.TenantSettingsResponse;
+import com.mzc.lp.domain.tenant.entity.Tenant;
+import com.mzc.lp.domain.tenant.entity.TenantSettings;
+import com.mzc.lp.domain.tenant.exception.TenantDomainNotFoundException;
+import com.mzc.lp.domain.tenant.repository.TenantRepository;
+import com.mzc.lp.domain.tenant.repository.TenantSettingsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TenantSettingsServiceImpl implements TenantSettingsService {
+
+    private final TenantSettingsRepository tenantSettingsRepository;
+    private final TenantRepository tenantRepository;
+
+    @Override
+    public TenantSettingsResponse getSettings(Long tenantId) {
+        TenantSettings settings = tenantSettingsRepository.findByTenantId(tenantId)
+                .orElseGet(() -> initializeAndGet(tenantId));
+        return TenantSettingsResponse.from(settings);
+    }
+
+    @Override
+    @Transactional
+    public TenantSettingsResponse updateSettings(Long tenantId, UpdateTenantSettingsRequest request) {
+        TenantSettings settings = tenantSettingsRepository.findByTenantId(tenantId)
+                .orElseGet(() -> initializeAndGet(tenantId));
+
+        // 브랜딩 설정 업데이트
+        settings.updateBranding(
+                request.logoUrl(),
+                request.faviconUrl(),
+                request.primaryColor(),
+                request.secondaryColor(),
+                request.fontFamily()
+        );
+
+        // 일반 설정 업데이트
+        settings.updateGeneralSettings(
+                request.defaultLanguage(),
+                request.timezone()
+        );
+
+        // 사용자 관리 설정 업데이트
+        settings.updateUserManagementSettings(
+                request.allowSelfRegistration(),
+                request.requireEmailVerification(),
+                request.requireApproval(),
+                request.allowedEmailDomains()
+        );
+
+        // 제한 설정 업데이트
+        settings.updateLimits(
+                request.maxUsersCount(),
+                request.maxStorageGB(),
+                request.maxCourses()
+        );
+
+        // 기능 활성화 설정 업데이트
+        settings.updateFeatures(
+                request.allowCustomDomain(),
+                request.allowCustomBranding(),
+                request.ssoEnabled(),
+                request.apiAccessEnabled()
+        );
+
+        return TenantSettingsResponse.from(settings);
+    }
+
+    @Override
+    @Transactional
+    public TenantSettingsResponse initializeSettings(Long tenantId) {
+        if (tenantSettingsRepository.existsByTenantId(tenantId)) {
+            return getSettings(tenantId);
+        }
+
+        TenantSettings settings = initializeAndGet(tenantId);
+        return TenantSettingsResponse.from(settings);
+    }
+
+    private TenantSettings initializeAndGet(Long tenantId) {
+        Tenant tenant = tenantRepository.findById(tenantId)
+                .orElseThrow(() -> new TenantDomainNotFoundException("Tenant not found: " + tenantId));
+
+        TenantSettings settings = TenantSettings.createDefault(tenant);
+        return tenantSettingsRepository.save(settings);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/controller/UserGroupController.java
+++ b/src/main/java/com/mzc/lp/domain/user/controller/UserGroupController.java
@@ -1,0 +1,116 @@
+package com.mzc.lp.domain.user.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.domain.user.dto.request.CreateUserGroupRequest;
+import com.mzc.lp.domain.user.dto.request.UpdateUserGroupRequest;
+import com.mzc.lp.domain.user.dto.response.UserGroupResponse;
+import com.mzc.lp.domain.user.service.UserGroupService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 사용자 그룹 컨트롤러
+ * TA/Operator가 테넌트 내 사용자 그룹을 관리
+ */
+@Tag(name = "User Groups", description = "사용자 그룹 관리 API")
+@RestController
+@RequestMapping("/api/groups")
+@RequiredArgsConstructor
+public class UserGroupController {
+
+    private final UserGroupService userGroupService;
+
+    @Operation(summary = "그룹 생성", description = "새로운 사용자 그룹을 생성합니다")
+    @PostMapping
+    @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'OPERATOR')")
+    public ResponseEntity<ApiResponse<UserGroupResponse>> createGroup(
+            @Valid @RequestBody CreateUserGroupRequest request
+    ) {
+        UserGroupResponse response = userGroupService.createGroup(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "그룹 목록 조회", description = "사용자 그룹 목록을 조회합니다")
+    @GetMapping
+    @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'OPERATOR')")
+    public ResponseEntity<ApiResponse<Page<UserGroupResponse>>> getGroups(
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<UserGroupResponse> response = userGroupService.getGroups(keyword, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "활성 그룹 목록 조회", description = "활성화된 모든 그룹을 조회합니다")
+    @GetMapping("/active")
+    @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'OPERATOR')")
+    public ResponseEntity<ApiResponse<List<UserGroupResponse>>> getActiveGroups() {
+        List<UserGroupResponse> response = userGroupService.getAllActiveGroups();
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "그룹 상세 조회", description = "특정 그룹의 상세 정보를 조회합니다")
+    @GetMapping("/{groupId}")
+    @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'OPERATOR')")
+    public ResponseEntity<ApiResponse<UserGroupResponse>> getGroup(
+            @PathVariable Long groupId
+    ) {
+        UserGroupResponse response = userGroupService.getGroup(groupId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "그룹 수정", description = "그룹 정보를 수정합니다")
+    @PutMapping("/{groupId}")
+    @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'OPERATOR')")
+    public ResponseEntity<ApiResponse<UserGroupResponse>> updateGroup(
+            @PathVariable Long groupId,
+            @Valid @RequestBody UpdateUserGroupRequest request
+    ) {
+        UserGroupResponse response = userGroupService.updateGroup(groupId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "그룹 삭제", description = "그룹을 삭제합니다")
+    @DeleteMapping("/{groupId}")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<Void> deleteGroup(
+            @PathVariable Long groupId
+    ) {
+        userGroupService.deleteGroup(groupId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "그룹에 멤버 추가", description = "그룹에 사용자를 추가합니다")
+    @PostMapping("/{groupId}/members/{userId}")
+    @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'OPERATOR')")
+    public ResponseEntity<Void> addMember(
+            @PathVariable Long groupId,
+            @PathVariable Long userId
+    ) {
+        userGroupService.addMember(groupId, userId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "그룹에서 멤버 제거", description = "그룹에서 사용자를 제거합니다")
+    @DeleteMapping("/{groupId}/members/{userId}")
+    @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'OPERATOR')")
+    public ResponseEntity<Void> removeMember(
+            @PathVariable Long groupId,
+            @PathVariable Long userId
+    ) {
+        userGroupService.removeMember(groupId, userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/CreateUserGroupRequest.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/CreateUserGroupRequest.java
@@ -1,0 +1,14 @@
+package com.mzc.lp.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateUserGroupRequest(
+        @NotBlank
+        @Size(max = 100)
+        String name,
+
+        @Size(max = 500)
+        String description
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/UpdateUserGroupRequest.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/UpdateUserGroupRequest.java
@@ -1,0 +1,14 @@
+package com.mzc.lp.domain.user.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record UpdateUserGroupRequest(
+        @Size(max = 100)
+        String name,
+
+        @Size(max = 500)
+        String description,
+
+        Boolean isActive
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/user/dto/response/UserGroupResponse.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/response/UserGroupResponse.java
@@ -1,0 +1,27 @@
+package com.mzc.lp.domain.user.dto.response;
+
+import com.mzc.lp.domain.user.entity.UserGroup;
+
+import java.time.Instant;
+
+public record UserGroupResponse(
+        Long id,
+        String name,
+        String description,
+        Boolean isActive,
+        Integer memberCount,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static UserGroupResponse from(UserGroup group) {
+        return new UserGroupResponse(
+                group.getId(),
+                group.getName(),
+                group.getDescription(),
+                group.getIsActive(),
+                group.getMemberCount(),
+                group.getCreatedAt(),
+                group.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/entity/UserGroup.java
+++ b/src/main/java/com/mzc/lp/domain/user/entity/UserGroup.java
@@ -1,0 +1,76 @@
+package com.mzc.lp.domain.user.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * 사용자 그룹 엔티티
+ * 테넌트 내에서 사용자를 그룹화하여 관리
+ */
+@Entity
+@Table(name = "user_groups", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"tenant_id", "name"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserGroup extends TenantEntity {
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(length = 500)
+    private String description;
+
+    @Column(nullable = false)
+    private Boolean isActive = true;
+
+    @ManyToMany
+    @JoinTable(
+            name = "user_group_members",
+            joinColumns = @JoinColumn(name = "group_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id")
+    )
+    private Set<User> members = new HashSet<>();
+
+    // 정적 팩토리 메서드
+    public static UserGroup create(String name, String description) {
+        UserGroup group = new UserGroup();
+        group.name = name;
+        group.description = description;
+        return group;
+    }
+
+    // 비즈니스 메서드
+    public void update(String name, String description) {
+        if (name != null && !name.isBlank()) {
+            this.name = name;
+        }
+        this.description = description;
+    }
+
+    public void activate() {
+        this.isActive = true;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    public void addMember(User user) {
+        this.members.add(user);
+    }
+
+    public void removeMember(User user) {
+        this.members.remove(user);
+    }
+
+    public int getMemberCount() {
+        return this.members.size();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/exception/DuplicateUserGroupNameException.java
+++ b/src/main/java/com/mzc/lp/domain/user/exception/DuplicateUserGroupNameException.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.user.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class DuplicateUserGroupNameException extends BusinessException {
+
+    public DuplicateUserGroupNameException(String name) {
+        super(ErrorCode.DUPLICATE_USER_GROUP_NAME, "User group name already exists: " + name);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/exception/UserGroupNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/user/exception/UserGroupNotFoundException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.user.exception;
+
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.common.constant.ErrorCode;
+
+public class UserGroupNotFoundException extends BusinessException {
+
+    public UserGroupNotFoundException(String message) {
+        super(ErrorCode.USER_GROUP_NOT_FOUND, message);
+    }
+
+    public UserGroupNotFoundException(Long groupId) {
+        super(ErrorCode.USER_GROUP_NOT_FOUND, "User group not found: " + groupId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/repository/UserGroupRepository.java
+++ b/src/main/java/com/mzc/lp/domain/user/repository/UserGroupRepository.java
@@ -1,0 +1,37 @@
+package com.mzc.lp.domain.user.repository;
+
+import com.mzc.lp.domain.user.entity.UserGroup;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserGroupRepository extends JpaRepository<UserGroup, Long> {
+
+    @Query("SELECT g FROM UserGroup g WHERE g.tenantId = :tenantId")
+    List<UserGroup> findAllByTenantId(@Param("tenantId") Long tenantId);
+
+    @Query("SELECT g FROM UserGroup g WHERE g.tenantId = :tenantId")
+    Page<UserGroup> findAllByTenantId(@Param("tenantId") Long tenantId, Pageable pageable);
+
+    @Query("SELECT g FROM UserGroup g WHERE g.tenantId = :tenantId AND g.isActive = :isActive")
+    List<UserGroup> findAllByTenantIdAndIsActive(@Param("tenantId") Long tenantId, @Param("isActive") Boolean isActive);
+
+    @Query("SELECT g FROM UserGroup g WHERE g.tenantId = :tenantId AND g.id = :id")
+    Optional<UserGroup> findByIdAndTenantId(@Param("id") Long id, @Param("tenantId") Long tenantId);
+
+    @Query("SELECT g FROM UserGroup g WHERE g.tenantId = :tenantId AND g.name = :name")
+    Optional<UserGroup> findByTenantIdAndName(@Param("tenantId") Long tenantId, @Param("name") String name);
+
+    @Query("SELECT CASE WHEN COUNT(g) > 0 THEN true ELSE false END FROM UserGroup g WHERE g.tenantId = :tenantId AND g.name = :name")
+    boolean existsByTenantIdAndName(@Param("tenantId") Long tenantId, @Param("name") String name);
+
+    @Query("SELECT g FROM UserGroup g WHERE g.tenantId = :tenantId AND (LOWER(g.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(g.description) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+    Page<UserGroup> searchByKeyword(@Param("tenantId") Long tenantId, @Param("keyword") String keyword, Pageable pageable);
+}

--- a/src/main/java/com/mzc/lp/domain/user/service/UserGroupService.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserGroupService.java
@@ -1,0 +1,28 @@
+package com.mzc.lp.domain.user.service;
+
+import com.mzc.lp.domain.user.dto.request.CreateUserGroupRequest;
+import com.mzc.lp.domain.user.dto.request.UpdateUserGroupRequest;
+import com.mzc.lp.domain.user.dto.response.UserGroupResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface UserGroupService {
+
+    UserGroupResponse createGroup(CreateUserGroupRequest request);
+
+    Page<UserGroupResponse> getGroups(String keyword, Pageable pageable);
+
+    List<UserGroupResponse> getAllActiveGroups();
+
+    UserGroupResponse getGroup(Long groupId);
+
+    UserGroupResponse updateGroup(Long groupId, UpdateUserGroupRequest request);
+
+    void deleteGroup(Long groupId);
+
+    void addMember(Long groupId, Long userId);
+
+    void removeMember(Long groupId, Long userId);
+}

--- a/src/main/java/com/mzc/lp/domain/user/service/UserGroupServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserGroupServiceImpl.java
@@ -1,0 +1,143 @@
+package com.mzc.lp.domain.user.service;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.domain.user.dto.request.CreateUserGroupRequest;
+import com.mzc.lp.domain.user.dto.request.UpdateUserGroupRequest;
+import com.mzc.lp.domain.user.dto.response.UserGroupResponse;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.entity.UserGroup;
+import com.mzc.lp.domain.user.exception.DuplicateUserGroupNameException;
+import com.mzc.lp.domain.user.exception.UserGroupNotFoundException;
+import com.mzc.lp.domain.user.exception.UserNotFoundException;
+import com.mzc.lp.domain.user.repository.UserGroupRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserGroupServiceImpl implements UserGroupService {
+
+    private final UserGroupRepository userGroupRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public UserGroupResponse createGroup(CreateUserGroupRequest request) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 중복 이름 검증
+        if (userGroupRepository.existsByTenantIdAndName(tenantId, request.name())) {
+            throw new DuplicateUserGroupNameException(request.name());
+        }
+
+        UserGroup group = UserGroup.create(request.name(), request.description());
+        UserGroup savedGroup = userGroupRepository.save(group);
+
+        return UserGroupResponse.from(savedGroup);
+    }
+
+    @Override
+    public Page<UserGroupResponse> getGroups(String keyword, Pageable pageable) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        Page<UserGroup> groups;
+        if (keyword != null && !keyword.isBlank()) {
+            groups = userGroupRepository.searchByKeyword(tenantId, keyword, pageable);
+        } else {
+            groups = userGroupRepository.findAllByTenantId(tenantId, pageable);
+        }
+
+        return groups.map(UserGroupResponse::from);
+    }
+
+    @Override
+    public List<UserGroupResponse> getAllActiveGroups() {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        return userGroupRepository.findAllByTenantIdAndIsActive(tenantId, true)
+                .stream()
+                .map(UserGroupResponse::from)
+                .toList();
+    }
+
+    @Override
+    public UserGroupResponse getGroup(Long groupId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        UserGroup group = userGroupRepository.findByIdAndTenantId(groupId, tenantId)
+                .orElseThrow(() -> new UserGroupNotFoundException(groupId));
+        return UserGroupResponse.from(group);
+    }
+
+    @Override
+    @Transactional
+    public UserGroupResponse updateGroup(Long groupId, UpdateUserGroupRequest request) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        UserGroup group = userGroupRepository.findByIdAndTenantId(groupId, tenantId)
+                .orElseThrow(() -> new UserGroupNotFoundException(groupId));
+
+        // 이름 변경 시 중복 검증
+        if (request.name() != null && !request.name().equals(group.getName())) {
+            if (userGroupRepository.existsByTenantIdAndName(tenantId, request.name())) {
+                throw new DuplicateUserGroupNameException(request.name());
+            }
+        }
+
+        group.update(request.name(), request.description());
+
+        if (request.isActive() != null) {
+            if (request.isActive()) {
+                group.activate();
+            } else {
+                group.deactivate();
+            }
+        }
+
+        return UserGroupResponse.from(group);
+    }
+
+    @Override
+    @Transactional
+    public void deleteGroup(Long groupId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        UserGroup group = userGroupRepository.findByIdAndTenantId(groupId, tenantId)
+                .orElseThrow(() -> new UserGroupNotFoundException(groupId));
+
+        userGroupRepository.delete(group);
+    }
+
+    @Override
+    @Transactional
+    public void addMember(Long groupId, Long userId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        UserGroup group = userGroupRepository.findByIdAndTenantId(groupId, tenantId)
+                .orElseThrow(() -> new UserGroupNotFoundException(groupId));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        group.addMember(user);
+    }
+
+    @Override
+    @Transactional
+    public void removeMember(Long groupId, Long userId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        UserGroup group = userGroupRepository.findByIdAndTenantId(groupId, tenantId)
+                .orElseThrow(() -> new UserGroupNotFoundException(groupId));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        group.removeMember(user);
+    }
+}


### PR DESCRIPTION
## Summary

SA/TA 관리자 페이지에서 사용할 백엔드 API를 구현합니다. TenantSettings, UserGroup, Notice 도메인에 대한 CRUD API를 제공합니다.

## Related Issue

- Closes #213

## Changes

- **TenantSettings API (TA용)**
  - `TenantSettings` 엔티티: 브랜딩, 사용자관리, 제한, 기능 설정 저장
  - `GET/PUT /api/tenant/settings`: 전체 설정 조회/수정
  - `PATCH /api/tenant/settings/branding`: 브랜딩 설정 부분 수정
  - `PATCH /api/tenant/settings/user-management`: 사용자관리 설정 부분 수정

- **UserGroup API (TA용)**
  - `UserGroup` 엔티티: User와 ManyToMany 관계
  - `CRUD /api/groups`: 그룹 생성/조회/수정/삭제
  - `POST/DELETE /api/groups/{id}/members/{userId}`: 멤버 추가/제거

- **Notice API (SA용)**
  - `Notice`, `NoticeDistribution` 엔티티
  - `CRUD /api/sa/notices`: 공지사항 관리
  - `POST /api/sa/notices/{id}/publish`: 발행
  - `POST /api/sa/notices/{id}/archive`: 보관
  - `POST /api/sa/notices/{id}/distribute`: 특정 테넌트 배포
  - `POST /api/sa/notices/{id}/distribute-all`: 전체 테넌트 배포

- **ErrorCode 추가**
  - `USER_GROUP_NOT_FOUND (UG001)`
  - `DUPLICATE_USER_GROUP_NAME (UG002)`
  - `NOTICE_NOT_FOUND (NT001)`

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 프론트엔드 API 연동 이슈: #125 (mzc-lp-frontend)
- TenantSettings는 Tenant와 1:1 관계로 설계
- Notice는 전역 공지로 별도 distribution 테이블로 테넌트별 배포 관리