### PR TITLE
feat: 차수별 수강생 목록 조회 API 소유권/강사 검증 추가

### DIFF
--- a/src/main/java/com/mzc/lp/domain/student/controller/EnrollmentController.java
+++ b/src/main/java/com/mzc/lp/domain/student/controller/EnrollmentController.java
@@ -66,15 +66,20 @@ public class EnrollmentController {
 
     /**
      * 차수별 수강생 목록 조회
+     * - OPERATOR/TENANT_ADMIN: 모든 차수 조회 가능
+     * - OWNER: 본인이 생성한 프로그램의 차수만 조회 가능
+     * - 배정된 강사: 본인이 배정된 차수만 조회 가능
      */
     @GetMapping("/api/times/{courseTimeId}/enrollments")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<Page<EnrollmentResponse>>> getEnrollmentsByCourseTime(
             @PathVariable Long courseTimeId,
             @RequestParam(required = false) EnrollmentStatus status,
-            @PageableDefault(size = 20) Pageable pageable
+            @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Page<EnrollmentResponse> response = enrollmentService.getEnrollmentsByCourseTime(courseTimeId, status, pageable);
+        Page<EnrollmentResponse> response = enrollmentService.getEnrollmentsByCourseTime(
+                courseTimeId, status, pageable, principal.id(), hasAdminRole(principal));
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/mzc/lp/domain/student/service/EnrollmentService.java
+++ b/src/main/java/com/mzc/lp/domain/student/service/EnrollmentService.java
@@ -22,8 +22,8 @@ public interface EnrollmentService {
     // 수강 상세 조회
     EnrollmentDetailResponse getEnrollment(Long enrollmentId);
 
-    // 차수별 수강생 목록 조회
-    Page<EnrollmentResponse> getEnrollmentsByCourseTime(Long courseTimeId, EnrollmentStatus status, Pageable pageable);
+    // 차수별 수강생 목록 조회 (소유권/강사 검증 포함)
+    Page<EnrollmentResponse> getEnrollmentsByCourseTime(Long courseTimeId, EnrollmentStatus status, Pageable pageable, Long userId, boolean isAdmin);
 
     // 내 수강 목록 조회
     Page<EnrollmentResponse> getMyEnrollments(Long userId, EnrollmentStatus status, Pageable pageable);

--- a/src/main/java/com/mzc/lp/domain/student/service/EnrollmentServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/student/service/EnrollmentServiceImpl.java
@@ -15,6 +15,9 @@ import com.mzc.lp.domain.student.exception.CannotCancelCompletedException;
 import com.mzc.lp.domain.student.exception.EnrollmentNotFoundException;
 import com.mzc.lp.domain.student.exception.EnrollmentPeriodClosedException;
 import com.mzc.lp.domain.student.exception.UnauthorizedEnrollmentAccessException;
+import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.repository.InstructorAssignmentRepository;
+import com.mzc.lp.domain.program.entity.Program;
 import com.mzc.lp.domain.student.repository.EnrollmentRepository;
 import com.mzc.lp.domain.ts.entity.CourseTime;
 import com.mzc.lp.domain.ts.exception.CourseTimeNotFoundException;
@@ -39,6 +42,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     private final EnrollmentRepository enrollmentRepository;
     private final CourseTimeRepository courseTimeRepository;
     private final CourseTimeService courseTimeService;
+    private final InstructorAssignmentRepository instructorAssignmentRepository;
 
     @Override
     @Transactional
@@ -141,10 +145,16 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     }
 
     @Override
-    public Page<EnrollmentResponse> getEnrollmentsByCourseTime(Long courseTimeId, EnrollmentStatus status, Pageable pageable) {
-        log.debug("Getting enrollments by course time: courseTimeId={}, status={}", courseTimeId, status);
+    public Page<EnrollmentResponse> getEnrollmentsByCourseTime(Long courseTimeId, EnrollmentStatus status, Pageable pageable, Long userId, boolean isAdmin) {
+        log.debug("Getting enrollments by course time: courseTimeId={}, status={}, userId={}, isAdmin={}",
+                courseTimeId, status, userId, isAdmin);
 
         Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 관리자(OPERATOR/TENANT_ADMIN)가 아닌 경우 소유권/강사 검증
+        if (!isAdmin) {
+            validateCourseTimeAccess(courseTimeId, userId, tenantId);
+        }
 
         if (status != null) {
             return enrollmentRepository.findByCourseTimeIdAndStatusAndTenantId(courseTimeId, status, tenantId, pageable)
@@ -153,6 +163,41 @@ public class EnrollmentServiceImpl implements EnrollmentService {
 
         return enrollmentRepository.findByCourseTimeIdAndTenantId(courseTimeId, tenantId, pageable)
                 .map(EnrollmentResponse::from);
+    }
+
+    /**
+     * 차수 접근 권한 검증
+     * - 프로그램 소유자(createdBy)인 경우 허용
+     * - 해당 차수에 배정된 강사인 경우 허용
+     */
+    private void validateCourseTimeAccess(Long courseTimeId, Long userId, Long tenantId) {
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(courseTimeId, tenantId)
+                .orElseThrow(() -> new CourseTimeNotFoundException(courseTimeId));
+
+        // 1. 프로그램 소유자 확인 (Program.createdBy == userId)
+        Program program = courseTime.getProgram();
+        if (program != null && program.getCreatedBy().equals(userId)) {
+            log.debug("User {} is the owner of program {}", userId, program.getId());
+            return;
+        }
+
+        // 2. 차수 생성자 확인 (CourseTime.createdBy == userId)
+        if (courseTime.getCreatedBy() != null && courseTime.getCreatedBy().equals(userId)) {
+            log.debug("User {} is the creator of course time {}", userId, courseTimeId);
+            return;
+        }
+
+        // 3. 배정된 강사인지 확인
+        boolean isAssignedInstructor = instructorAssignmentRepository
+                .existsByTimeKeyAndUserKeyAndTenantIdAndStatus(courseTimeId, userId, tenantId, AssignmentStatus.ACTIVE);
+        if (isAssignedInstructor) {
+            log.debug("User {} is an assigned instructor for course time {}", userId, courseTimeId);
+            return;
+        }
+
+        // 권한 없음
+        log.warn("User {} has no access to course time {} enrollments", userId, courseTimeId);
+        throw new UnauthorizedEnrollmentAccessException(courseTimeId, userId);
     }
 
     @Override


### PR DESCRIPTION
## Summary

차수별 수강생 목록 조회 API에 소유권/강사 검증 로직을 추가하여 OPERATOR/TENANT_ADMIN 외에 프로그램 소유자, 차수 생성자, 배정된 강사만 수강생 목록을 조회할 수 있도록 구현

## Related Issue

- Closes #

## Changes

- EnrollmentController: @PreAuthorize를 isAuthenticated()로 변경하고 서비스 레이어에서 소유권 검증 수행
- EnrollmentService: getEnrollmentsByCourseTime 메서드에 userId, isAdmin 파라미터 추가
- EnrollmentServiceImpl: validateCourseTimeAccess() 메서드 추가
  - 프로그램 소유자(Program.createdBy) 접근 허용
  - 차수 생성자(CourseTime.createdBy) 접근 허용
  - 배정된 강사(InstructorAssignment.ACTIVE) 접근 허용
  - OPERATOR/TENANT_ADMIN은 검증 없이 접근 허용
- EnrollmentServiceTest: 소유권 검증 테스트 5개 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

권한 없는 사용자가 조회 시도 시 UnauthorizedEnrollmentAccessException 발생