### PR TITLE
fix: /courses/my 라우팅 충돌 수정

### DIFF
--- a/src/main/java/com/mzc/lp/domain/course/controller/CourseController.java
+++ b/src/main/java/com/mzc/lp/domain/course/controller/CourseController.java
@@ -58,10 +58,24 @@ public class CourseController {
     }
 
     /**
+     * 내가 생성한 강의 목록 조회
+     * GET /api/courses/my
+     */
+    @GetMapping("/my")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<Page<CourseResponse>>> getMyCourses(
+            @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Page<CourseResponse> response = courseService.getMyCourses(principal.id(), pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
      * 강의 상세 조회
      * GET /api/courses/{courseId}
      */
-    @GetMapping("/{courseId}")
+    @GetMapping("/{courseId:\\d+}")
     public ResponseEntity<ApiResponse<CourseDetailResponse>> getCourseDetail(
             @PathVariable @Positive Long courseId,
             @AuthenticationPrincipal UserPrincipal principal
@@ -74,7 +88,7 @@ public class CourseController {
      * 강의 수정
      * PUT /api/courses/{courseId}
      */
-    @PutMapping("/{courseId}")
+    @PutMapping("/{courseId:\\d+}")
     @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<CourseResponse>> updateCourse(
             @PathVariable @Positive Long courseId,
@@ -89,7 +103,7 @@ public class CourseController {
      * 강의 삭제
      * DELETE /api/courses/{courseId}
      */
-    @DeleteMapping("/{courseId}")
+    @DeleteMapping("/{courseId:\\d+}")
     @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<Void> deleteCourse(
             @PathVariable @Positive Long courseId,

--- a/src/main/java/com/mzc/lp/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/mzc/lp/domain/course/repository/CourseRepository.java
@@ -25,4 +25,6 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     Optional<Course> findByIdWithItems(@Param("id") Long id, @Param("tenantId") Long tenantId);
 
     boolean existsByIdAndTenantId(Long id, Long tenantId);
+
+    Page<Course> findByTenantIdAndCreatedBy(Long tenantId, Long createdBy, Pageable pageable);
 }

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseService.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseService.java
@@ -48,4 +48,12 @@ public interface CourseService {
      * @param isTenantAdmin 테넌트 관리자 여부
      */
     void deleteCourse(Long courseId, Long currentUserId, boolean isTenantAdmin);
+
+    /**
+     * 내가 생성한 강의 목록 조회
+     * @param creatorId 생성자 ID
+     * @param pageable 페이징 정보
+     * @return 강의 목록 페이지
+     */
+    Page<CourseResponse> getMyCourses(Long creatorId, Pageable pageable);
 }

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
@@ -129,4 +129,14 @@ public class CourseServiceImpl implements CourseService {
         courseRepository.delete(course);
         log.info("Course deleted: id={}", courseId);
     }
+
+    @Override
+    public Page<CourseResponse> getMyCourses(Long creatorId, Pageable pageable) {
+        log.debug("Getting my courses: creatorId={}", creatorId);
+
+        Page<Course> courses = courseRepository.findByTenantIdAndCreatedBy(
+                TenantContext.getCurrentTenantId(), creatorId, pageable);
+
+        return courses.map(CourseResponse::from);
+    }
 }


### PR DESCRIPTION
## Summary
- `/{courseId}` 경로에 정규식(`\d+`) 추가하여 숫자만 매칭되도록 변경
- `/my` 엔드포인트 추가로 토큰 기반 사용자의 강의 목록 조회 지원
- Service, Repository 레이어에 `getMyCourses` 메서드 추가

## 변경 파일
- `CourseController.java` - 정규식 패턴 및 /my 엔드포인트 추가
- `CourseService.java` - getMyCourses 메서드 시그니처 추가
- `CourseServiceImpl.java` - getMyCourses 구현
- `CourseRepository.java` - findByTenantIdAndCreatedBy 쿼리 메서드 추가

## Test plan
- [ ] `/api/courses/my` 요청 시 현재 사용자의 강의 목록 반환 확인
- [ ] `/api/courses/123` 요청 시 정상적으로 강의 상세 조회
- [ ] `/api/courses/abc` 요청 시 404 또는 적절한 에러 응답 확인

Closes #239