### PR TITLE
feat: PendingProgramResponse에 creatorName 필드 추가 (#210)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/program/dto/response/PendingProgramResponse.java
+++ b/src/main/java/com/mzc/lp/domain/program/dto/response/PendingProgramResponse.java
@@ -13,6 +13,7 @@ public record PendingProgramResponse(
         ProgramLevel level,
         ProgramType type,
         Long createdBy,
+        String creatorName,
         Instant submittedAt,
         Long snapshotId
 ) {
@@ -24,6 +25,21 @@ public record PendingProgramResponse(
                 program.getLevel(),
                 program.getType(),
                 program.getCreatedBy(),
+                null,
+                program.getSubmittedAt(),
+                program.getSnapshot() != null ? program.getSnapshot().getId() : null
+        );
+    }
+
+    public static PendingProgramResponse from(Program program, String creatorName) {
+        return new PendingProgramResponse(
+                program.getId(),
+                program.getTitle(),
+                program.getThumbnailUrl(),
+                program.getLevel(),
+                program.getType(),
+                program.getCreatedBy(),
+                creatorName,
                 program.getSubmittedAt(),
                 program.getSnapshot() != null ? program.getSnapshot().getId() : null
         );


### PR DESCRIPTION
## Summary

검토 대기 프로그램 목록(PendingProgramResponse)에 생성자 이름(creatorName) 필드를 추가하여 운영자가 검토 화면에서 누가 프로그램을 생성했는지 확인할 수 있도록 개선합니다.

## Related Issue

- Closes #210

## Changes

- `PendingProgramResponse`에 `creatorName` 필드 추가
- `from(Program, String creatorName)` 오버로드 메서드 추가
- `ProgramServiceImpl.getPendingPrograms()`에 User 일괄 조회 로직 추가 (N+1 방지)

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다

## Test plan

- [ ] GET /api/programs/pending 호출 시 creatorName 필드 반환 확인
- [ ] creatorName이 실제 사용자 이름으로 표시되는지 확인

## Additional Notes

기존 #210 이슈에서 `ProgramResponse`, `ProgramDetailResponse`는 이미 수정되었으나, `PendingProgramResponse`가 누락되어 추가 작업을 진행했습니다.