### PR TITLE
feat: 강사 배정 전체 목록 조회 API 추가 (#236)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
+++ b/src/main/java/com/mzc/lp/domain/iis/controller/InstructorAssignmentController.java
@@ -4,11 +4,13 @@ import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.common.security.UserPrincipal;
 import com.mzc.lp.domain.iis.constant.AssignmentAction;
 import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.constant.InstructorRole;
 import com.mzc.lp.domain.iis.dto.request.CancelAssignmentRequest;
 import com.mzc.lp.domain.iis.dto.request.InstructorAvailabilityCheckRequest;
 import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
 import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
 import com.mzc.lp.domain.iis.dto.response.AssignmentHistoryResponse;
+import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentListResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorAvailabilityResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorDetailStatResponse;
@@ -37,6 +39,22 @@ import java.util.List;
 public class InstructorAssignmentController {
 
     private final InstructorAssignmentService assignmentService;
+
+    // ========== 배정 목록 API ==========
+
+    @GetMapping("/api/instructor-assignments")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<Page<InstructorAssignmentListResponse>>> getAssignments(
+            @RequestParam(required = false) Long instructorId,
+            @RequestParam(required = false) Long courseTimeId,
+            @RequestParam(required = false) InstructorRole role,
+            @RequestParam(required = false) AssignmentStatus status,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<InstructorAssignmentListResponse> response = assignmentService.getAssignments(
+                instructorId, courseTimeId, role, status, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 
     // ========== 배정 단건 API ==========
     // 차수 기준 API는 CourseTimeInstructorController에서 처리 (차수 상태 검증 포함)

--- a/src/main/java/com/mzc/lp/domain/iis/dto/response/InstructorAssignmentListResponse.java
+++ b/src/main/java/com/mzc/lp/domain/iis/dto/response/InstructorAssignmentListResponse.java
@@ -1,0 +1,91 @@
+package com.mzc.lp.domain.iis.dto.response;
+
+import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.constant.InstructorRole;
+import com.mzc.lp.domain.iis.entity.InstructorAssignment;
+import com.mzc.lp.domain.program.entity.Program;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.user.entity.User;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+public record InstructorAssignmentListResponse(
+        Long id,
+        InstructorInfo instructor,
+        CourseTimeInfo courseTime,
+        ProgramInfo program,
+        InstructorRole role,
+        AssignmentStatus status,
+        Instant assignedAt,
+        Instant createdAt
+) {
+    public record InstructorInfo(
+            Long id,
+            String name,
+            String email
+    ) {
+        public static InstructorInfo from(User user) {
+            if (user == null) {
+                return null;
+            }
+            return new InstructorInfo(
+                    user.getId(),
+                    user.getName(),
+                    user.getEmail()
+            );
+        }
+    }
+
+    public record CourseTimeInfo(
+            Long id,
+            String title,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        public static CourseTimeInfo from(CourseTime courseTime) {
+            if (courseTime == null) {
+                return null;
+            }
+            return new CourseTimeInfo(
+                    courseTime.getId(),
+                    courseTime.getTitle(),
+                    courseTime.getClassStartDate(),
+                    courseTime.getClassEndDate()
+            );
+        }
+    }
+
+    public record ProgramInfo(
+            Long id,
+            String title
+    ) {
+        public static ProgramInfo from(Program program) {
+            if (program == null) {
+                return null;
+            }
+            return new ProgramInfo(
+                    program.getId(),
+                    program.getTitle()
+            );
+        }
+    }
+
+    public static InstructorAssignmentListResponse from(
+            InstructorAssignment entity,
+            User user,
+            CourseTime courseTime,
+            Program program
+    ) {
+        return new InstructorAssignmentListResponse(
+                entity.getId(),
+                InstructorInfo.from(user),
+                CourseTimeInfo.from(courseTime),
+                ProgramInfo.from(program),
+                entity.getRole(),
+                entity.getStatus(),
+                entity.getAssignedAt(),
+                entity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/iis/repository/InstructorAssignmentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/iis/repository/InstructorAssignmentRepository.java
@@ -15,7 +15,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-public interface InstructorAssignmentRepository extends JpaRepository<InstructorAssignment, Long> {
+public interface InstructorAssignmentRepository extends JpaRepository<InstructorAssignment, Long>, InstructorAssignmentRepositoryCustom {
 
     Optional<InstructorAssignment> findByIdAndTenantId(Long id, Long tenantId);
 

--- a/src/main/java/com/mzc/lp/domain/iis/repository/InstructorAssignmentRepositoryCustom.java
+++ b/src/main/java/com/mzc/lp/domain/iis/repository/InstructorAssignmentRepositoryCustom.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.domain.iis.repository;
+
+import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.constant.InstructorRole;
+import com.mzc.lp.domain.iis.entity.InstructorAssignment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface InstructorAssignmentRepositoryCustom {
+
+    Page<InstructorAssignment> searchAssignments(
+            Long tenantId,
+            Long instructorId,
+            Long courseTimeId,
+            InstructorRole role,
+            AssignmentStatus status,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/mzc/lp/domain/iis/repository/InstructorAssignmentRepositoryCustomImpl.java
+++ b/src/main/java/com/mzc/lp/domain/iis/repository/InstructorAssignmentRepositoryCustomImpl.java
@@ -1,0 +1,97 @@
+package com.mzc.lp.domain.iis.repository;
+
+import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.constant.InstructorRole;
+import com.mzc.lp.domain.iis.entity.InstructorAssignment;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+public class InstructorAssignmentRepositoryCustomImpl implements InstructorAssignmentRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public Page<InstructorAssignment> searchAssignments(
+            Long tenantId,
+            Long instructorId,
+            Long courseTimeId,
+            InstructorRole role,
+            AssignmentStatus status,
+            Pageable pageable
+    ) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+
+        // Main query
+        CriteriaQuery<InstructorAssignment> query = cb.createQuery(InstructorAssignment.class);
+        Root<InstructorAssignment> assignment = query.from(InstructorAssignment.class);
+
+        List<Predicate> predicates = buildPredicates(cb, assignment, tenantId, instructorId, courseTimeId, role, status);
+        query.where(predicates.toArray(new Predicate[0]));
+        query.orderBy(cb.desc(assignment.get("createdAt")));
+
+        TypedQuery<InstructorAssignment> typedQuery = entityManager.createQuery(query);
+        typedQuery.setFirstResult((int) pageable.getOffset());
+        typedQuery.setMaxResults(pageable.getPageSize());
+
+        List<InstructorAssignment> assignments = typedQuery.getResultList();
+
+        // Count query
+        CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
+        Root<InstructorAssignment> countRoot = countQuery.from(InstructorAssignment.class);
+
+        List<Predicate> countPredicates = buildPredicates(cb, countRoot, tenantId, instructorId, courseTimeId, role, status);
+        countQuery.select(cb.count(countRoot));
+        countQuery.where(countPredicates.toArray(new Predicate[0]));
+
+        Long total = entityManager.createQuery(countQuery).getSingleResult();
+
+        return new PageImpl<>(assignments, pageable, total);
+    }
+
+    private List<Predicate> buildPredicates(
+            CriteriaBuilder cb,
+            Root<InstructorAssignment> assignment,
+            Long tenantId,
+            Long instructorId,
+            Long courseTimeId,
+            InstructorRole role,
+            AssignmentStatus status
+    ) {
+        List<Predicate> predicates = new ArrayList<>();
+
+        // tenantId 필수
+        predicates.add(cb.equal(assignment.get("tenantId"), tenantId));
+
+        if (instructorId != null) {
+            predicates.add(cb.equal(assignment.get("userKey"), instructorId));
+        }
+
+        if (courseTimeId != null) {
+            predicates.add(cb.equal(assignment.get("timeKey"), courseTimeId));
+        }
+
+        if (role != null) {
+            predicates.add(cb.equal(assignment.get("role"), role));
+        }
+
+        if (status != null) {
+            predicates.add(cb.equal(assignment.get("status"), status));
+        }
+
+        return predicates;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentService.java
+++ b/src/main/java/com/mzc/lp/domain/iis/service/InstructorAssignmentService.java
@@ -2,11 +2,13 @@ package com.mzc.lp.domain.iis.service;
 
 import com.mzc.lp.domain.iis.constant.AssignmentAction;
 import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.constant.InstructorRole;
 import com.mzc.lp.domain.iis.dto.request.AssignInstructorRequest;
 import com.mzc.lp.domain.iis.dto.request.CancelAssignmentRequest;
 import com.mzc.lp.domain.iis.dto.request.ReplaceInstructorRequest;
 import com.mzc.lp.domain.iis.dto.request.UpdateRoleRequest;
 import com.mzc.lp.domain.iis.dto.response.AssignmentHistoryResponse;
+import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentListResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorAssignmentResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorAvailabilityResponse;
 import com.mzc.lp.domain.iis.dto.response.InstructorDetailStatResponse;
@@ -28,6 +30,14 @@ public interface InstructorAssignmentService {
     List<InstructorAssignmentResponse> getInstructorsByTimeId(Long timeId, AssignmentStatus status);
 
     InstructorAssignmentResponse getAssignment(Long id);
+
+    Page<InstructorAssignmentListResponse> getAssignments(
+            Long instructorId,
+            Long courseTimeId,
+            InstructorRole role,
+            AssignmentStatus status,
+            Pageable pageable
+    );
 
     Page<InstructorAssignmentResponse> getAssignmentsByUserId(Long userId, AssignmentStatus status, Pageable pageable);
 


### PR DESCRIPTION
## Summary
- 전체 강사 배정 목록 조회 API 구현 (`GET /api/instructor-assignments`)
- 운영자/관리자가 전체 강사 배정 현황을 필터링하여 조회 가능

## Related Issue
- Closes #236

## Changes
- `InstructorAssignmentRepositoryCustom` - 동적 쿼리 인터페이스 추가
- `InstructorAssignmentRepositoryCustomImpl` - Criteria API 기반 구현
- `InstructorAssignmentListResponse` - 강사, 차수, 프로그램 정보 포함 DTO
- `InstructorAssignmentService` - `getAssignments()` 메서드 추가
- `InstructorAssignmentServiceImpl` - N+1 방지 벌크 조회 구현
- `InstructorAssignmentController` - 엔드포인트 추가

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] 코드 컨벤션 준수
- [x] 기존 코드 패턴과 일관성 유지
- [x] N+1 문제 방지 (벌크 조회)
- [x] 전체 테스트 통과

## Test plan
- [x] OPERATOR 토큰으로 `GET /api/instructor-assignments` 호출
- [x] 필터 파라미터 테스트 (instructorId, courseTimeId, role, status)
- [x] 페이징 테스트 (page, size, sort)
- [ ] 권한 테스트 (LEARNER → 403 Forbidden)

## Additional Notes
- 기존 `/api/users/{userId}/instructor-assignments`는 특정 사용자 배정 조회용으로 유지
- 새 API는 전체 배정 현황 파악용 (관리자 대시보드 등)