### PR TITLE
fix: SnapshotController에서 createdBy를 UserPrincipal에서 추출하도록 변경

### DIFF
--- a/src/main/java/com/mzc/lp/domain/snapshot/controller/SnapshotController.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/controller/SnapshotController.java
@@ -38,10 +38,9 @@ public class SnapshotController {
     @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<SnapshotDetailResponse>> createSnapshotFromCourse(
             @PathVariable @Positive Long courseId,
-            @RequestParam @Positive Long createdBy,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        SnapshotDetailResponse response = snapshotService.createSnapshotFromCourse(courseId, createdBy);
+        SnapshotDetailResponse response = snapshotService.createSnapshotFromCourse(courseId, principal.id());
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 
@@ -66,10 +65,9 @@ public class SnapshotController {
     @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<SnapshotResponse>> createSnapshot(
             @Valid @RequestBody CreateSnapshotRequest request,
-            @RequestParam @Positive Long createdBy,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        SnapshotResponse response = snapshotService.createSnapshot(request, createdBy);
+        SnapshotResponse response = snapshotService.createSnapshot(request, principal.id());
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 


### PR DESCRIPTION
## Summary

- `createSnapshotFromCourse`, `createSnapshot` 엔드포인트에서 `@RequestParam createdBy` 제거
- 인증된 사용자 정보(`UserPrincipal`)에서 ID 추출하여 서비스에 전달

## 변경 이유

**문제**: 필수 파라미터 `createdBy`가 누락되어 에러 발생
```
Required request parameter 'createdBy' for method parameter type Long is not present
```

**보안 개선**: 클라이언트가 `createdBy`를 직접 전달하면 다른 사용자로 위장 가능 → 인증 토큰에서 추출하여 해결

## Test plan

- [ ] `POST /api/courses/{courseId}/snapshots` 호출 시 createdBy 파라미터 없이 정상 동작 확인
- [ ] `POST /api/snapshots` 호출 시 createdBy 파라미터 없이 정상 동작 확인
- [ ] 생성된 스냅샷의 createdBy가 인증된 사용자 ID와 일치하는지 확인

Closes #245