### PR TITLE
Feat/좋아요(게시글/댓글) 및 찜 기능의 동시성 처리

### DIFF
--- a/src/main/java/com/mzc/lp/domain/community/repository/CommunityCommentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/community/repository/CommunityCommentRepository.java
@@ -31,10 +31,10 @@ public interface CommunityCommentRepository extends JpaRepository<CommunityComme
 
     void deleteByPostId(Long postId);
 
-    @Query("SELECT DISTINCT c.postId FROM CommunityComment c WHERE c.authorId = :authorId ORDER BY c.createdAt DESC")
+    @Query("SELECT c.postId FROM CommunityComment c WHERE c.authorId = :authorId GROUP BY c.postId ORDER BY MAX(c.createdAt) DESC")
     List<Long> findDistinctPostIdsByAuthorId(@Param("authorId") Long authorId);
 
-    @Query("SELECT DISTINCT c.postId FROM CommunityComment c WHERE c.authorId = :authorId ORDER BY c.createdAt DESC")
+    @Query("SELECT c.postId FROM CommunityComment c WHERE c.authorId = :authorId GROUP BY c.postId ORDER BY MAX(c.createdAt) DESC")
     Page<Long> findDistinctPostIdsByAuthorIdPaged(@Param("authorId") Long authorId, Pageable pageable);
 
     List<CommunityComment> findByAuthorId(Long authorId);


### PR DESCRIPTION
## Summary

좋아요(게시글/댓글) 및 찜 기능의 동시성 문제를 해결하기 위해 DataIntegrityViolationException 처리를 추가했습니다.

## Related Issue

- Closes #

## Changes

- CommunityPostService.likePost()에 DataIntegrityViolationException 처리 추가
- CommunityCommentService.likeComment()에 DataIntegrityViolationException 처리 추가
- WishlistService.addToWishlist()에 DataIntegrityViolationException 처리 추가
- flush()를 통해 즉시 DB에 반영하여 유니크 제약조건 위반 즉시 감지

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

기존에는 exists 체크 후 save를 하는 방식으로 동시성 이슈가 발생할 수 있었습니다. 두 요청이 거의 동시에 exists 체크를 통과하면 둘 다 save를 시도하게 되어 DB 유니크 제약조건 위반 에러가 발생했습니다.

이번 수정으로 DataIntegrityViolationException을 catch하여 이미 존재하는 경우로 처리하도록 개선했습니다.