### PR TITLE
fix: 내 댓글 조회 쿼리 수정

### DIFF
--- a/src/main/java/com/mzc/lp/domain/community/repository/CommunityCommentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/community/repository/CommunityCommentRepository.java
@@ -31,10 +31,10 @@ public interface CommunityCommentRepository extends JpaRepository<CommunityComme
 
     void deleteByPostId(Long postId);
 
-    @Query("SELECT DISTINCT c.postId FROM CommunityComment c WHERE c.authorId = :authorId ORDER BY c.createdAt DESC")
+    @Query("SELECT c.postId FROM CommunityComment c WHERE c.authorId = :authorId GROUP BY c.postId ORDER BY MAX(c.createdAt) DESC")
     List<Long> findDistinctPostIdsByAuthorId(@Param("authorId") Long authorId);
 
-    @Query("SELECT DISTINCT c.postId FROM CommunityComment c WHERE c.authorId = :authorId ORDER BY c.createdAt DESC")
+    @Query("SELECT c.postId FROM CommunityComment c WHERE c.authorId = :authorId GROUP BY c.postId ORDER BY MAX(c.createdAt) DESC")
     Page<Long> findDistinctPostIdsByAuthorIdPaged(@Param("authorId") Long authorId, Pageable pageable);
 
     List<CommunityComment> findByAuthorId(Long authorId);


### PR DESCRIPTION
## Summary

내 댓글 조회 API에서 발생하던 MySQL DISTINCT + ORDER BY 호환성 오류를 수정했습니다.

## Related Issue

- Closes #

## Changes

- CommunityCommentRepository의 findDistinctPostIdsByAuthorId 쿼리 수정
- `SELECT DISTINCT ... ORDER BY` → `SELECT ... GROUP BY ... ORDER BY MAX()` 패턴으로 변경
- MySQL의 ONLY_FULL_GROUP_BY 모드와 호환되도록 개선

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

기존 쿼리:
```sql
SELECT DISTINCT c.postId FROM CommunityComment c WHERE c.authorId = :authorId ORDER BY c.createdAt DESC

수정된 쿼리:
SELECT c.postId FROM CommunityComment c WHERE c.authorId = :authorId GROUP BY c.postId ORDER BY MAX(c.createdAt) DESC

MySQL에서 DISTINCT와 ORDER BY를 함께 사용할 때, ORDER BY 절의 컬럼이 SELECT 절에 없으면 오류가 발생합니다. GROUP BY와 MAX() 집계 함수를 사용하여 동일한 결과를 얻으면서 호환성 문제를 해결했습니다.