### PR TITLE
feat: 학습자용 차수 공개 API 및 ProgramResponse 필드, 카테고리 정보 추가 (#254)

### DIFF
--- a/src/main/java/com/mzc/lp/common/config/SecurityConfig.java
+++ b/src/main/java/com/mzc/lp/common/config/SecurityConfig.java
@@ -49,7 +49,8 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/uploads/**").permitAll()  // 정적 리소스 (썸네일 등) 인증 없이 접근 허용
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/courses", "/api/courses/**").permitAll()  // 강의 목록/상세 조회 공개
-                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/community/posts", "/api/community/posts/**", "/api/community/categories").permitAll();  // 커뮤니티 게시글/카테고리 조회 공개
+                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/community/posts", "/api/community/posts/**", "/api/community/categories").permitAll()  // 커뮤니티 게시글/카테고리 조회 공개
+                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/public/course-times", "/api/public/course-times/**").permitAll();  // 학습자용 차수 목록/상세 조회 공개
                     // H2 Console은 명시적으로 활성화된 경우에만 허용
                     if (h2ConsoleEnabled) {
                         auth.requestMatchers("/h2-console/**").permitAll();

--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -66,6 +66,7 @@ public enum ErrorCode {
     CANNOT_DELETE_MAIN_INSTRUCTOR(HttpStatus.BAD_REQUEST, "TS007", "Cannot delete main instructor while course is ongoing"),
     MAIN_INSTRUCTOR_REQUIRED(HttpStatus.BAD_REQUEST, "TS008", "Main instructor required for opening course time"),
     UNAUTHORIZED_COURSE_TIME_ACCESS(HttpStatus.FORBIDDEN, "TS009", "Not authorized to access this course time"),
+    COURSE_TIME_NOT_AVAILABLE(HttpStatus.NOT_FOUND, "TS010", "CourseTime is not available for public access"),
 
     // Enrollment (SIS)
     ENROLLMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "SIS001", "Enrollment not found"),

--- a/src/main/java/com/mzc/lp/domain/program/dto/response/ProgramResponse.java
+++ b/src/main/java/com/mzc/lp/domain/program/dto/response/ProgramResponse.java
@@ -1,11 +1,14 @@
 package com.mzc.lp.domain.program.dto.response;
 
+import com.mzc.lp.domain.course.entity.Course;
 import com.mzc.lp.domain.program.constant.ProgramLevel;
 import com.mzc.lp.domain.program.constant.ProgramStatus;
 import com.mzc.lp.domain.program.constant.ProgramType;
 import com.mzc.lp.domain.program.entity.Program;
+import com.mzc.lp.domain.snapshot.entity.CourseSnapshot;
 
 import java.time.Instant;
+import java.time.LocalDate;
 
 public record ProgramResponse(
         Long id,
@@ -23,10 +26,23 @@ public record ProgramResponse(
         Long ownerId,
         String ownerName,
         String ownerEmail,
+        // Course 권장 운영 기간 (차수 생성 시 기본값으로 활용)
+        LocalDate courseStartDate,
+        LocalDate courseEndDate,
         Instant createdAt,
         Instant updatedAt
 ) {
     public static ProgramResponse from(Program program) {
+        LocalDate courseStartDate = null;
+        LocalDate courseEndDate = null;
+
+        CourseSnapshot snapshot = program.getSnapshot();
+        if (snapshot != null && snapshot.getSourceCourse() != null) {
+            Course course = snapshot.getSourceCourse();
+            courseStartDate = course.getStartDate();
+            courseEndDate = course.getEndDate();
+        }
+
         return new ProgramResponse(
                 program.getId(),
                 program.getTitle(),
@@ -38,16 +54,28 @@ public record ProgramResponse(
                 program.getStatus(),
                 program.getCreatedBy(),
                 null,
-                program.getSnapshot() != null ? program.getSnapshot().getId() : null,
+                snapshot != null ? snapshot.getId() : null,
                 null,
                 null,
                 null,
+                courseStartDate,
+                courseEndDate,
                 program.getCreatedAt(),
                 program.getUpdatedAt()
         );
     }
 
     public static ProgramResponse from(Program program, String creatorName, Long ownerId, String ownerName, String ownerEmail) {
+        LocalDate courseStartDate = null;
+        LocalDate courseEndDate = null;
+
+        CourseSnapshot snapshot = program.getSnapshot();
+        if (snapshot != null && snapshot.getSourceCourse() != null) {
+            Course course = snapshot.getSourceCourse();
+            courseStartDate = course.getStartDate();
+            courseEndDate = course.getEndDate();
+        }
+
         return new ProgramResponse(
                 program.getId(),
                 program.getTitle(),
@@ -59,10 +87,12 @@ public record ProgramResponse(
                 program.getStatus(),
                 program.getCreatedBy(),
                 creatorName,
-                program.getSnapshot() != null ? program.getSnapshot().getId() : null,
+                snapshot != null ? snapshot.getId() : null,
                 ownerId,
                 ownerName,
                 ownerEmail,
+                courseStartDate,
+                courseEndDate,
                 program.getCreatedAt(),
                 program.getUpdatedAt()
         );

--- a/src/main/java/com/mzc/lp/domain/program/repository/ProgramRepository.java
+++ b/src/main/java/com/mzc/lp/domain/program/repository/ProgramRepository.java
@@ -33,8 +33,11 @@ public interface ProgramRepository extends JpaRepository<Program, Long> {
     @Query("SELECT COUNT(p) FROM Program p WHERE p.tenantId = :tenantId AND p.status = 'PENDING'")
     long countPendingPrograms(@Param("tenantId") Long tenantId);
 
-    @Query("SELECT p FROM Program p LEFT JOIN FETCH p.snapshot WHERE p.id = :id AND p.tenantId = :tenantId")
+    @Query("SELECT p FROM Program p LEFT JOIN FETCH p.snapshot s LEFT JOIN FETCH s.sourceCourse WHERE p.id = :id AND p.tenantId = :tenantId")
     Optional<Program> findByIdWithSnapshot(@Param("id") Long id, @Param("tenantId") Long tenantId);
+
+    @Query("SELECT p FROM Program p LEFT JOIN FETCH p.snapshot s LEFT JOIN FETCH s.sourceCourse WHERE p.id IN :ids")
+    List<Program> findAllWithSnapshotAndCourse(@Param("ids") List<Long> ids);
 
     boolean existsByIdAndTenantId(Long id, Long tenantId);
 

--- a/src/main/java/com/mzc/lp/domain/program/service/ProgramServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/program/service/ProgramServiceImpl.java
@@ -142,12 +142,17 @@ public class ProgramServiceImpl implements ProgramService {
                 .toList();
         Map<Long, User> ownerMap = findOwnersByProgramIds(programIds);
 
+        // 4. Snapshot + Course 일괄 조회 (courseStartDate/courseEndDate용)
+        Map<Long, Program> programWithCourseMap = programRepository.findAllWithSnapshotAndCourse(programIds).stream()
+                .collect(Collectors.toMap(Program::getId, Function.identity()));
+
         return programs.map(program -> {
             User creator = userMap.get(program.getCreatedBy());
             User owner = ownerMap.get(program.getId());
+            Program programWithCourse = programWithCourseMap.get(program.getId());
 
             return ProgramResponse.from(
-                    program,
+                    programWithCourse != null ? programWithCourse : program,
                     creator != null ? creator.getName() : null,
                     owner != null ? owner.getId() : null,
                     owner != null ? owner.getName() : null,

--- a/src/main/java/com/mzc/lp/domain/ts/controller/PublicCourseTimeController.java
+++ b/src/main/java/com/mzc/lp/domain/ts/controller/PublicCourseTimeController.java
@@ -35,6 +35,7 @@ public class PublicCourseTimeController {
      * @param programId    프로그램 ID 필터
      * @param isFree       무료/유료 필터
      * @param keyword      제목 검색 키워드
+     * @param categoryId   카테고리 ID 필터
      * @param pageable     페이징 정보
      * @return 페이징된 차수 목록
      */
@@ -45,10 +46,11 @@ public class PublicCourseTimeController {
             @RequestParam(required = false) Long programId,
             @RequestParam(required = false) Boolean isFree,
             @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) Long categoryId,
             @PageableDefault(size = 20) Pageable pageable
     ) {
         Page<CourseTimeCatalogResponse> response = publicCourseTimeService.getPublicCourseTimes(
-                status, deliveryType, programId, isFree, keyword, pageable
+                status, deliveryType, programId, isFree, keyword, categoryId, pageable
         );
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/mzc/lp/domain/ts/controller/PublicCourseTimeController.java
+++ b/src/main/java/com/mzc/lp/domain/ts/controller/PublicCourseTimeController.java
@@ -1,0 +1,69 @@
+package com.mzc.lp.domain.ts.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+import com.mzc.lp.domain.ts.constant.DeliveryType;
+import com.mzc.lp.domain.ts.dto.response.CourseTimeCatalogResponse;
+import com.mzc.lp.domain.ts.dto.response.CourseTimePublicDetailResponse;
+import com.mzc.lp.domain.ts.service.PublicCourseTimeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 학습자용 CourseTime Public API Controller
+ */
+@RestController
+@RequestMapping("/api/public/course-times")
+@RequiredArgsConstructor
+@Validated
+public class PublicCourseTimeController {
+
+    private final PublicCourseTimeService publicCourseTimeService;
+
+    /**
+     * 학습자용 차수 목록 조회 (카탈로그)
+     *
+     * @param status       상태 필터 (다중 선택 가능, 기본: RECRUITING, ONGOING)
+     * @param deliveryType 운영 방식 필터
+     * @param programId    프로그램 ID 필터
+     * @param isFree       무료/유료 필터
+     * @param keyword      제목 검색 키워드
+     * @param pageable     페이징 정보
+     * @return 페이징된 차수 목록
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<CourseTimeCatalogResponse>>> getPublicCourseTimes(
+            @RequestParam(required = false) List<CourseTimeStatus> status,
+            @RequestParam(required = false) DeliveryType deliveryType,
+            @RequestParam(required = false) Long programId,
+            @RequestParam(required = false) Boolean isFree,
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<CourseTimeCatalogResponse> response = publicCourseTimeService.getPublicCourseTimes(
+                status, deliveryType, programId, isFree, keyword, pageable
+        );
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 학습자용 차수 상세 조회
+     *
+     * @param id 차수 ID
+     * @return 차수 상세 정보 (커리큘럼, 강사 정보 포함)
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<CourseTimePublicDetailResponse>> getPublicCourseTime(
+            @PathVariable Long id
+    ) {
+        CourseTimePublicDetailResponse response = publicCourseTimeService.getPublicCourseTime(id);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/dto/response/CourseTimeCatalogResponse.java
+++ b/src/main/java/com/mzc/lp/domain/ts/dto/response/CourseTimeCatalogResponse.java
@@ -1,0 +1,63 @@
+package com.mzc.lp.domain.ts.dto.response;
+
+import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+import com.mzc.lp.domain.ts.constant.DeliveryType;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 학습자용 CourseTime 목록 응답 DTO (카탈로그)
+ */
+public record CourseTimeCatalogResponse(
+        Long id,
+        String title,
+        CourseTimeStatus status,
+        DeliveryType deliveryType,
+        boolean isOnDemand,
+        LocalDate enrollStartDate,
+        LocalDate enrollEndDate,
+        LocalDate classStartDate,
+        LocalDate classEndDate,
+        Integer capacity,
+        Integer currentEnrollment,
+        Integer availableSeats,
+        BigDecimal price,
+        boolean isFree,
+        ProgramSummaryResponse program,
+        List<InstructorSummaryResponse> instructors
+) {
+    private static final LocalDate ON_DEMAND_DATE = LocalDate.of(9999, 12, 31);
+
+    public static CourseTimeCatalogResponse from(
+            CourseTime courseTime,
+            List<InstructorSummaryResponse> instructors
+    ) {
+        boolean isOnDemand = ON_DEMAND_DATE.equals(courseTime.getClassEndDate());
+        int availableSeats = Math.max(0,
+                courseTime.getCapacity() != null
+                        ? courseTime.getCapacity() - courseTime.getCurrentEnrollment()
+                        : Integer.MAX_VALUE);
+
+        return new CourseTimeCatalogResponse(
+                courseTime.getId(),
+                courseTime.getTitle(),
+                courseTime.getStatus(),
+                courseTime.getDeliveryType(),
+                isOnDemand,
+                courseTime.getEnrollStartDate(),
+                courseTime.getEnrollEndDate(),
+                courseTime.getClassStartDate(),
+                courseTime.getClassEndDate(),
+                courseTime.getCapacity(),
+                courseTime.getCurrentEnrollment(),
+                availableSeats,
+                courseTime.getPrice(),
+                courseTime.isFree(),
+                ProgramSummaryResponse.forList(courseTime.getProgram()),
+                instructors != null ? instructors : List.of()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/dto/response/CourseTimeCatalogResponse.java
+++ b/src/main/java/com/mzc/lp/domain/ts/dto/response/CourseTimeCatalogResponse.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.ts.dto.response;
 
+import com.mzc.lp.domain.category.entity.Category;
 import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
 import com.mzc.lp.domain.ts.constant.DeliveryType;
 import com.mzc.lp.domain.ts.entity.CourseTime;
@@ -35,6 +36,14 @@ public record CourseTimeCatalogResponse(
             CourseTime courseTime,
             List<InstructorSummaryResponse> instructors
     ) {
+        return from(courseTime, instructors, null);
+    }
+
+    public static CourseTimeCatalogResponse from(
+            CourseTime courseTime,
+            List<InstructorSummaryResponse> instructors,
+            Category category
+    ) {
         boolean isOnDemand = ON_DEMAND_DATE.equals(courseTime.getClassEndDate());
         int availableSeats = Math.max(0,
                 courseTime.getCapacity() != null
@@ -56,7 +65,7 @@ public record CourseTimeCatalogResponse(
                 availableSeats,
                 courseTime.getPrice(),
                 courseTime.isFree(),
-                ProgramSummaryResponse.forList(courseTime.getProgram()),
+                ProgramSummaryResponse.forListWithCategory(courseTime.getProgram(), category),
                 instructors != null ? instructors : List.of()
         );
     }

--- a/src/main/java/com/mzc/lp/domain/ts/dto/response/CourseTimePublicDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/ts/dto/response/CourseTimePublicDetailResponse.java
@@ -1,0 +1,75 @@
+package com.mzc.lp.domain.ts.dto.response;
+
+import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+import com.mzc.lp.domain.ts.constant.DeliveryType;
+import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 학습자용 CourseTime 상세 응답 DTO
+ */
+public record CourseTimePublicDetailResponse(
+        Long id,
+        String title,
+        CourseTimeStatus status,
+        DeliveryType deliveryType,
+        boolean isOnDemand,
+        LocalDate enrollStartDate,
+        LocalDate enrollEndDate,
+        LocalDate classStartDate,
+        LocalDate classEndDate,
+        Integer capacity,
+        Integer currentEnrollment,
+        Integer availableSeats,
+        BigDecimal price,
+        boolean isFree,
+        EnrollmentMethod enrollmentMethod,
+        boolean allowLateEnrollment,
+        Integer minProgressForCompletion,
+        String locationInfo,
+        ProgramSummaryResponse program,
+        List<CurriculumItemResponse> curriculum,
+        List<InstructorSummaryResponse> instructors
+) {
+    private static final LocalDate ON_DEMAND_DATE = LocalDate.of(9999, 12, 31);
+
+    public static CourseTimePublicDetailResponse from(
+            CourseTime courseTime,
+            List<CurriculumItemResponse> curriculum,
+            List<InstructorSummaryResponse> instructors
+    ) {
+        boolean isOnDemand = ON_DEMAND_DATE.equals(courseTime.getClassEndDate());
+        int availableSeats = Math.max(0,
+                courseTime.getCapacity() != null
+                        ? courseTime.getCapacity() - courseTime.getCurrentEnrollment()
+                        : Integer.MAX_VALUE);
+
+        return new CourseTimePublicDetailResponse(
+                courseTime.getId(),
+                courseTime.getTitle(),
+                courseTime.getStatus(),
+                courseTime.getDeliveryType(),
+                isOnDemand,
+                courseTime.getEnrollStartDate(),
+                courseTime.getEnrollEndDate(),
+                courseTime.getClassStartDate(),
+                courseTime.getClassEndDate(),
+                courseTime.getCapacity(),
+                courseTime.getCurrentEnrollment(),
+                availableSeats,
+                courseTime.getPrice(),
+                courseTime.isFree(),
+                courseTime.getEnrollmentMethod(),
+                courseTime.isAllowLateEnrollment(),
+                courseTime.getMinProgressForCompletion(),
+                courseTime.getLocationInfo(),
+                ProgramSummaryResponse.from(courseTime.getProgram()),
+                curriculum != null ? curriculum : List.of(),
+                instructors != null ? instructors : List.of()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/dto/response/CurriculumItemResponse.java
+++ b/src/main/java/com/mzc/lp/domain/ts/dto/response/CurriculumItemResponse.java
@@ -1,0 +1,44 @@
+package com.mzc.lp.domain.ts.dto.response;
+
+import com.mzc.lp.domain.snapshot.entity.SnapshotItem;
+
+import java.util.List;
+
+/**
+ * 커리큘럼 아이템 응답 DTO (트리 구조)
+ */
+public record CurriculumItemResponse(
+        Long id,
+        String itemName,
+        String itemType,
+        boolean isFolder,
+        Integer duration,
+        List<CurriculumItemResponse> children
+) {
+    /**
+     * SnapshotItem을 CurriculumItemResponse로 변환 (children 포함)
+     */
+    public static CurriculumItemResponse fromWithChildren(SnapshotItem item) {
+        if (item == null) {
+            return null;
+        }
+
+        List<CurriculumItemResponse> childResponses = item.getChildren().stream()
+                .map(CurriculumItemResponse::fromWithChildren)
+                .toList();
+
+        Integer duration = null;
+        if (item.getSnapshotLearningObject() != null) {
+            duration = item.getSnapshotLearningObject().getDuration();
+        }
+
+        return new CurriculumItemResponse(
+                item.getId(),
+                item.getItemName(),
+                item.getItemType(),
+                item.isFolder(),
+                duration,
+                childResponses
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/dto/response/InstructorSummaryResponse.java
+++ b/src/main/java/com/mzc/lp/domain/ts/dto/response/InstructorSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.mzc.lp.domain.ts.dto.response;
+
+import com.mzc.lp.domain.iis.constant.InstructorRole;
+import com.mzc.lp.domain.iis.entity.InstructorAssignment;
+import com.mzc.lp.domain.user.entity.User;
+
+public record InstructorSummaryResponse(
+        Long id,
+        String name,
+        InstructorRole role,
+        String profileImageUrl
+) {
+    public static InstructorSummaryResponse from(InstructorAssignment assignment, User user) {
+        if (assignment == null || user == null) {
+            return null;
+        }
+        return new InstructorSummaryResponse(
+                user.getId(),
+                user.getName(),
+                assignment.getRole(),
+                user.getProfileImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/dto/response/ProgramSummaryResponse.java
+++ b/src/main/java/com/mzc/lp/domain/ts/dto/response/ProgramSummaryResponse.java
@@ -1,0 +1,48 @@
+package com.mzc.lp.domain.ts.dto.response;
+
+import com.mzc.lp.domain.program.constant.ProgramLevel;
+import com.mzc.lp.domain.program.constant.ProgramType;
+import com.mzc.lp.domain.program.entity.Program;
+
+public record ProgramSummaryResponse(
+        Long id,
+        String title,
+        String description,
+        String thumbnailUrl,
+        ProgramLevel level,
+        ProgramType type,
+        Integer estimatedHours
+) {
+    public static ProgramSummaryResponse from(Program program) {
+        if (program == null) {
+            return null;
+        }
+        return new ProgramSummaryResponse(
+                program.getId(),
+                program.getTitle(),
+                program.getDescription(),
+                program.getThumbnailUrl(),
+                program.getLevel(),
+                program.getType(),
+                program.getEstimatedHours()
+        );
+    }
+
+    /**
+     * 목록용 요약 응답 (description 제외)
+     */
+    public static ProgramSummaryResponse forList(Program program) {
+        if (program == null) {
+            return null;
+        }
+        return new ProgramSummaryResponse(
+                program.getId(),
+                program.getTitle(),
+                null,
+                program.getThumbnailUrl(),
+                program.getLevel(),
+                program.getType(),
+                program.getEstimatedHours()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/dto/response/ProgramSummaryResponse.java
+++ b/src/main/java/com/mzc/lp/domain/ts/dto/response/ProgramSummaryResponse.java
@@ -1,5 +1,7 @@
 package com.mzc.lp.domain.ts.dto.response;
 
+import com.mzc.lp.domain.category.entity.Category;
+import com.mzc.lp.domain.course.entity.Course;
 import com.mzc.lp.domain.program.constant.ProgramLevel;
 import com.mzc.lp.domain.program.constant.ProgramType;
 import com.mzc.lp.domain.program.entity.Program;
@@ -11,12 +13,15 @@ public record ProgramSummaryResponse(
         String thumbnailUrl,
         ProgramLevel level,
         ProgramType type,
-        Integer estimatedHours
+        Integer estimatedHours,
+        Long categoryId,
+        String categoryName
 ) {
     public static ProgramSummaryResponse from(Program program) {
         if (program == null) {
             return null;
         }
+        Long categoryId = extractCategoryId(program);
         return new ProgramSummaryResponse(
                 program.getId(),
                 program.getTitle(),
@@ -24,7 +29,9 @@ public record ProgramSummaryResponse(
                 program.getThumbnailUrl(),
                 program.getLevel(),
                 program.getType(),
-                program.getEstimatedHours()
+                program.getEstimatedHours(),
+                categoryId,
+                null
         );
     }
 
@@ -35,6 +42,7 @@ public record ProgramSummaryResponse(
         if (program == null) {
             return null;
         }
+        Long categoryId = extractCategoryId(program);
         return new ProgramSummaryResponse(
                 program.getId(),
                 program.getTitle(),
@@ -42,7 +50,39 @@ public record ProgramSummaryResponse(
                 program.getThumbnailUrl(),
                 program.getLevel(),
                 program.getType(),
-                program.getEstimatedHours()
+                program.getEstimatedHours(),
+                categoryId,
+                null
         );
+    }
+
+    /**
+     * 목록용 요약 응답 (카테고리 이름 포함)
+     */
+    public static ProgramSummaryResponse forListWithCategory(Program program, Category category) {
+        if (program == null) {
+            return null;
+        }
+        Long categoryId = extractCategoryId(program);
+        return new ProgramSummaryResponse(
+                program.getId(),
+                program.getTitle(),
+                null,
+                program.getThumbnailUrl(),
+                program.getLevel(),
+                program.getType(),
+                program.getEstimatedHours(),
+                categoryId,
+                category != null ? category.getName() : null
+        );
+    }
+
+    private static Long extractCategoryId(Program program) {
+        if (program.getSnapshot() != null
+                && program.getSnapshot().getSourceCourse() != null) {
+            Course course = program.getSnapshot().getSourceCourse();
+            return course.getCategoryId();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/mzc/lp/domain/ts/exception/CourseTimeNotAvailableException.java
+++ b/src/main/java/com/mzc/lp/domain/ts/exception/CourseTimeNotAvailableException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.ts.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class CourseTimeNotAvailableException extends BusinessException {
+
+    public CourseTimeNotAvailableException() {
+        super(ErrorCode.COURSE_TIME_NOT_AVAILABLE);
+    }
+
+    public CourseTimeNotAvailableException(Long courseTimeId) {
+        super(ErrorCode.COURSE_TIME_NOT_AVAILABLE, "CourseTime is not available for public access: " + courseTimeId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/repository/CourseTimeRepository.java
+++ b/src/main/java/com/mzc/lp/domain/ts/repository/CourseTimeRepository.java
@@ -11,6 +11,7 @@ import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,7 +20,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-public interface CourseTimeRepository extends JpaRepository<CourseTime, Long> {
+public interface CourseTimeRepository extends JpaRepository<CourseTime, Long>, JpaSpecificationExecutor<CourseTime> {
 
     Optional<CourseTime> findByIdAndTenantId(Long id, Long tenantId);
 

--- a/src/main/java/com/mzc/lp/domain/ts/repository/CourseTimeSpecification.java
+++ b/src/main/java/com/mzc/lp/domain/ts/repository/CourseTimeSpecification.java
@@ -66,6 +66,19 @@ public class CourseTimeSpecification {
         };
     }
 
+    public static Specification<CourseTime> withCategoryId(Long categoryId) {
+        return (root, query, cb) -> {
+            if (categoryId == null) {
+                return cb.conjunction();
+            }
+            // CourseTime → Program → Snapshot → SourceCourse.categoryId
+            return cb.equal(
+                    root.get("program").get("snapshot").get("sourceCourse").get("categoryId"),
+                    categoryId
+            );
+        };
+    }
+
     /**
      * Public API용 복합 Specification
      */
@@ -75,13 +88,15 @@ public class CourseTimeSpecification {
             DeliveryType deliveryType,
             Long programId,
             Boolean isFree,
-            String keyword
+            String keyword,
+            Long categoryId
     ) {
         return Specification.where(withTenantId(tenantId))
                 .and(withStatusIn(statuses))
                 .and(withDeliveryType(deliveryType))
                 .and(withProgramId(programId))
                 .and(withIsFree(isFree))
-                .and(withKeyword(keyword));
+                .and(withKeyword(keyword))
+                .and(withCategoryId(categoryId));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/ts/repository/CourseTimeSpecification.java
+++ b/src/main/java/com/mzc/lp/domain/ts/repository/CourseTimeSpecification.java
@@ -1,0 +1,87 @@
+package com.mzc.lp.domain.ts.repository;
+
+import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+import com.mzc.lp.domain.ts.constant.DeliveryType;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+
+/**
+ * CourseTime 동적 쿼리를 위한 Specification
+ */
+public class CourseTimeSpecification {
+
+    private CourseTimeSpecification() {
+        // Utility class
+    }
+
+    public static Specification<CourseTime> withTenantId(Long tenantId) {
+        return (root, query, cb) -> cb.equal(root.get("tenantId"), tenantId);
+    }
+
+    public static Specification<CourseTime> withStatusIn(List<CourseTimeStatus> statuses) {
+        return (root, query, cb) -> {
+            if (statuses == null || statuses.isEmpty()) {
+                return cb.conjunction();
+            }
+            return root.get("status").in(statuses);
+        };
+    }
+
+    public static Specification<CourseTime> withDeliveryType(DeliveryType deliveryType) {
+        return (root, query, cb) -> {
+            if (deliveryType == null) {
+                return cb.conjunction();
+            }
+            return cb.equal(root.get("deliveryType"), deliveryType);
+        };
+    }
+
+    public static Specification<CourseTime> withProgramId(Long programId) {
+        return (root, query, cb) -> {
+            if (programId == null) {
+                return cb.conjunction();
+            }
+            return cb.equal(root.get("program").get("id"), programId);
+        };
+    }
+
+    public static Specification<CourseTime> withIsFree(Boolean isFree) {
+        return (root, query, cb) -> {
+            if (isFree == null) {
+                return cb.conjunction();
+            }
+            return cb.equal(root.get("free"), isFree);
+        };
+    }
+
+    public static Specification<CourseTime> withKeyword(String keyword) {
+        return (root, query, cb) -> {
+            if (keyword == null || keyword.isBlank()) {
+                return cb.conjunction();
+            }
+            String pattern = "%" + keyword.toLowerCase() + "%";
+            return cb.like(cb.lower(root.get("title")), pattern);
+        };
+    }
+
+    /**
+     * Public API용 복합 Specification
+     */
+    public static Specification<CourseTime> forPublicCatalog(
+            Long tenantId,
+            List<CourseTimeStatus> statuses,
+            DeliveryType deliveryType,
+            Long programId,
+            Boolean isFree,
+            String keyword
+    ) {
+        return Specification.where(withTenantId(tenantId))
+                .and(withStatusIn(statuses))
+                .and(withDeliveryType(deliveryType))
+                .and(withProgramId(programId))
+                .and(withIsFree(isFree))
+                .and(withKeyword(keyword));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/ts/service/PublicCourseTimeService.java
+++ b/src/main/java/com/mzc/lp/domain/ts/service/PublicCourseTimeService.java
@@ -1,0 +1,44 @@
+package com.mzc.lp.domain.ts.service;
+
+import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+import com.mzc.lp.domain.ts.constant.DeliveryType;
+import com.mzc.lp.domain.ts.dto.response.CourseTimeCatalogResponse;
+import com.mzc.lp.domain.ts.dto.response.CourseTimePublicDetailResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+/**
+ * 학습자용 CourseTime Public API Service
+ */
+public interface PublicCourseTimeService {
+
+    /**
+     * 학습자용 차수 목록 조회 (카탈로그)
+     *
+     * @param statuses     상태 필터 (기본: RECRUITING, ONGOING)
+     * @param deliveryType 운영 방식 필터
+     * @param programId    프로그램 ID 필터
+     * @param isFree       무료/유료 필터
+     * @param keyword      제목 검색 키워드
+     * @param pageable     페이징 정보
+     * @return 페이징된 차수 목록
+     */
+    Page<CourseTimeCatalogResponse> getPublicCourseTimes(
+            List<CourseTimeStatus> statuses,
+            DeliveryType deliveryType,
+            Long programId,
+            Boolean isFree,
+            String keyword,
+            Pageable pageable
+    );
+
+    /**
+     * 학습자용 차수 상세 조회
+     *
+     * @param id 차수 ID
+     * @return 차수 상세 정보 (커리큘럼, 강사 정보 포함)
+     */
+    CourseTimePublicDetailResponse getPublicCourseTime(Long id);
+}

--- a/src/main/java/com/mzc/lp/domain/ts/service/PublicCourseTimeService.java
+++ b/src/main/java/com/mzc/lp/domain/ts/service/PublicCourseTimeService.java
@@ -22,6 +22,7 @@ public interface PublicCourseTimeService {
      * @param programId    프로그램 ID 필터
      * @param isFree       무료/유료 필터
      * @param keyword      제목 검색 키워드
+     * @param categoryId   카테고리 ID 필터
      * @param pageable     페이징 정보
      * @return 페이징된 차수 목록
      */
@@ -31,6 +32,7 @@ public interface PublicCourseTimeService {
             Long programId,
             Boolean isFree,
             String keyword,
+            Long categoryId,
             Pageable pageable
     );
 

--- a/src/main/java/com/mzc/lp/domain/ts/service/PublicCourseTimeServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/ts/service/PublicCourseTimeServiceImpl.java
@@ -1,0 +1,199 @@
+package com.mzc.lp.domain.ts.service;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.domain.iis.constant.AssignmentStatus;
+import com.mzc.lp.domain.iis.entity.InstructorAssignment;
+import com.mzc.lp.domain.iis.repository.InstructorAssignmentRepository;
+import com.mzc.lp.domain.snapshot.entity.SnapshotItem;
+import com.mzc.lp.domain.snapshot.repository.SnapshotItemRepository;
+import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+import com.mzc.lp.domain.ts.constant.DeliveryType;
+import com.mzc.lp.domain.ts.dto.response.CourseTimeCatalogResponse;
+import com.mzc.lp.domain.ts.dto.response.CourseTimePublicDetailResponse;
+import com.mzc.lp.domain.ts.dto.response.CurriculumItemResponse;
+import com.mzc.lp.domain.ts.dto.response.InstructorSummaryResponse;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.ts.exception.CourseTimeNotAvailableException;
+import com.mzc.lp.domain.ts.exception.CourseTimeNotFoundException;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import com.mzc.lp.domain.ts.repository.CourseTimeSpecification;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PublicCourseTimeServiceImpl implements PublicCourseTimeService {
+
+    private final CourseTimeRepository courseTimeRepository;
+    private final InstructorAssignmentRepository instructorAssignmentRepository;
+    private final SnapshotItemRepository snapshotItemRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 공개 가능한 상태 목록
+     */
+    private static final List<CourseTimeStatus> PUBLIC_STATUSES = Arrays.asList(
+            CourseTimeStatus.RECRUITING,
+            CourseTimeStatus.ONGOING
+    );
+
+    @Override
+    public Page<CourseTimeCatalogResponse> getPublicCourseTimes(
+            List<CourseTimeStatus> statuses,
+            DeliveryType deliveryType,
+            Long programId,
+            Boolean isFree,
+            String keyword,
+            Pageable pageable
+    ) {
+        log.debug("Getting public course times: statuses={}, deliveryType={}, programId={}, isFree={}, keyword={}",
+                statuses, deliveryType, programId, isFree, keyword);
+
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 상태 필터 기본값: RECRUITING, ONGOING
+        List<CourseTimeStatus> effectiveStatuses = (statuses == null || statuses.isEmpty())
+                ? PUBLIC_STATUSES
+                : statuses.stream().filter(PUBLIC_STATUSES::contains).toList();
+
+        // 동적 쿼리 생성
+        Specification<CourseTime> spec = CourseTimeSpecification.forPublicCatalog(
+                tenantId,
+                effectiveStatuses,
+                deliveryType,
+                programId,
+                isFree,
+                keyword
+        );
+
+        Page<CourseTime> courseTimePage = courseTimeRepository.findAll(spec, pageable);
+
+        // N+1 방지: 강사 정보 Bulk 조회
+        List<Long> timeIds = courseTimePage.getContent().stream()
+                .map(CourseTime::getId)
+                .toList();
+
+        Map<Long, List<InstructorSummaryResponse>> instructorMap = getInstructorsByTimeIds(timeIds);
+
+        return courseTimePage.map(ct ->
+                CourseTimeCatalogResponse.from(ct, instructorMap.getOrDefault(ct.getId(), List.of()))
+        );
+    }
+
+    @Override
+    public CourseTimePublicDetailResponse getPublicCourseTime(Long id) {
+        log.debug("Getting public course time detail: id={}", id);
+
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(id, tenantId)
+                .orElseThrow(() -> new CourseTimeNotFoundException(id));
+
+        // 공개 가능한 상태 검증
+        if (!PUBLIC_STATUSES.contains(courseTime.getStatus())) {
+            throw new CourseTimeNotAvailableException(id);
+        }
+
+        // 강사 정보 조회
+        List<InstructorSummaryResponse> instructors = getInstructorsByTimeId(id);
+
+        // 커리큘럼 조회
+        List<CurriculumItemResponse> curriculum = getCurriculum(courseTime);
+
+        return CourseTimePublicDetailResponse.from(courseTime, curriculum, instructors);
+    }
+
+    /**
+     * 차수 ID 목록으로 강사 정보 Bulk 조회 (N+1 방지)
+     */
+    private Map<Long, List<InstructorSummaryResponse>> getInstructorsByTimeIds(List<Long> timeIds) {
+        if (timeIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // ACTIVE 상태 강사 배정 목록 조회
+        List<InstructorAssignment> assignments = instructorAssignmentRepository
+                .findActiveByTimeKeyIn(timeIds, tenantId);
+
+        // 강사 User 정보 Bulk 조회
+        Set<Long> userIds = assignments.stream()
+                .map(InstructorAssignment::getUserKey)
+                .collect(Collectors.toSet());
+
+        Map<Long, User> userMap = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        // timeKey별로 그룹핑하여 반환
+        return assignments.stream()
+                .collect(Collectors.groupingBy(
+                        InstructorAssignment::getTimeKey,
+                        Collectors.mapping(
+                                ia -> InstructorSummaryResponse.from(ia, userMap.get(ia.getUserKey())),
+                                Collectors.toList()
+                        )
+                ));
+    }
+
+    /**
+     * 단일 차수의 강사 정보 조회
+     */
+    private List<InstructorSummaryResponse> getInstructorsByTimeId(Long timeId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        List<InstructorAssignment> assignments = instructorAssignmentRepository
+                .findByTimeKeyAndTenantIdAndStatus(timeId, tenantId, AssignmentStatus.ACTIVE);
+
+        if (assignments.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Long> userIds = assignments.stream()
+                .map(InstructorAssignment::getUserKey)
+                .collect(Collectors.toSet());
+
+        Map<Long, User> userMap = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        return assignments.stream()
+                .map(ia -> InstructorSummaryResponse.from(ia, userMap.get(ia.getUserKey())))
+                .toList();
+    }
+
+    /**
+     * CourseTime에 연결된 Program의 Snapshot에서 커리큘럼 조회
+     */
+    private List<CurriculumItemResponse> getCurriculum(CourseTime courseTime) {
+        if (courseTime.getProgram() == null || courseTime.getProgram().getSnapshot() == null) {
+            return List.of();
+        }
+
+        Long snapshotId = courseTime.getProgram().getSnapshot().getId();
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 루트 아이템만 조회 (children은 엔티티에서 자동 로딩)
+        List<SnapshotItem> rootItems = snapshotItemRepository
+                .findRootItemsWithLo(snapshotId, tenantId);
+
+        return rootItems.stream()
+                .map(CurriculumItemResponse::fromWithChildren)
+                .toList();
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/ts/controller/PublicCourseTimeControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/ts/controller/PublicCourseTimeControllerTest.java
@@ -1,0 +1,308 @@
+package com.mzc.lp.domain.ts.controller;
+
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.iis.repository.InstructorAssignmentRepository;
+import com.mzc.lp.domain.program.entity.Program;
+import com.mzc.lp.domain.program.repository.ProgramRepository;
+import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
+import com.mzc.lp.domain.ts.constant.DeliveryType;
+import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PublicCourseTimeControllerTest extends TenantTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private CourseTimeRepository courseTimeRepository;
+
+    @Autowired
+    private ProgramRepository programRepository;
+
+    @Autowired
+    private UserCourseRoleRepository userCourseRoleRepository;
+
+    @Autowired
+    private InstructorAssignmentRepository instructorAssignmentRepository;
+
+    private Program testProgram;
+
+    @BeforeEach
+    void setUp() {
+        instructorAssignmentRepository.deleteAll();
+        courseTimeRepository.deleteAll();
+        userCourseRoleRepository.deleteAll();
+        programRepository.deleteAll();
+
+        testProgram = createApprovedProgram();
+    }
+
+    private Program createApprovedProgram() {
+        Program program = Program.create("테스트 프로그램", 1L);
+        program.submit();
+        program.approve(1L, "테스트 승인");
+        return programRepository.save(program);
+    }
+
+    private CourseTime createCourseTimeWithStatus(String title, CourseTimeStatus status) {
+        CourseTime courseTime = CourseTime.create(
+                title,
+                DeliveryType.ONLINE,
+                LocalDate.now(),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(7),
+                LocalDate.now().plusDays(30),
+                30,
+                5,
+                EnrollmentMethod.FIRST_COME,
+                80,
+                new BigDecimal("100000"),
+                false,
+                null,
+                true,
+                1L
+        );
+        courseTime.linkProgram(testProgram);
+
+        // 상태 전이
+        if (status == CourseTimeStatus.RECRUITING || status == CourseTimeStatus.ONGOING) {
+            courseTime.open();
+        }
+        if (status == CourseTimeStatus.ONGOING) {
+            courseTime.startClass();
+        }
+
+        return courseTimeRepository.save(courseTime);
+    }
+
+    private CourseTime createOnDemandCourseTime(String title) {
+        CourseTime courseTime = CourseTime.create(
+                title,
+                DeliveryType.ONLINE,
+                LocalDate.of(2020, 1, 1),
+                LocalDate.of(9999, 12, 31),
+                LocalDate.of(2020, 1, 1),
+                LocalDate.of(9999, 12, 31),
+                null,  // 무제한 정원
+                null,
+                EnrollmentMethod.FIRST_COME,
+                80,
+                BigDecimal.ZERO,
+                true,
+                null,
+                true,
+                1L
+        );
+        courseTime.linkProgram(testProgram);
+        courseTime.open();
+
+        return courseTimeRepository.save(courseTime);
+    }
+
+    @Nested
+    @DisplayName("GET /api/public/course-times - 목록 조회")
+    class GetPublicCourseTimes {
+
+        @Test
+        @DisplayName("인증 없이 조회 성공")
+        void getPublicCourseTimes_withoutAuth_success() throws Exception {
+            // given
+            createCourseTimeWithStatus("모집 중 과정", CourseTimeStatus.RECRUITING);
+            createCourseTimeWithStatus("진행 중 과정", CourseTimeStatus.ONGOING);
+
+            // when & then
+            mockMvc.perform(get("/api/public/course-times")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.content", hasSize(2)));
+        }
+
+        @Test
+        @DisplayName("DRAFT 상태 차수는 목록에서 제외")
+        void getPublicCourseTimes_excludeDraft() throws Exception {
+            // given
+            createCourseTimeWithStatus("모집 중 과정", CourseTimeStatus.RECRUITING);
+            createCourseTimeWithStatus("초안 과정", CourseTimeStatus.DRAFT);
+
+            // when & then
+            mockMvc.perform(get("/api/public/course-times")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content", hasSize(1)))
+                    .andExpect(jsonPath("$.data.content[0].title").value("모집 중 과정"));
+        }
+
+        @Test
+        @DisplayName("status 파라미터로 필터링")
+        void getPublicCourseTimes_filterByStatus() throws Exception {
+            // given
+            createCourseTimeWithStatus("모집 중 과정", CourseTimeStatus.RECRUITING);
+            createCourseTimeWithStatus("진행 중 과정", CourseTimeStatus.ONGOING);
+
+            // when & then
+            mockMvc.perform(get("/api/public/course-times")
+                            .param("status", "RECRUITING")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content", hasSize(1)))
+                    .andExpect(jsonPath("$.data.content[0].status").value("RECRUITING"));
+        }
+
+        @Test
+        @DisplayName("isFree 파라미터로 필터링")
+        void getPublicCourseTimes_filterByFree() throws Exception {
+            // given
+            createCourseTimeWithStatus("유료 과정", CourseTimeStatus.RECRUITING);
+            createOnDemandCourseTime("무료 과정");
+
+            // when & then
+            mockMvc.perform(get("/api/public/course-times")
+                            .param("isFree", "true")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content", hasSize(1)))
+                    .andExpect(jsonPath("$.data.content[0].isFree").value(true));
+        }
+
+        @Test
+        @DisplayName("keyword 파라미터로 제목 검색")
+        void getPublicCourseTimes_searchByKeyword() throws Exception {
+            // given
+            createCourseTimeWithStatus("Python 기초 과정", CourseTimeStatus.RECRUITING);
+            createCourseTimeWithStatus("Java 고급 과정", CourseTimeStatus.RECRUITING);
+
+            // when & then
+            mockMvc.perform(get("/api/public/course-times")
+                            .param("keyword", "python")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content", hasSize(1)))
+                    .andExpect(jsonPath("$.data.content[0].title", containsStringIgnoringCase("python")));
+        }
+
+        @Test
+        @DisplayName("상시모집 차수 isOnDemand 필드 검증")
+        void getPublicCourseTimes_onDemandFlag() throws Exception {
+            // given
+            createOnDemandCourseTime("상시모집 과정");
+
+            // when & then
+            mockMvc.perform(get("/api/public/course-times")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content[0].isOnDemand").value(true));
+        }
+
+        @Test
+        @DisplayName("페이징 처리")
+        void getPublicCourseTimes_pagination() throws Exception {
+            // given
+            for (int i = 0; i < 25; i++) {
+                createCourseTimeWithStatus("과정 " + i, CourseTimeStatus.RECRUITING);
+            }
+
+            // when & then
+            mockMvc.perform(get("/api/public/course-times")
+                            .param("page", "0")
+                            .param("size", "10")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content", hasSize(10)))
+                    .andExpect(jsonPath("$.data.totalElements").value(25))
+                    .andExpect(jsonPath("$.data.totalPages").value(3));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/public/course-times/{id} - 상세 조회")
+    class GetPublicCourseTime {
+
+        @Test
+        @DisplayName("인증 없이 상세 조회 성공")
+        void getPublicCourseTime_withoutAuth_success() throws Exception {
+            // given
+            CourseTime courseTime = createCourseTimeWithStatus("모집 중 과정", CourseTimeStatus.RECRUITING);
+
+            // when & then
+            mockMvc.perform(get("/api/public/course-times/{id}", courseTime.getId())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.id").value(courseTime.getId()))
+                    .andExpect(jsonPath("$.data.title").value("모집 중 과정"))
+                    .andExpect(jsonPath("$.data.program").exists())
+                    .andExpect(jsonPath("$.data.curriculum").isArray())
+                    .andExpect(jsonPath("$.data.instructors").isArray());
+        }
+
+        @Test
+        @DisplayName("DRAFT 상태 차수 조회 시 404")
+        void getPublicCourseTime_draftStatus_notFound() throws Exception {
+            // given
+            CourseTime courseTime = createCourseTimeWithStatus("초안 과정", CourseTimeStatus.DRAFT);
+
+            // when & then
+            mockMvc.perform(get("/api/public/course-times/{id}", courseTime.getId())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID 조회 시 404")
+        void getPublicCourseTime_notFound() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/public/course-times/{id}", 99999L)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("상세 응답에 enrollmentMethod 포함")
+        void getPublicCourseTime_containsEnrollmentMethod() throws Exception {
+            // given
+            CourseTime courseTime = createCourseTimeWithStatus("모집 중 과정", CourseTimeStatus.RECRUITING);
+
+            // when & then
+            mockMvc.perform(get("/api/public/course-times/{id}", courseTime.getId())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.enrollmentMethod").value("FIRST_COME"))
+                    .andExpect(jsonPath("$.data.minProgressForCompletion").value(80))
+                    .andExpect(jsonPath("$.data.allowLateEnrollment").value(true));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 학습자(비인증 사용자)가 차수 목록/상세를 조회할 수 있는 Public API 구현
- ProgramResponse에 Course 권장 운영 기간 필드 추가

## Related Issue
- Closes #254

## Changes

### Public CourseTime API
- `PublicCourseTimeController` - 공개 API 컨트롤러
- `PublicCourseTimeService` / `PublicCourseTimeServiceImpl` - 서비스 계층
- `CourseTimeSpecification` - JPA Specification 기반 동적 쿼리
- `CourseTimeCatalogResponse`, `CourseTimePublicDetailResponse` - 목록/상세 응답 DTO
- `CurriculumItemResponse`, `InstructorSummaryResponse`, `ProgramSummaryResponse` - 연관 DTO
- `CourseTimeNotAvailableException` - 비공개 차수 접근 예외
- `SecurityConfig` - `/api/public/course-times/**` permitAll 설정
- `PublicCourseTimeControllerTest` - 통합 테스트 10개 케이스

### ProgramResponse 필드 추가
- `courseStartDate`, `courseEndDate` 필드 추가 (차수 생성 시 기본값 활용)
- `findAllWithSnapshotAndCourse` 쿼리로 N+1 방지

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] 코드가 프로젝트 컨벤션을 준수합니다
- [x] 셀프 코드 리뷰를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 모든 테스트가 통과합니다

## Test plan
- [x] 인증 없이 목록 조회 성공
- [x] DRAFT 상태 차수 목록에서 제외
- [x] status, isFree, keyword 파라미터 필터링
- [x] 상시모집 차수 isOnDemand 플래그 검증
- [x] 페이징 처리 확인
- [x] 인증 없이 상세 조회 성공
- [x] DRAFT 상태 차수 상세 조회 시 404
- [x] 존재하지 않는 ID 조회 시 404
- [x] 상세 응답에 enrollmentMethod 등 필드 포함 확인
- [x] 기존 Program API 테스트 통과

## Additional Notes
- 공개 상태 (RECRUITING, ONGOING)만 조회 가능
- N+1 문제 방지를 위해 강사 정보 벌크 조회 적용
- 상시모집 여부는 classEndDate가 9999-12-31인지로 판단
- courseStartDate/courseEndDate는 null 가능 (설계자가 입력하지 않은 경우)