### PR TITLE
feat: B2C OWNER 자동화 및 CourseRole 필터 추가 (#220, #221, #215)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
+++ b/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
@@ -109,9 +109,10 @@ public class UserController {
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) TenantRole role,
             @RequestParam(required = false) UserStatus status,
+            @RequestParam(required = false) Boolean hasCourseRole,
             @PageableDefault(size = 20) Pageable pageable
     ) {
-        Page<UserListResponse> response = userService.getUsers(keyword, role, status, pageable);
+        Page<UserListResponse> response = userService.getUsers(keyword, role, status, hasCourseRole, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/mzc/lp/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/mzc/lp/domain/user/repository/UserRepositoryCustom.java
@@ -8,5 +8,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface UserRepositoryCustom {
 
-    Page<User> searchUsers(String keyword, TenantRole role, UserStatus status, Pageable pageable);
+    Page<User> searchUsers(String keyword, TenantRole role, UserStatus status, Boolean hasCourseRole, Pageable pageable);
 }

--- a/src/main/java/com/mzc/lp/domain/user/service/UserService.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserService.java
@@ -34,7 +34,7 @@ public interface UserService {
     ProfileImageResponse uploadProfileImage(Long userId, MultipartFile file);
 
     // 관리 API (OPERATOR 권한)
-    Page<UserListResponse> getUsers(String keyword, TenantRole role, UserStatus status, Pageable pageable);
+    Page<UserListResponse> getUsers(String keyword, TenantRole role, UserStatus status, Boolean hasCourseRole, Pageable pageable);
 
     UserDetailResponse getUser(Long userId);
 

--- a/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
@@ -114,9 +114,9 @@ public class UserServiceImpl implements UserService {
     // ========== 관리 API (OPERATOR 권한) ==========
 
     @Override
-    public Page<UserListResponse> getUsers(String keyword, TenantRole role, UserStatus status, Pageable pageable) {
-        log.debug("Searching users: keyword={}, role={}, status={}", keyword, role, status);
-        return userRepository.searchUsers(keyword, role, status, pageable)
+    public Page<UserListResponse> getUsers(String keyword, TenantRole role, UserStatus status, Boolean hasCourseRole, Pageable pageable) {
+        log.debug("Searching users: keyword={}, role={}, status={}, hasCourseRole={}", keyword, role, status, hasCourseRole);
+        return userRepository.searchUsers(keyword, role, status, hasCourseRole, pageable)
                 .map(UserListResponse::from);
     }
 

--- a/src/test/java/com/mzc/lp/domain/ts/service/CourseTimeServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/ts/service/CourseTimeServiceTest.java
@@ -6,6 +6,7 @@ import com.mzc.lp.domain.program.entity.Program;
 import com.mzc.lp.domain.program.repository.ProgramRepository;
 import com.mzc.lp.domain.ts.constant.DeliveryType;
 import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
+import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
 import com.mzc.lp.domain.ts.dto.response.CapacityResponse;
 import com.mzc.lp.domain.ts.dto.response.PriceResponse;
 import com.mzc.lp.domain.ts.entity.CourseTime;
@@ -47,6 +48,9 @@ class CourseTimeServiceTest extends TenantTestSupport {
 
     @Mock
     private InstructorAssignmentService instructorAssignmentService;
+
+    @Mock
+    private UserCourseRoleRepository userCourseRoleRepository;
 
     private CourseTime createTestCourseTime(Integer capacity, int currentEnrollment) {
         CourseTime courseTime = CourseTime.create(


### PR DESCRIPTION
## Summary
- B2C 모델에서 Program 승인 시 OWNER 역할 자동 부여
- 차수 생성 시 OWNER를 MAIN 강사로 자동 배정하여 수동 배정 불필요
- 사용자 검색 시 CourseRole 보유자만 필터링 가능

## Related Issue
- Closes #220 (Program 승인 시 CourseRole.OWNER 자동 부여 누락)
- Closes #221 (B2C 차수 생성 시 OWNER를 MAIN 강사로 자동 배정)
- Closes #215 (사용자 검색 API에 CourseRole 필터 추가)

## Changes
- `ProgramServiceImpl.approveProgram()`: OWNER 역할 자동 부여 로직 추가
- `CourseTimeServiceImpl.createCourseTime()`: MAIN 강사 자동 배정 로직 추가
- `UserController/Service/Repository`: `hasCourseRole` 파라미터 추가
- `CourseTimeServiceTest`: UserCourseRoleRepository Mock 추가

## Type of Change
- [x] feature 

## Checklist
- [x] 코드가 컨벤션을 준수합니다
- [x] 기존 테스트가 모두 통과합니다
- [x] 변경된 기능에 대한 테스트가 추가/수정되었습니다

## Test plan
- [x] DESIGNER로 로그인 → Program 생성 → 제출 → OPERATOR로 승인 → DB에서 OWNER 역할 확인
- [x] OWNER로 로그인 → 차수 생성 → 강사 배정 없이 모집 개시(OPEN) 성공 확인
- [x] `GET /api/users?hasCourseRole=true` 호출 → CourseRole 보유자만 반환 확인

## Additional Notes
B2C 흐름: DESIGNER가 Program 생성 → OPERATOR 승인 → OWNER 자동 부여 → 차수 생성 시 MAIN 강사 자동 배정