### PR TITLE
feat: Program API 응답에 사용자 정보 필드 추가 (#210)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/program/dto/response/ProgramDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/program/dto/response/ProgramDetailResponse.java
@@ -17,10 +17,12 @@ public record ProgramDetailResponse(
         Integer estimatedHours,
         ProgramStatus status,
         Long createdBy,
+        String creatorName,
         Long snapshotId,
         String snapshotName,
         // 승인 정보
         Long approvedBy,
+        String approvedByName,
         Instant approvedAt,
         String approvalComment,
         // 반려 정보
@@ -28,6 +30,10 @@ public record ProgramDetailResponse(
         Instant rejectedAt,
         // 제출 정보
         Instant submittedAt,
+        // OWNER 정보 (승인된 프로그램에만 존재)
+        Long ownerId,
+        String ownerName,
+        String ownerEmail,
         Instant createdAt,
         Instant updatedAt
 ) {
@@ -42,14 +48,49 @@ public record ProgramDetailResponse(
                 program.getEstimatedHours(),
                 program.getStatus(),
                 program.getCreatedBy(),
+                null,
                 program.getSnapshot() != null ? program.getSnapshot().getId() : null,
                 program.getSnapshot() != null ? program.getSnapshot().getSnapshotName() : null,
                 program.getApprovedBy(),
+                null,
                 program.getApprovedAt(),
                 program.getApprovalComment(),
                 program.getRejectionReason(),
                 program.getRejectedAt(),
                 program.getSubmittedAt(),
+                null,
+                null,
+                null,
+                program.getCreatedAt(),
+                program.getUpdatedAt()
+        );
+    }
+
+    public static ProgramDetailResponse from(Program program, String creatorName, String approvedByName,
+                                              Long ownerId, String ownerName, String ownerEmail) {
+        return new ProgramDetailResponse(
+                program.getId(),
+                program.getTitle(),
+                program.getDescription(),
+                program.getThumbnailUrl(),
+                program.getLevel(),
+                program.getType(),
+                program.getEstimatedHours(),
+                program.getStatus(),
+                program.getCreatedBy(),
+                creatorName,
+                program.getSnapshot() != null ? program.getSnapshot().getId() : null,
+                program.getSnapshot() != null ? program.getSnapshot().getSnapshotName() : null,
+                program.getApprovedBy(),
+                approvedByName,
+                program.getApprovedAt(),
+                program.getApprovalComment(),
+                program.getRejectionReason(),
+                program.getRejectedAt(),
+                program.getSubmittedAt(),
+                ownerId,
+                ownerName,
+                ownerEmail,
                 program.getCreatedAt(),
                 program.getUpdatedAt()
         );

--- a/src/main/java/com/mzc/lp/domain/program/dto/response/ProgramResponse.java
+++ b/src/main/java/com/mzc/lp/domain/program/dto/response/ProgramResponse.java
@@ -17,7 +17,12 @@ public record ProgramResponse(
         Integer estimatedHours,
         ProgramStatus status,
         Long createdBy,
+        String creatorName,
         Long snapshotId,
+        // OWNER 정보 (승인된 프로그램에만 존재)
+        Long ownerId,
+        String ownerName,
+        String ownerEmail,
         Instant createdAt,
         Instant updatedAt
 ) {
@@ -32,7 +37,32 @@ public record ProgramResponse(
                 program.getEstimatedHours(),
                 program.getStatus(),
                 program.getCreatedBy(),
+                null,
                 program.getSnapshot() != null ? program.getSnapshot().getId() : null,
+                null,
+                null,
+                null,
+                program.getCreatedAt(),
+                program.getUpdatedAt()
+        );
+    }
+
+    public static ProgramResponse from(Program program, String creatorName, Long ownerId, String ownerName, String ownerEmail) {
+        return new ProgramResponse(
+                program.getId(),
+                program.getTitle(),
+                program.getDescription(),
+                program.getThumbnailUrl(),
+                program.getLevel(),
+                program.getType(),
+                program.getEstimatedHours(),
+                program.getStatus(),
+                program.getCreatedBy(),
+                creatorName,
+                program.getSnapshot() != null ? program.getSnapshot().getId() : null,
+                ownerId,
+                ownerName,
+                ownerEmail,
                 program.getCreatedAt(),
                 program.getUpdatedAt()
         );


### PR DESCRIPTION
## Summary
- Program API 응답에서 사용자 ID만 반환되던 것을 이름/이메일 정보도 함께 반환하도록 개선
- TO가 프로그램 목록/상세 화면에서 생성자, 승인자, OWNER 정보를 바로 확인 가능

## Related Issue
- Closes #210

## Changes
- `ProgramResponse.java`: creatorName, ownerId, ownerName, ownerEmail 필드 추가 및 오버로드 from() 메서드 추가
- `ProgramDetailResponse.java`: creatorName, approvedByName, ownerId, ownerName, ownerEmail 필드 추가 및 오버로드 from() 메서드 추가
- `ProgramServiceImpl.java`: 
  - `getProgram()`: User 정보 및 OWNER 정보 조회 로직 추가
  - `getPrograms()`: N+1 방지를 위한 User/OWNER 일괄 조회 로직 추가
  - `findOwnerByProgramId()`: 단일 프로그램의 OWNER 조회
  - `findOwnersByProgramIds()`: 다수 프로그램의 OWNER 일괄 조회

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Test plan

- [x] `./gradlew test` 전체 테스트 통과 (603 tests)
- [x] GET /api/programs 목록 조회 시 creatorName, owner 정보 확인
- [x] GET /api/programs/{id} 상세 조회 시 creatorName, approvedByName, owner 정보 확인

## Additional Notes

- OWNER가 없는 프로그램(DRAFT, PENDING, REJECTED)은 owner 관련 필드가 null 반환
- 기존 `from(Program)` 메서드는 하위 호환성을 위해 유지