### PR TITLE
refactor: 차수별 수강생 조회 API 권한 완화 및 테스트 계정 설정 추가

### DIFF
--- a/src/main/java/com/mzc/lp/domain/student/controller/EnrollmentController.java
+++ b/src/main/java/com/mzc/lp/domain/student/controller/EnrollmentController.java
@@ -68,7 +68,7 @@ public class EnrollmentController {
      * 차수별 수강생 목록 조회
      */
     @GetMapping("/api/times/{courseTimeId}/enrollments")
-    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<Page<EnrollmentResponse>>> getEnrollmentsByCourseTime(
             @PathVariable Long courseTimeId,
             @RequestParam(required = false) EnrollmentStatus status,

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,3 +2,7 @@
 INSERT INTO tenants (id, code, name, type, status, plan, subdomain, created_at, updated_at)
 SELECT 1, 'default', '기본 테넌트', 'B2B', 'ACTIVE', 'ENTERPRISE', 'default', NOW(), NOW()
 WHERE NOT EXISTS (SELECT 1 FROM tenants WHERE id = 1);
+
+-- 테스트 계정 역할 업데이트
+UPDATE users SET role = 'DESIGNER' WHERE email = 'designer@test.com';
+UPDATE users SET role = 'OPERATOR' WHERE email = 'operator@test.com';


### PR DESCRIPTION
## Summary
- 차수별 수강생 목록 조회 API 권한을 OPERATOR/TENANT_ADMIN에서 인증된 사용자로 완화
- 테스트 계정 역할 초기화 쿼리 추가

## Changes

### 권한 변경
| API | 변경 전 | 변경 후 |
|-----|---------|---------|
| `GET /api/times/{courseTimeId}/enrollments` | OPERATOR, TENANT_ADMIN | isAuthenticated() |

### 테스트 데이터
- `designer@test.com` → DESIGNER 역할
- `operator@test.com` → OPERATOR 역할

## Related Files
- `src/main/java/com/mzc/lp/domain/student/controller/EnrollmentController.java`
- `src/main/resources/data.sql`

## Test plan
- [ ] 일반 사용자(USER)로 차수별 수강생 목록 조회 가능 확인
- [ ] 비로그인 상태에서 403 응답 확인
- [ ] 서버 재시작 후 테스트 계정 역할 적용 확인