### PR TITLE
Feat/wishlist api

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -112,7 +112,11 @@ public enum ErrorCode {
     DUPLICATE_USER_GROUP_NAME(HttpStatus.CONFLICT, "UG002", "User group name already exists"),
 
     // Notice (NT)
-    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NT001", "Notice not found");
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NT001", "Notice not found"),
+
+    // Wishlist (WL)
+    WISHLIST_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "WL001", "Wishlist item not found"),
+    ALREADY_IN_WISHLIST(HttpStatus.CONFLICT, "WL002", "Course is already in wishlist");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/mzc/lp/common/constant/ValidationMessages.java
+++ b/src/main/java/com/mzc/lp/common/constant/ValidationMessages.java
@@ -1,0 +1,33 @@
+package com.mzc.lp.common.constant;
+
+/**
+ * 도메인 검증 관련 공통 에러 메시지 상수
+ */
+public final class ValidationMessages {
+
+    private ValidationMessages() {
+        // 인스턴스화 방지
+    }
+
+    // Item 관련 메시지
+    public static final String MAX_DEPTH_EXCEEDED = "최대 깊이(10단계)를 초과할 수 없습니다";
+    public static final String ITEM_NAME_REQUIRED = "항목 이름은 필수입니다";
+    public static final String ITEM_NAME_TOO_LONG = "항목 이름은 255자 이하여야 합니다";
+    public static final String CANNOT_MOVE_TO_CHILD = "하위 항목으로 이동할 수 없습니다";
+
+    // Relation 관련 메시지
+    public static final String FOLDER_CANNOT_BE_IN_LEARNING_ORDER = "폴더는 학습 순서에 포함할 수 없습니다";
+    public static final String START_POINT_REQUIRED = "시작점 항목은 필수입니다";
+    public static final String TARGET_ITEM_REQUIRED = "대상 항목은 필수입니다";
+    public static final String CANNOT_REFERENCE_SELF = "자기 자신을 참조할 수 없습니다";
+
+    // 공통 Title 관련 메시지
+    public static final String TITLE_REQUIRED = "제목은 필수입니다";
+    public static final String TITLE_TOO_LONG = "제목은 255자 이하여야 합니다";
+    public static final String COURSE_TITLE_REQUIRED = "강의 제목은 필수입니다";
+    public static final String COURSE_TITLE_TOO_LONG = "강의 제목은 255자 이하여야 합니다";
+
+    // 반려 관련 메시지
+    public static final String REJECTION_REASON_REQUIRED = "반려 사유는 필수입니다";
+    public static final String REJECTION_REASON_TOO_LONG = "반려 사유는 500자 이하여야 합니다";
+}

--- a/src/main/java/com/mzc/lp/domain/content/dto/request/UploadFileRequest.java
+++ b/src/main/java/com/mzc/lp/domain/content/dto/request/UploadFileRequest.java
@@ -1,0 +1,17 @@
+package com.mzc.lp.domain.content.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record UploadFileRequest(
+        MultipartFile file,
+        Long folderId,
+        String originalFileName,
+        String description,
+        String tags,
+        MultipartFile thumbnail
+) {
+    public static UploadFileRequest of(MultipartFile file, Long folderId, String originalFileName,
+                                       String description, String tags, MultipartFile thumbnail) {
+        return new UploadFileRequest(file, folderId, originalFileName, description, tags, thumbnail);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/content/service/ThumbnailServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/content/service/ThumbnailServiceImpl.java
@@ -1,6 +1,7 @@
 package com.mzc.lp.domain.content.service;
 
 import com.mzc.lp.domain.content.constant.ContentType;
+import com.mzc.lp.domain.content.exception.FileStorageException;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.Loader;
@@ -188,7 +189,7 @@ public class ThumbnailServiceImpl implements ThumbnailService {
             return relativePath;
         } catch (IOException e) {
             log.error("Failed to store custom thumbnail", e);
-            throw new RuntimeException("Failed to store custom thumbnail", e);
+            throw new FileStorageException("Failed to store custom thumbnail: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseItemHierarchyResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseItemHierarchyResponse.java
@@ -3,7 +3,6 @@ package com.mzc.lp.domain.course.dto.response;
 import com.mzc.lp.domain.course.entity.CourseItem;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public record CourseItemHierarchyResponse(
         Long itemId,
@@ -26,13 +25,13 @@ public record CourseItemHierarchyResponse(
                 item.getDescription(),
                 item.getChildren().stream()
                         .map(CourseItemHierarchyResponse::from)
-                        .collect(Collectors.toList())
+                        .toList()
         );
     }
 
     public static List<CourseItemHierarchyResponse> fromList(List<CourseItem> rootItems) {
         return rootItems.stream()
                 .map(CourseItemHierarchyResponse::from)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/src/main/java/com/mzc/lp/domain/course/entity/Course.java
+++ b/src/main/java/com/mzc/lp/domain/course/entity/Course.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.course.entity;
 
+import com.mzc.lp.common.constant.ValidationMessages;
 import com.mzc.lp.common.entity.TenantEntity;
 import com.mzc.lp.domain.course.constant.CourseLevel;
 import com.mzc.lp.domain.course.constant.CourseType;
@@ -159,10 +160,10 @@ public class Course extends TenantEntity {
     // ===== Private 검증 메서드 =====
     private void validateTitle(String title) {
         if (title == null || title.isBlank()) {
-            throw new IllegalArgumentException("강의 제목은 필수입니다");
+            throw new IllegalArgumentException(ValidationMessages.COURSE_TITLE_REQUIRED);
         }
         if (title.length() > 255) {
-            throw new IllegalArgumentException("강의 제목은 255자 이하여야 합니다");
+            throw new IllegalArgumentException(ValidationMessages.COURSE_TITLE_TOO_LONG);
         }
     }
 }

--- a/src/main/java/com/mzc/lp/domain/course/entity/CourseItem.java
+++ b/src/main/java/com/mzc/lp/domain/course/entity/CourseItem.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.course.entity;
 
+import com.mzc.lp.common.constant.ValidationMessages;
 import com.mzc.lp.common.entity.TenantEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -112,12 +113,12 @@ public class CourseItem extends TenantEntity {
         int depthDiff = newDepth - this.depth;
 
         if (maxChildDepth + depthDiff > MAX_DEPTH) {
-            throw new IllegalArgumentException("최대 깊이(10단계)를 초과할 수 없습니다");
+            throw new IllegalArgumentException(ValidationMessages.MAX_DEPTH_EXCEEDED);
         }
 
         // 순환 참조 검증
         if (newParent != null && isAncestorOf(newParent)) {
-            throw new IllegalArgumentException("하위 항목으로 이동할 수 없습니다");
+            throw new IllegalArgumentException(ValidationMessages.CANNOT_MOVE_TO_CHILD);
         }
 
         if (this.parent != null) {
@@ -145,16 +146,16 @@ public class CourseItem extends TenantEntity {
     // ===== Private 검증/헬퍼 메서드 =====
     private void validateDepth() {
         if (this.depth > MAX_DEPTH) {
-            throw new IllegalArgumentException("최대 깊이(10단계)를 초과할 수 없습니다");
+            throw new IllegalArgumentException(ValidationMessages.MAX_DEPTH_EXCEEDED);
         }
     }
 
     private void validateItemName(String itemName) {
         if (itemName == null || itemName.isBlank()) {
-            throw new IllegalArgumentException("항목 이름은 필수입니다");
+            throw new IllegalArgumentException(ValidationMessages.ITEM_NAME_REQUIRED);
         }
         if (itemName.length() > 255) {
-            throw new IllegalArgumentException("항목 이름은 255자 이하여야 합니다");
+            throw new IllegalArgumentException(ValidationMessages.ITEM_NAME_TOO_LONG);
         }
     }
 

--- a/src/main/java/com/mzc/lp/domain/course/entity/CourseRelation.java
+++ b/src/main/java/com/mzc/lp/domain/course/entity/CourseRelation.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.course.entity;
 
+import com.mzc.lp.common.constant.ValidationMessages;
 import com.mzc.lp.common.entity.TenantEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -37,10 +38,10 @@ public class CourseRelation extends TenantEntity {
 
     public static CourseRelation createStartPoint(CourseItem toItem) {
         if (toItem == null) {
-            throw new IllegalArgumentException("시작점 항목은 필수입니다");
+            throw new IllegalArgumentException(ValidationMessages.START_POINT_REQUIRED);
         }
         if (toItem.isFolder()) {
-            throw new IllegalArgumentException("폴더는 학습 순서에 포함할 수 없습니다");
+            throw new IllegalArgumentException(ValidationMessages.FOLDER_CANNOT_BE_IN_LEARNING_ORDER);
         }
 
         CourseRelation relation = new CourseRelation();
@@ -67,17 +68,17 @@ public class CourseRelation extends TenantEntity {
     // ===== Private 검증 메서드 =====
     private static void validateRelation(CourseItem fromItem, CourseItem toItem) {
         if (toItem == null) {
-            throw new IllegalArgumentException("대상 항목은 필수입니다");
+            throw new IllegalArgumentException(ValidationMessages.TARGET_ITEM_REQUIRED);
         }
         if (toItem.isFolder()) {
-            throw new IllegalArgumentException("폴더는 학습 순서에 포함할 수 없습니다");
+            throw new IllegalArgumentException(ValidationMessages.FOLDER_CANNOT_BE_IN_LEARNING_ORDER);
         }
         if (fromItem != null) {
             if (fromItem.isFolder()) {
-                throw new IllegalArgumentException("폴더는 학습 순서에 포함할 수 없습니다");
+                throw new IllegalArgumentException(ValidationMessages.FOLDER_CANNOT_BE_IN_LEARNING_ORDER);
             }
             if (fromItem.getId() != null && fromItem.getId().equals(toItem.getId())) {
-                throw new IllegalArgumentException("자기 자신을 참조할 수 없습니다");
+                throw new IllegalArgumentException(ValidationMessages.CANNOT_REFERENCE_SELF);
             }
         }
     }

--- a/src/main/java/com/mzc/lp/domain/program/entity/Program.java
+++ b/src/main/java/com/mzc/lp/domain/program/entity/Program.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.program.entity;
 
+import com.mzc.lp.common.constant.ValidationMessages;
 import com.mzc.lp.common.entity.TenantEntity;
 import com.mzc.lp.domain.program.constant.ProgramLevel;
 import com.mzc.lp.domain.program.constant.ProgramStatus;
@@ -210,19 +211,19 @@ public class Program extends TenantEntity {
 
     private void validateTitle(String title) {
         if (title == null || title.isBlank()) {
-            throw new IllegalArgumentException("제목은 필수입니다");
+            throw new IllegalArgumentException(ValidationMessages.TITLE_REQUIRED);
         }
         if (title.length() > 255) {
-            throw new IllegalArgumentException("제목은 255자 이하여야 합니다");
+            throw new IllegalArgumentException(ValidationMessages.TITLE_TOO_LONG);
         }
     }
 
     private void validateRejectionReason(String reason) {
         if (reason == null || reason.isBlank()) {
-            throw new IllegalArgumentException("반려 사유는 필수입니다");
+            throw new IllegalArgumentException(ValidationMessages.REJECTION_REASON_REQUIRED);
         }
         if (reason.length() > 500) {
-            throw new IllegalArgumentException("반려 사유는 500자 이하여야 합니다");
+            throw new IllegalArgumentException(ValidationMessages.REJECTION_REASON_TOO_LONG);
         }
     }
 }

--- a/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotItem.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotItem.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.snapshot.entity;
 
+import com.mzc.lp.common.constant.ValidationMessages;
 import com.mzc.lp.common.entity.TenantEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -119,11 +120,11 @@ public class SnapshotItem extends TenantEntity {
         int depthDiff = newDepth - this.depth;
 
         if (maxChildDepth + depthDiff > MAX_DEPTH) {
-            throw new IllegalArgumentException("최대 깊이(10단계)를 초과할 수 없습니다");
+            throw new IllegalArgumentException(ValidationMessages.MAX_DEPTH_EXCEEDED);
         }
 
         if (newParent != null && isAncestorOf(newParent)) {
-            throw new IllegalArgumentException("하위 항목으로 이동할 수 없습니다");
+            throw new IllegalArgumentException(ValidationMessages.CANNOT_MOVE_TO_CHILD);
         }
 
         if (this.parent != null) {
@@ -151,16 +152,16 @@ public class SnapshotItem extends TenantEntity {
     // ===== Private 검증/헬퍼 메서드 =====
     private void validateDepth() {
         if (this.depth > MAX_DEPTH) {
-            throw new IllegalArgumentException("최대 깊이(10단계)를 초과할 수 없습니다");
+            throw new IllegalArgumentException(ValidationMessages.MAX_DEPTH_EXCEEDED);
         }
     }
 
     private void validateItemName(String itemName) {
         if (itemName == null || itemName.isBlank()) {
-            throw new IllegalArgumentException("항목 이름은 필수입니다");
+            throw new IllegalArgumentException(ValidationMessages.ITEM_NAME_REQUIRED);
         }
         if (itemName.length() > 255) {
-            throw new IllegalArgumentException("항목 이름은 255자 이하여야 합니다");
+            throw new IllegalArgumentException(ValidationMessages.ITEM_NAME_TOO_LONG);
         }
     }
 

--- a/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotRelation.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotRelation.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.snapshot.entity;
 
+import com.mzc.lp.common.constant.ValidationMessages;
 import com.mzc.lp.common.entity.TenantEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -47,10 +48,10 @@ public class SnapshotRelation extends TenantEntity {
 
     public static SnapshotRelation createStartPoint(CourseSnapshot snapshot, SnapshotItem toItem) {
         if (toItem == null) {
-            throw new IllegalArgumentException("시작점 항목은 필수입니다");
+            throw new IllegalArgumentException(ValidationMessages.START_POINT_REQUIRED);
         }
         if (toItem.isFolder()) {
-            throw new IllegalArgumentException("폴더는 학습 순서에 포함할 수 없습니다");
+            throw new IllegalArgumentException(ValidationMessages.FOLDER_CANNOT_BE_IN_LEARNING_ORDER);
         }
 
         SnapshotRelation relation = new SnapshotRelation();
@@ -83,17 +84,17 @@ public class SnapshotRelation extends TenantEntity {
     // ===== Private 검증 메서드 =====
     private static void validateRelation(SnapshotItem fromItem, SnapshotItem toItem) {
         if (toItem == null) {
-            throw new IllegalArgumentException("대상 항목은 필수입니다");
+            throw new IllegalArgumentException(ValidationMessages.TARGET_ITEM_REQUIRED);
         }
         if (toItem.isFolder()) {
-            throw new IllegalArgumentException("폴더는 학습 순서에 포함할 수 없습니다");
+            throw new IllegalArgumentException(ValidationMessages.FOLDER_CANNOT_BE_IN_LEARNING_ORDER);
         }
         if (fromItem != null) {
             if (fromItem.isFolder()) {
-                throw new IllegalArgumentException("폴더는 학습 순서에 포함할 수 없습니다");
+                throw new IllegalArgumentException(ValidationMessages.FOLDER_CANNOT_BE_IN_LEARNING_ORDER);
             }
             if (fromItem.getId() != null && fromItem.getId().equals(toItem.getId())) {
-                throw new IllegalArgumentException("자기 자신을 참조할 수 없습니다");
+                throw new IllegalArgumentException(ValidationMessages.CANNOT_REFERENCE_SELF);
             }
         }
     }

--- a/src/main/java/com/mzc/lp/domain/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/controller/WishlistController.java
@@ -1,0 +1,118 @@
+package com.mzc.lp.domain.wishlist.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.wishlist.dto.request.WishlistAddRequest;
+import com.mzc.lp.domain.wishlist.dto.request.WishlistCheckRequest;
+import com.mzc.lp.domain.wishlist.dto.response.WishlistCheckResponse;
+import com.mzc.lp.domain.wishlist.dto.response.WishlistCountResponse;
+import com.mzc.lp.domain.wishlist.dto.response.WishlistItemResponse;
+import com.mzc.lp.domain.wishlist.service.WishlistService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/wishlist")
+@RequiredArgsConstructor
+@Validated
+public class WishlistController {
+
+    private final WishlistService wishlistService;
+
+    /**
+     * 찜 추가
+     */
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<WishlistItemResponse>> addToWishlist(
+            @Valid @RequestBody WishlistAddRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        WishlistItemResponse response = wishlistService.addToWishlist(principal.id(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 찜 삭제
+     */
+    @DeleteMapping("/courses/{courseId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> removeFromWishlist(
+            @PathVariable Long courseId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        wishlistService.removeFromWishlist(principal.id(), courseId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 내 찜 목록 조회
+     */
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<Page<WishlistItemResponse>>> getMyWishlist(
+            @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Page<WishlistItemResponse> response = wishlistService.getWishlist(principal.id(), pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 특정 강의 찜 여부 확인
+     */
+    @GetMapping("/courses/{courseId}/check")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<Boolean>> checkWishlistStatus(
+            @PathVariable Long courseId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        boolean isInWishlist = wishlistService.isInWishlist(principal.id(), courseId);
+        return ResponseEntity.ok(ApiResponse.success(isInWishlist));
+    }
+
+    /**
+     * 여러 강의 찜 여부 일괄 확인
+     */
+    @PostMapping("/check")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<WishlistCheckResponse>> checkWishlistStatusBulk(
+            @Valid @RequestBody WishlistCheckRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        WishlistCheckResponse response = wishlistService.checkWishlistStatus(principal.id(), request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 내 찜 개수 조회
+     */
+    @GetMapping("/count")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<WishlistCountResponse>> getMyWishlistCount(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        WishlistCountResponse response = wishlistService.getWishlistCount(principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 특정 강의의 찜 개수 조회 (공개)
+     */
+    @GetMapping("/courses/{courseId}/count")
+    public ResponseEntity<ApiResponse<WishlistCountResponse>> getCourseWishlistCount(
+            @PathVariable Long courseId
+    ) {
+        WishlistCountResponse response = wishlistService.getCourseWishlistCount(courseId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/wishlist/dto/request/WishlistAddRequest.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/dto/request/WishlistAddRequest.java
@@ -1,0 +1,17 @@
+package com.mzc.lp.domain.wishlist.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class WishlistAddRequest {
+
+    @NotNull(message = "강의 ID는 필수입니다")
+    private Long courseId;
+
+    public WishlistAddRequest(Long courseId) {
+        this.courseId = courseId;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/wishlist/dto/request/WishlistCheckRequest.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/dto/request/WishlistCheckRequest.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.domain.wishlist.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class WishlistCheckRequest {
+
+    @NotEmpty(message = "강의 ID 목록은 필수입니다")
+    private List<Long> courseIds;
+
+    public WishlistCheckRequest(List<Long> courseIds) {
+        this.courseIds = courseIds;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/wishlist/dto/response/WishlistCheckResponse.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/dto/response/WishlistCheckResponse.java
@@ -1,0 +1,27 @@
+package com.mzc.lp.domain.wishlist.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class WishlistCheckResponse {
+
+    private Map<Long, Boolean> wishlistStatus;
+
+    public static WishlistCheckResponse of(List<Long> requestedCourseIds, List<Long> wishlistedCourseIds) {
+        Map<Long, Boolean> statusMap = requestedCourseIds.stream()
+                .collect(Collectors.toMap(
+                        id -> id,
+                        wishlistedCourseIds::contains
+                ));
+
+        return WishlistCheckResponse.builder()
+                .wishlistStatus(statusMap)
+                .build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/wishlist/dto/response/WishlistCountResponse.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/dto/response/WishlistCountResponse.java
@@ -1,0 +1,17 @@
+package com.mzc.lp.domain.wishlist.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class WishlistCountResponse {
+
+    private long count;
+
+    public static WishlistCountResponse of(long count) {
+        return WishlistCountResponse.builder()
+                .count(count)
+                .build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/wishlist/dto/response/WishlistItemResponse.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/dto/response/WishlistItemResponse.java
@@ -1,0 +1,49 @@
+package com.mzc.lp.domain.wishlist.dto.response;
+
+import com.mzc.lp.domain.wishlist.entity.WishlistItem;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+public class WishlistItemResponse {
+
+    private Long id;
+    private Long courseId;
+    private String courseTitle;
+    private String courseThumbnailUrl;
+    private String courseLevel;
+    private String courseType;
+    private Integer courseEstimatedHours;
+    private Instant addedAt;
+
+    public static WishlistItemResponse from(WishlistItem item) {
+        return WishlistItemResponse.builder()
+                .id(item.getId())
+                .courseId(item.getCourseId())
+                .addedAt(item.getCreatedAt())
+                .build();
+    }
+
+    public static WishlistItemResponse of(
+            WishlistItem item,
+            String courseTitle,
+            String courseThumbnailUrl,
+            String courseLevel,
+            String courseType,
+            Integer courseEstimatedHours
+    ) {
+        return WishlistItemResponse.builder()
+                .id(item.getId())
+                .courseId(item.getCourseId())
+                .courseTitle(courseTitle)
+                .courseThumbnailUrl(courseThumbnailUrl)
+                .courseLevel(courseLevel)
+                .courseType(courseType)
+                .courseEstimatedHours(courseEstimatedHours)
+                .addedAt(item.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/wishlist/entity/WishlistItem.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/entity/WishlistItem.java
@@ -1,0 +1,44 @@
+package com.mzc.lp.domain.wishlist.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 찜(위시리스트) 아이템 엔티티
+ * 사용자가 관심 있는 강의를 저장하는 기능
+ */
+@Entity
+@Table(
+    name = "cm_wishlist_items",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_wishlist_user_course",
+            columnNames = {"tenant_id", "user_id", "course_id"}
+        )
+    },
+    indexes = {
+        @Index(name = "idx_wishlist_user", columnList = "tenant_id, user_id"),
+        @Index(name = "idx_wishlist_course", columnList = "tenant_id, course_id")
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WishlistItem extends TenantEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "course_id", nullable = false)
+    private Long courseId;
+
+    // ===== 정적 팩토리 메서드 =====
+    public static WishlistItem create(Long userId, Long courseId) {
+        WishlistItem item = new WishlistItem();
+        item.userId = userId;
+        item.courseId = courseId;
+        return item;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/wishlist/exception/AlreadyInWishlistException.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/exception/AlreadyInWishlistException.java
@@ -1,0 +1,16 @@
+package com.mzc.lp.domain.wishlist.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class AlreadyInWishlistException extends BusinessException {
+
+    public AlreadyInWishlistException() {
+        super(ErrorCode.ALREADY_IN_WISHLIST);
+    }
+
+    public AlreadyInWishlistException(Long userId, Long courseId) {
+        super(ErrorCode.ALREADY_IN_WISHLIST,
+              "Course " + courseId + " is already in wishlist for user " + userId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/wishlist/exception/WishlistItemNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/exception/WishlistItemNotFoundException.java
@@ -1,0 +1,16 @@
+package com.mzc.lp.domain.wishlist.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class WishlistItemNotFoundException extends BusinessException {
+
+    public WishlistItemNotFoundException() {
+        super(ErrorCode.WISHLIST_ITEM_NOT_FOUND);
+    }
+
+    public WishlistItemNotFoundException(Long userId, Long courseId) {
+        super(ErrorCode.WISHLIST_ITEM_NOT_FOUND,
+              "Wishlist item not found for user " + userId + " and course " + courseId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/repository/WishlistRepository.java
@@ -1,0 +1,57 @@
+package com.mzc.lp.domain.wishlist.repository;
+
+import com.mzc.lp.domain.wishlist.entity.WishlistItem;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface WishlistRepository extends JpaRepository<WishlistItem, Long> {
+
+    /**
+     * 사용자의 찜 목록 조회 (페이징)
+     */
+    Page<WishlistItem> findByUserId(Long userId, Pageable pageable);
+
+    /**
+     * 사용자의 찜 목록 전체 조회
+     */
+    List<WishlistItem> findByUserId(Long userId);
+
+    /**
+     * 특정 사용자의 특정 강의 찜 여부 확인
+     */
+    Optional<WishlistItem> findByUserIdAndCourseId(Long userId, Long courseId);
+
+    /**
+     * 특정 사용자의 특정 강의 찜 존재 여부
+     */
+    boolean existsByUserIdAndCourseId(Long userId, Long courseId);
+
+    /**
+     * 특정 사용자의 특정 강의 찜 삭제
+     */
+    void deleteByUserIdAndCourseId(Long userId, Long courseId);
+
+    /**
+     * 사용자의 찜 개수 조회
+     */
+    long countByUserId(Long userId);
+
+    /**
+     * 특정 강의의 찜 개수 조회
+     */
+    long countByCourseId(Long courseId);
+
+    /**
+     * 사용자의 여러 강의 찜 여부 일괄 확인
+     */
+    @Query("SELECT w.courseId FROM WishlistItem w WHERE w.userId = :userId AND w.courseId IN :courseIds")
+    List<Long> findWishlistedCourseIds(@Param("userId") Long userId, @Param("courseIds") List<Long> courseIds);
+}

--- a/src/main/java/com/mzc/lp/domain/wishlist/service/WishlistService.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/service/WishlistService.java
@@ -1,0 +1,134 @@
+package com.mzc.lp.domain.wishlist.service;
+
+import com.mzc.lp.domain.course.entity.Course;
+import com.mzc.lp.domain.course.exception.CourseNotFoundException;
+import com.mzc.lp.domain.course.repository.CourseRepository;
+import com.mzc.lp.domain.wishlist.dto.request.WishlistAddRequest;
+import com.mzc.lp.domain.wishlist.dto.request.WishlistCheckRequest;
+import com.mzc.lp.domain.wishlist.dto.response.WishlistCheckResponse;
+import com.mzc.lp.domain.wishlist.dto.response.WishlistCountResponse;
+import com.mzc.lp.domain.wishlist.dto.response.WishlistItemResponse;
+import com.mzc.lp.domain.wishlist.entity.WishlistItem;
+import com.mzc.lp.domain.wishlist.exception.AlreadyInWishlistException;
+import com.mzc.lp.domain.wishlist.exception.WishlistItemNotFoundException;
+import com.mzc.lp.domain.wishlist.repository.WishlistRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WishlistService {
+
+    private final WishlistRepository wishlistRepository;
+    private final CourseRepository courseRepository;
+
+    /**
+     * 찜 추가
+     */
+    @Transactional
+    public WishlistItemResponse addToWishlist(Long userId, WishlistAddRequest request) {
+        Long courseId = request.getCourseId();
+
+        // 강의 존재 확인
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(CourseNotFoundException::new);
+
+        // 이미 찜한 강의인지 확인
+        if (wishlistRepository.existsByUserIdAndCourseId(userId, courseId)) {
+            throw new AlreadyInWishlistException(userId, courseId);
+        }
+
+        // 찜 아이템 생성 및 저장
+        WishlistItem item = WishlistItem.create(userId, courseId);
+        WishlistItem savedItem = wishlistRepository.save(item);
+
+        return WishlistItemResponse.of(
+                savedItem,
+                course.getTitle(),
+                course.getThumbnailUrl(),
+                course.getLevel() != null ? course.getLevel().name() : null,
+                course.getType() != null ? course.getType().name() : null,
+                course.getEstimatedHours()
+        );
+    }
+
+    /**
+     * 찜 삭제
+     */
+    @Transactional
+    public void removeFromWishlist(Long userId, Long courseId) {
+        if (!wishlistRepository.existsByUserIdAndCourseId(userId, courseId)) {
+            throw new WishlistItemNotFoundException(userId, courseId);
+        }
+        wishlistRepository.deleteByUserIdAndCourseId(userId, courseId);
+    }
+
+    /**
+     * 찜 목록 조회 (페이징)
+     */
+    public Page<WishlistItemResponse> getWishlist(Long userId, Pageable pageable) {
+        Page<WishlistItem> wishlistItems = wishlistRepository.findByUserId(userId, pageable);
+
+        // 강의 정보를 한 번에 조회
+        List<Long> courseIds = wishlistItems.getContent().stream()
+                .map(WishlistItem::getCourseId)
+                .collect(Collectors.toList());
+
+        Map<Long, Course> courseMap = courseRepository.findAllById(courseIds).stream()
+                .collect(Collectors.toMap(Course::getId, c -> c));
+
+        return wishlistItems.map(item -> {
+            Course course = courseMap.get(item.getCourseId());
+            if (course != null) {
+                return WishlistItemResponse.of(
+                        item,
+                        course.getTitle(),
+                        course.getThumbnailUrl(),
+                        course.getLevel() != null ? course.getLevel().name() : null,
+                        course.getType() != null ? course.getType().name() : null,
+                        course.getEstimatedHours()
+                );
+            }
+            return WishlistItemResponse.from(item);
+        });
+    }
+
+    /**
+     * 특정 강의 찜 여부 확인
+     */
+    public boolean isInWishlist(Long userId, Long courseId) {
+        return wishlistRepository.existsByUserIdAndCourseId(userId, courseId);
+    }
+
+    /**
+     * 여러 강의 찜 여부 일괄 확인
+     */
+    public WishlistCheckResponse checkWishlistStatus(Long userId, WishlistCheckRequest request) {
+        List<Long> wishlistedCourseIds = wishlistRepository.findWishlistedCourseIds(userId, request.getCourseIds());
+        return WishlistCheckResponse.of(request.getCourseIds(), wishlistedCourseIds);
+    }
+
+    /**
+     * 사용자의 찜 개수 조회
+     */
+    public WishlistCountResponse getWishlistCount(Long userId) {
+        long count = wishlistRepository.countByUserId(userId);
+        return WishlistCountResponse.of(count);
+    }
+
+    /**
+     * 특정 강의의 찜 개수 조회
+     */
+    public WishlistCountResponse getCourseWishlistCount(Long courseId) {
+        long count = wishlistRepository.countByCourseId(courseId);
+        return WishlistCountResponse.of(count);
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/content/service/ThumbnailServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/content/service/ThumbnailServiceTest.java
@@ -11,12 +11,12 @@ import org.junit.jupiter.api.io.TempDir;
 import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 class ThumbnailServiceTest extends TenantTestSupport {
 
@@ -158,15 +158,15 @@ class ThumbnailServiceTest extends TenantTestSupport {
         @Test
         @DisplayName("null 경로 - 에러 없이 무시")
         void deleteThumbnail_nullPath() {
-            // when & then - 에러 없이 완료
-            thumbnailService.deleteThumbnail(null);
+            // when & then
+            assertThatNoException().isThrownBy(() -> thumbnailService.deleteThumbnail(null));
         }
 
         @Test
         @DisplayName("빈 경로 - 에러 없이 무시")
         void deleteThumbnail_emptyPath() {
-            // when & then - 에러 없이 완료
-            thumbnailService.deleteThumbnail("");
+            // when & then
+            assertThatNoException().isThrownBy(() -> thumbnailService.deleteThumbnail(""));
         }
     }
 


### PR DESCRIPTION
## Summary

찜(Wishlist) 기능 백엔드 API 구현 - 사용자가 관심 있는 강의를 저장하고 관리할 수 있는 기능

## Related Issue

- Closes #232

## Changes

- WishlistItem 엔티티 추가 (tenant_id, user_id, course_id 복합 unique 제약)
- WishlistRepository 구현 (페이징 조회, 일괄 확인 쿼리)
- WishlistService 구현 (추가, 삭제, 조회, 일괄 확인, 개수 조회)
- WishlistController REST API 엔드포인트 구현
- ErrorCode에 WISHLIST_ITEM_NOT_FOUND, ALREADY_IN_WISHLIST 추가
- 커스텀 예외 클래스 추가

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

API 엔드포인트:
- POST /api/wishlist - 찜 추가
- DELETE /api/wishlist/courses/{courseId} - 찜 삭제
- GET /api/wishlist - 내 찜 목록 조회 (페이징)
- GET /api/wishlist/courses/{courseId}/check - 특정 강의 찜 여부 확인
- POST /api/wishlist/check - 여러 강의 찜 여부 일괄 확인
- GET /api/wishlist/count - 내 찜 개수
- GET /api/wishlist/courses/{courseId}/count - 강의별 찜 개수