### PR TITLE
feat: SA 대시보드 통계 API 구현 (#206)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/sa/controller/SaDashboardController.java
+++ b/src/main/java/com/mzc/lp/domain/sa/controller/SaDashboardController.java
@@ -1,0 +1,30 @@
+package com.mzc.lp.domain.sa.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.domain.sa.dto.response.SaDashboardResponse;
+import com.mzc.lp.domain.sa.service.SaDashboardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/sa/dashboard")
+@RequiredArgsConstructor
+public class SaDashboardController {
+
+    private final SaDashboardService saDashboardService;
+
+    /**
+     * SA 대시보드 통계 조회
+     * GET /api/sa/dashboard
+     */
+    @GetMapping
+    @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+    public ResponseEntity<ApiResponse<SaDashboardResponse>> getDashboard() {
+        SaDashboardResponse response = saDashboardService.getDashboard();
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/sa/dto/response/SaDashboardResponse.java
+++ b/src/main/java/com/mzc/lp/domain/sa/dto/response/SaDashboardResponse.java
@@ -1,0 +1,47 @@
+package com.mzc.lp.domain.sa.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+public class SaDashboardResponse {
+
+    private TenantStats tenantStats;
+    private UserStats userStats;
+    private List<RecentTenant> recentTenants;
+
+    @Getter
+    @Builder
+    public static class TenantStats {
+        private long total;
+        private long active;
+        private long pending;
+        private long suspended;
+        private long terminated;
+        private Map<String, Long> byPlan;
+    }
+
+    @Getter
+    @Builder
+    public static class UserStats {
+        private long total;
+        private long active;
+        private long suspended;
+        private long withdrawn;
+    }
+
+    @Getter
+    @Builder
+    public static class RecentTenant {
+        private Long id;
+        private String code;
+        private String name;
+        private String status;
+        private String plan;
+        private String createdAt;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/sa/service/SaDashboardService.java
+++ b/src/main/java/com/mzc/lp/domain/sa/service/SaDashboardService.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.sa.service;
+
+import com.mzc.lp.domain.sa.dto.response.SaDashboardResponse;
+
+public interface SaDashboardService {
+
+    /**
+     * SA 대시보드 통계 조회
+     */
+    SaDashboardResponse getDashboard();
+}

--- a/src/main/java/com/mzc/lp/domain/sa/service/SaDashboardServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/sa/service/SaDashboardServiceImpl.java
@@ -1,0 +1,94 @@
+package com.mzc.lp.domain.sa.service;
+
+import com.mzc.lp.domain.sa.dto.response.SaDashboardResponse;
+import com.mzc.lp.domain.tenant.constant.TenantStatus;
+import com.mzc.lp.domain.tenant.entity.Tenant;
+import com.mzc.lp.domain.tenant.repository.TenantRepository;
+import com.mzc.lp.domain.user.constant.UserStatus;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SaDashboardServiceImpl implements SaDashboardService {
+
+    private final TenantRepository tenantRepository;
+    private final UserRepository userRepository;
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    @Override
+    public SaDashboardResponse getDashboard() {
+        return SaDashboardResponse.builder()
+                .tenantStats(getTenantStats())
+                .userStats(getUserStats())
+                .recentTenants(getRecentTenants())
+                .build();
+    }
+
+    private SaDashboardResponse.TenantStats getTenantStats() {
+        List<Tenant> allTenants = tenantRepository.findAll();
+
+        Map<TenantStatus, Long> statusCount = allTenants.stream()
+                .collect(Collectors.groupingBy(Tenant::getStatus, Collectors.counting()));
+
+        Map<String, Long> planCount = allTenants.stream()
+                .collect(Collectors.groupingBy(
+                        t -> t.getPlan().name(),
+                        Collectors.counting()
+                ));
+
+        return SaDashboardResponse.TenantStats.builder()
+                .total(allTenants.size())
+                .active(statusCount.getOrDefault(TenantStatus.ACTIVE, 0L))
+                .pending(statusCount.getOrDefault(TenantStatus.PENDING, 0L))
+                .suspended(statusCount.getOrDefault(TenantStatus.SUSPENDED, 0L))
+                .terminated(statusCount.getOrDefault(TenantStatus.TERMINATED, 0L))
+                .byPlan(planCount)
+                .build();
+    }
+
+    private SaDashboardResponse.UserStats getUserStats() {
+        List<com.mzc.lp.domain.user.entity.User> allUsers = userRepository.findAll();
+
+        Map<UserStatus, Long> statusCount = allUsers.stream()
+                .collect(Collectors.groupingBy(
+                        com.mzc.lp.domain.user.entity.User::getStatus,
+                        Collectors.counting()
+                ));
+
+        return SaDashboardResponse.UserStats.builder()
+                .total(allUsers.size())
+                .active(statusCount.getOrDefault(UserStatus.ACTIVE, 0L))
+                .suspended(statusCount.getOrDefault(UserStatus.SUSPENDED, 0L))
+                .withdrawn(statusCount.getOrDefault(UserStatus.WITHDRAWN, 0L))
+                .build();
+    }
+
+    private List<SaDashboardResponse.RecentTenant> getRecentTenants() {
+        PageRequest pageRequest = PageRequest.of(0, 5, Sort.by(Sort.Direction.DESC, "createdAt"));
+        List<Tenant> recentTenants = tenantRepository.findAll(pageRequest).getContent();
+
+        return recentTenants.stream()
+                .map(tenant -> SaDashboardResponse.RecentTenant.builder()
+                        .id(tenant.getId())
+                        .code(tenant.getCode())
+                        .name(tenant.getName())
+                        .status(tenant.getStatus().name())
+                        .plan(tenant.getPlan().name())
+                        .createdAt(tenant.getCreatedAt().atZone(java.time.ZoneId.systemDefault())
+                                .format(DATE_FORMATTER))
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/sa/service/SaDashboardServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/sa/service/SaDashboardServiceTest.java
@@ -1,0 +1,86 @@
+package com.mzc.lp.domain.sa.service;
+
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.sa.dto.response.SaDashboardResponse;
+import com.mzc.lp.domain.tenant.constant.PlanType;
+import com.mzc.lp.domain.tenant.constant.TenantType;
+import com.mzc.lp.domain.tenant.entity.Tenant;
+import com.mzc.lp.domain.tenant.repository.TenantRepository;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class SaDashboardServiceTest extends TenantTestSupport {
+
+    @Autowired
+    private SaDashboardService saDashboardService;
+
+    @Autowired
+    private TenantRepository tenantRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+        tenantRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("대시보드 통계를 조회한다")
+    void getDashboard_success() {
+        // given
+        Tenant tenant1 = Tenant.create("TENANT1", "테넌트1", TenantType.B2B, "tenant1", PlanType.BASIC);
+        tenant1.activate();
+        tenantRepository.save(tenant1);
+
+        Tenant tenant2 = Tenant.create("TENANT2", "테넌트2", TenantType.B2C, "tenant2", PlanType.PRO);
+        tenantRepository.save(tenant2);
+
+        // TenantContext를 통해 자동으로 tenantId가 설정됨
+        User user1 = User.create("user1@example.com", "사용자1", passwordEncoder.encode("Password123!"));
+        userRepository.save(user1);
+
+        User user2 = User.create("user2@example.com", "사용자2", passwordEncoder.encode("Password123!"));
+        userRepository.save(user2);
+
+        // when
+        SaDashboardResponse response = saDashboardService.getDashboard();
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getTenantStats().getTotal()).isEqualTo(2);
+        assertThat(response.getTenantStats().getActive()).isEqualTo(1);
+        assertThat(response.getTenantStats().getPending()).isEqualTo(1);
+        assertThat(response.getUserStats().getTotal()).isEqualTo(2);
+        assertThat(response.getUserStats().getActive()).isEqualTo(2);
+        assertThat(response.getRecentTenants()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("데이터가 없을 때 대시보드 통계를 조회한다")
+    void getDashboard_empty() {
+        // when
+        SaDashboardResponse response = saDashboardService.getDashboard();
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getTenantStats().getTotal()).isEqualTo(0);
+        assertThat(response.getUserStats().getTotal()).isEqualTo(0);
+        assertThat(response.getRecentTenants()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

SA 대시보드 통계 API를 구현합니다. 테넌트 및 사용자 통계를 조회할 수 있습니다.

## Related Issue

- Closes #206
- Closes #207
- Closes #208

## Changes

- SA 대시보드 통계 API 구현 (`GET /api/sa/dashboard`)
- 테넌트 통계 (전체/상태별/플랜별)
- 사용자 통계 (전체/상태별)
- 최근 생성 테넌트 목록 조회
- 테스트 코드 작성
- #207, #208은 기존 `TenantController`, `UserController`에 이미 구현되어 있음

## Type of Change

- [x] Feat: 새로운 기능
- [x] Test: 테스트 추가/수정

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- #207 테넌트 CRUD API: `TenantController`에 이미 구현됨
- #208 TA 사용자 관리 API: `UserController`에 이미 구현됨