### PR TITLE
feat: User 관리 API 추가 (PUT, DELETE /users/{id})

### DIFF
--- a/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
+++ b/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
@@ -9,6 +9,7 @@ import com.mzc.lp.domain.user.dto.request.ChangePasswordRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeRoleRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeStatusRequest;
 import com.mzc.lp.domain.user.dto.request.UpdateProfileRequest;
+import com.mzc.lp.domain.user.dto.request.UpdateUserRequest;
 import com.mzc.lp.domain.user.dto.request.WithdrawRequest;
 import com.mzc.lp.domain.user.dto.response.CourseRoleResponse;
 import com.mzc.lp.domain.user.dto.response.UserDetailResponse;
@@ -142,6 +143,25 @@ public class UserController {
     ) {
         UserStatusResponse response = userService.changeUserStatus(userId, request);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PutMapping("/{userId}")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<UserDetailResponse>> updateUser(
+            @PathVariable Long userId,
+            @Valid @RequestBody UpdateUserRequest request
+    ) {
+        UserDetailResponse response = userService.updateUser(userId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/{userId}")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<Void> deleteUser(
+            @PathVariable Long userId
+    ) {
+        userService.deleteUser(userId);
+        return ResponseEntity.noContent().build();
     }
 
     // ========== CourseRole 관리 API (OPERATOR 이상 권한) ==========

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/UpdateUserRequest.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/UpdateUserRequest.java
@@ -1,0 +1,26 @@
+package com.mzc.lp.domain.user.dto.request;
+
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.constant.UserStatus;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 관리자가 사용자 정보를 수정할 때 사용하는 요청 DTO
+ */
+public record UpdateUserRequest(
+        @Size(max = 50, message = "이름은 50자 이하여야 합니다")
+        String name,
+
+        @Size(max = 20, message = "전화번호는 20자 이하여야 합니다")
+        String phone,
+
+        @Size(max = 100, message = "부서는 100자 이하여야 합니다")
+        String department,
+
+        @Size(max = 100, message = "직책은 100자 이하여야 합니다")
+        String position,
+
+        UserStatus status,
+
+        TenantRole role
+) {}

--- a/src/main/java/com/mzc/lp/domain/user/service/UserService.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserService.java
@@ -7,6 +7,7 @@ import com.mzc.lp.domain.user.dto.request.ChangePasswordRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeRoleRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeStatusRequest;
 import com.mzc.lp.domain.user.dto.request.UpdateProfileRequest;
+import com.mzc.lp.domain.user.dto.request.UpdateUserRequest;
 import com.mzc.lp.domain.user.dto.request.WithdrawRequest;
 import com.mzc.lp.domain.user.dto.response.CourseRoleResponse;
 import com.mzc.lp.domain.user.dto.response.UserDetailResponse;
@@ -37,6 +38,10 @@ public interface UserService {
     Page<UserListResponse> getUsers(String keyword, TenantRole role, UserStatus status, Pageable pageable);
 
     UserDetailResponse getUser(Long userId);
+
+    UserDetailResponse updateUser(Long userId, UpdateUserRequest request);
+
+    void deleteUser(Long userId);
 
     UserRoleResponse changeUserRole(Long userId, ChangeRoleRequest request);
 


### PR DESCRIPTION
## Summary
TA(Tenant Admin)가 사용자 정보를 수정하고 삭제할 수 있는 관리 API를 추가합니다.

## Related Issue
- Closes #223

## Changes
- `UpdateUserRequest` DTO 추가
- `UserService`에 `updateUser`, `deleteUser` 메서드 추가
- `UserController`에 `PUT /users/{userId}`, `DELETE /users/{userId}` 엔드포인트 추가
- TENANT_ADMIN 권한으로 접근 제한

## Type of Change
- [x] Feat: 새로운 기능

## Checklist
- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 로컬에서 테스트가 통과합니다

## Additional Notes
프론트엔드 TA 사용자 상세 페이지에서 사용자 수정/삭제 기능과 연동됩니다.