### PR TITLE
feat: 개인 알림 시스템 구현 (#252, #253)

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -128,7 +128,10 @@ public enum ErrorCode {
     COMMUNITY_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CMT002", "Community comment not found"),
     COMMUNITY_ALREADY_LIKED(HttpStatus.CONFLICT, "CMT003", "Already liked"),
     COMMUNITY_NOT_POST_AUTHOR(HttpStatus.FORBIDDEN, "CMT004", "Not authorized to modify this post"),
-    COMMUNITY_NOT_COMMENT_AUTHOR(HttpStatus.FORBIDDEN, "CMT005", "Not authorized to modify this comment");
+    COMMUNITY_NOT_COMMENT_AUTHOR(HttpStatus.FORBIDDEN, "CMT005", "Not authorized to modify this comment"),
+
+    // Notification (NF)
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NF001", "Notification not found");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/mzc/lp/domain/community/service/CommunityCommentService.java
+++ b/src/main/java/com/mzc/lp/domain/community/service/CommunityCommentService.java
@@ -10,9 +10,12 @@ import com.mzc.lp.domain.community.exception.AlreadyLikedException;
 import com.mzc.lp.domain.community.exception.CommentNotFoundException;
 import com.mzc.lp.domain.community.exception.NotCommentAuthorException;
 import com.mzc.lp.domain.community.exception.PostNotFoundException;
+import com.mzc.lp.domain.community.entity.CommunityPost;
 import com.mzc.lp.domain.community.repository.CommunityCommentLikeRepository;
 import com.mzc.lp.domain.community.repository.CommunityCommentRepository;
 import com.mzc.lp.domain.community.repository.CommunityPostRepository;
+import com.mzc.lp.domain.notification.constant.NotificationType;
+import com.mzc.lp.domain.notification.service.NotificationService;
 import com.mzc.lp.domain.user.entity.User;
 import com.mzc.lp.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +41,7 @@ public class CommunityCommentService {
     private final CommunityCommentLikeRepository commentLikeRepository;
     private final CommunityPostRepository postRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     public CommentListResponse getComments(Long postId, int page, int pageSize, Long userId) {
         if (!postRepository.existsById(postId)) {
@@ -110,22 +114,59 @@ public class CommunityCommentService {
 
     @Transactional
     public CommentResponse createComment(Long userId, Long postId, CreateCommentRequest request) {
-        if (!postRepository.existsById(postId)) {
-            throw new PostNotFoundException(postId);
-        }
+        CommunityPost post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
 
         // 대댓글인 경우 부모 댓글 존재 확인
+        CommunityComment parentComment = null;
         if (request.parentId() != null) {
-            if (!commentRepository.existsById(request.parentId())) {
-                throw new CommentNotFoundException(request.parentId());
-            }
+            parentComment = commentRepository.findById(request.parentId())
+                    .orElseThrow(() -> new CommentNotFoundException(request.parentId()));
         }
 
         CommunityComment comment = CommunityComment.create(postId, userId, request.content(), request.parentId());
         CommunityComment savedComment = commentRepository.save(comment);
 
         User author = userRepository.findById(userId).orElse(null);
+        String authorName = author != null ? author.getName() : "알 수 없음";
+
+        // 알림 생성: 게시글 작성자에게 (본인 제외)
+        if (!post.getAuthorId().equals(userId)) {
+            notificationService.createNotification(
+                    post.getAuthorId(),
+                    NotificationType.COMMENT,
+                    "새 댓글이 달렸습니다",
+                    authorName + "님이 \"" + truncate(post.getTitle(), 20) + "\" 게시글에 댓글을 남겼습니다.",
+                    "/tu/b2c/community/" + postId,
+                    postId,
+                    "POST",
+                    userId,
+                    authorName
+            );
+        }
+
+        // 대댓글인 경우: 부모 댓글 작성자에게도 알림 (본인 및 게시글 작성자 제외)
+        if (parentComment != null && !parentComment.getAuthorId().equals(userId)
+                && !parentComment.getAuthorId().equals(post.getAuthorId())) {
+            notificationService.createNotification(
+                    parentComment.getAuthorId(),
+                    NotificationType.COMMENT,
+                    "대댓글이 달렸습니다",
+                    authorName + "님이 회원님의 댓글에 답글을 남겼습니다.",
+                    "/tu/b2c/community/" + postId,
+                    savedComment.getId(),
+                    "COMMENT",
+                    userId,
+                    authorName
+            );
+        }
+
         return CommentResponse.from(savedComment, author, 0, false);
+    }
+
+    private String truncate(String text, int maxLength) {
+        if (text == null) return "";
+        return text.length() > maxLength ? text.substring(0, maxLength) + "..." : text;
     }
 
     @Transactional
@@ -172,9 +213,8 @@ public class CommunityCommentService {
 
     @Transactional
     public void likeComment(Long userId, Long postId, Long commentId) {
-        if (!commentRepository.findByIdAndPostId(commentId, postId).isPresent()) {
-            throw new CommentNotFoundException(commentId);
-        }
+        CommunityComment comment = commentRepository.findByIdAndPostId(commentId, postId)
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
 
         if (commentLikeRepository.existsByCommentIdAndUserId(commentId, userId)) {
             throw new AlreadyLikedException("Already liked comment: " + commentId);
@@ -184,6 +224,24 @@ public class CommunityCommentService {
             CommunityCommentLike like = CommunityCommentLike.create(commentId, userId);
             commentLikeRepository.save(like);
             commentLikeRepository.flush(); // 즉시 DB에 반영하여 제약조건 위반 확인
+
+            // 알림 생성: 댓글 작성자에게 (본인 제외)
+            if (!comment.getAuthorId().equals(userId)) {
+                User actor = userRepository.findById(userId).orElse(null);
+                String actorName = actor != null ? actor.getName() : "알 수 없음";
+
+                notificationService.createNotification(
+                        comment.getAuthorId(),
+                        NotificationType.LIKE,
+                        "댓글에 좋아요를 받았습니다",
+                        actorName + "님이 회원님의 댓글을 좋아합니다.",
+                        "/tu/b2c/community/" + postId,
+                        commentId,
+                        "COMMENT_LIKE",
+                        userId,
+                        actorName
+                );
+            }
         } catch (DataIntegrityViolationException e) {
             // 동시성 이슈로 인한 중복 좋아요 시도
             log.debug("Concurrent comment like attempt detected for comment {} by user {}", commentId, userId);

--- a/src/main/java/com/mzc/lp/domain/notification/constant/NotificationType.java
+++ b/src/main/java/com/mzc/lp/domain/notification/constant/NotificationType.java
@@ -1,0 +1,12 @@
+package com.mzc.lp.domain.notification.constant;
+
+/**
+ * 알림 타입
+ */
+public enum NotificationType {
+    COMMENT,      // 댓글 알림
+    LIKE,         // 좋아요 알림
+    COURSE,       // 강의 관련 알림
+    SYSTEM,       // 시스템 알림
+    ASSIGNMENT    // 과제 알림
+}

--- a/src/main/java/com/mzc/lp/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/mzc/lp/domain/notification/controller/NotificationController.java
@@ -1,0 +1,97 @@
+package com.mzc.lp.domain.notification.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.notification.constant.NotificationType;
+import com.mzc.lp.domain.notification.dto.response.NotificationListResponse;
+import com.mzc.lp.domain.notification.dto.response.NotificationResponse;
+import com.mzc.lp.domain.notification.dto.response.UnreadCountResponse;
+import com.mzc.lp.domain.notification.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/tu/notifications")
+@RequiredArgsConstructor
+@PreAuthorize("isAuthenticated()")
+@Tag(name = "Notification", description = "알림 API")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    @Operation(summary = "알림 목록 조회", description = "사용자의 알림 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<NotificationListResponse>> getNotifications(
+            @RequestParam(required = false) NotificationType type,
+            @RequestParam(required = false) Boolean isRead,
+            @RequestParam(required = false, defaultValue = "0") int page,
+            @RequestParam(required = false, defaultValue = "20") int pageSize,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        NotificationListResponse response = notificationService.getNotifications(
+                principal.id(), type, isRead, page, pageSize);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{notificationId}")
+    @Operation(summary = "알림 상세 조회", description = "특정 알림의 상세 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<NotificationResponse>> getNotification(
+            @PathVariable Long notificationId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        NotificationResponse response = notificationService.getNotification(principal.id(), notificationId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/unread-count")
+    @Operation(summary = "읽지 않은 알림 개수 조회", description = "읽지 않은 알림의 개수를 조회합니다.")
+    public ResponseEntity<ApiResponse<UnreadCountResponse>> getUnreadCount(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        UnreadCountResponse response = notificationService.getUnreadCount(principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    @Operation(summary = "알림 읽음 처리", description = "특정 알림을 읽음 처리합니다.")
+    public ResponseEntity<ApiResponse<Void>> markAsRead(
+            @PathVariable Long notificationId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        notificationService.markAsRead(principal.id(), notificationId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @PatchMapping("/read-all")
+    @Operation(summary = "모든 알림 읽음 처리", description = "사용자의 모든 알림을 읽음 처리합니다.")
+    public ResponseEntity<ApiResponse<Void>> markAllAsRead(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        notificationService.markAllAsRead(principal.id());
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @DeleteMapping("/{notificationId}")
+    @Operation(summary = "알림 삭제", description = "특정 알림을 삭제합니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteNotification(
+            @PathVariable Long notificationId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        notificationService.deleteNotification(principal.id(), notificationId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @DeleteMapping("/read")
+    @Operation(summary = "읽은 알림 전체 삭제", description = "읽은 알림을 모두 삭제합니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteReadNotifications(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        notificationService.deleteReadNotifications(principal.id());
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notification/dto/response/NotificationListResponse.java
+++ b/src/main/java/com/mzc/lp/domain/notification/dto/response/NotificationListResponse.java
@@ -1,0 +1,32 @@
+package com.mzc.lp.domain.notification.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class NotificationListResponse {
+    private List<NotificationResponse> notifications;
+    private long totalCount;
+    private int page;
+    private int pageSize;
+    private int totalPages;
+    private long unreadCount;
+
+    public static NotificationListResponse of(
+            Page<NotificationResponse> notificationPage,
+            long unreadCount
+    ) {
+        return NotificationListResponse.builder()
+                .notifications(notificationPage.getContent())
+                .totalCount(notificationPage.getTotalElements())
+                .page(notificationPage.getNumber())
+                .pageSize(notificationPage.getSize())
+                .totalPages(notificationPage.getTotalPages())
+                .unreadCount(unreadCount)
+                .build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/mzc/lp/domain/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,40 @@
+package com.mzc.lp.domain.notification.dto.response;
+
+import com.mzc.lp.domain.notification.constant.NotificationType;
+import com.mzc.lp.domain.notification.entity.Notification;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+public class NotificationResponse {
+    private Long id;
+    private NotificationType type;
+    private String title;
+    private String message;
+    private Boolean isRead;
+    private String link;
+    private Long referenceId;
+    private String referenceType;
+    private Long actorId;
+    private String actorName;
+    private Instant createdAt;
+
+    public static NotificationResponse from(Notification notification) {
+        return NotificationResponse.builder()
+                .id(notification.getId())
+                .type(notification.getType())
+                .title(notification.getTitle())
+                .message(notification.getMessage())
+                .isRead(notification.getIsRead())
+                .link(notification.getLink())
+                .referenceId(notification.getReferenceId())
+                .referenceType(notification.getReferenceType())
+                .actorId(notification.getActorId())
+                .actorName(notification.getActorName())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notification/dto/response/UnreadCountResponse.java
+++ b/src/main/java/com/mzc/lp/domain/notification/dto/response/UnreadCountResponse.java
@@ -1,0 +1,16 @@
+package com.mzc.lp.domain.notification.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UnreadCountResponse {
+    private long count;
+
+    public static UnreadCountResponse of(long count) {
+        return UnreadCountResponse.builder()
+                .count(count)
+                .build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notification/entity/Notification.java
+++ b/src/main/java/com/mzc/lp/domain/notification/entity/Notification.java
@@ -1,0 +1,87 @@
+package com.mzc.lp.domain.notification.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import com.mzc.lp.domain.notification.constant.NotificationType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 개인 알림 엔티티
+ */
+@Entity
+@Table(
+    name = "notifications",
+    indexes = {
+        @Index(name = "idx_notification_user", columnList = "tenant_id, user_id"),
+        @Index(name = "idx_notification_user_unread", columnList = "tenant_id, user_id, is_read"),
+        @Index(name = "idx_notification_created", columnList = "tenant_id, user_id, created_at DESC")
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends TenantEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private NotificationType type;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "message", nullable = false, columnDefinition = "TEXT")
+    private String message;
+
+    @Column(name = "is_read", nullable = false)
+    private Boolean isRead = false;
+
+    @Column(name = "link", length = 500)
+    private String link;
+
+    @Column(name = "reference_id")
+    private Long referenceId;
+
+    @Column(name = "reference_type", length = 50)
+    private String referenceType;
+
+    @Column(name = "actor_id")
+    private Long actorId;
+
+    @Column(name = "actor_name", length = 100)
+    private String actorName;
+
+    // ===== 정적 팩토리 메서드 =====
+    public static Notification create(
+            Long userId,
+            NotificationType type,
+            String title,
+            String message,
+            String link,
+            Long referenceId,
+            String referenceType,
+            Long actorId,
+            String actorName
+    ) {
+        Notification notification = new Notification();
+        notification.userId = userId;
+        notification.type = type;
+        notification.title = title;
+        notification.message = message;
+        notification.link = link;
+        notification.referenceId = referenceId;
+        notification.referenceType = referenceType;
+        notification.actorId = actorId;
+        notification.actorName = actorName;
+        notification.isRead = false;
+        return notification;
+    }
+
+    // ===== 비즈니스 메서드 =====
+    public void markAsRead() {
+        this.isRead = true;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notification/exception/NotificationNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/notification/exception/NotificationNotFoundException.java
@@ -1,0 +1,10 @@
+package com.mzc.lp.domain.notification.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class NotificationNotFoundException extends BusinessException {
+    public NotificationNotFoundException(Long notificationId) {
+        super(ErrorCode.NOTIFICATION_NOT_FOUND, "Notification not found: " + notificationId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/mzc/lp/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,52 @@
+package com.mzc.lp.domain.notification.repository;
+
+import com.mzc.lp.domain.notification.constant.NotificationType;
+import com.mzc.lp.domain.notification.entity.Notification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    // 사용자별 알림 목록 조회 (페이징)
+    Page<Notification> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    // 사용자별 + 타입별 알림 목록 조회
+    Page<Notification> findByUserIdAndTypeOrderByCreatedAtDesc(Long userId, NotificationType type, Pageable pageable);
+
+    // 사용자별 + 읽음 상태별 알림 목록 조회
+    Page<Notification> findByUserIdAndIsReadOrderByCreatedAtDesc(Long userId, Boolean isRead, Pageable pageable);
+
+    // 사용자별 + 타입 + 읽음 상태
+    Page<Notification> findByUserIdAndTypeAndIsReadOrderByCreatedAtDesc(
+            Long userId, NotificationType type, Boolean isRead, Pageable pageable);
+
+    // 읽지 않은 알림 개수
+    long countByUserIdAndIsRead(Long userId, Boolean isRead);
+
+    // 특정 알림 조회
+    Optional<Notification> findByIdAndUserId(Long id, Long userId);
+
+    // 모든 알림 읽음 처리
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = true WHERE n.userId = :userId AND n.isRead = false")
+    int markAllAsReadByUserId(@Param("userId") Long userId);
+
+    // 읽은 알림 삭제
+    @Modifying
+    @Query("DELETE FROM Notification n WHERE n.userId = :userId AND n.isRead = true")
+    int deleteReadByUserId(@Param("userId") Long userId);
+
+    // 사용자의 모든 알림 삭제
+    void deleteByUserId(Long userId);
+
+    // 특정 reference에 대한 알림 존재 여부 (중복 알림 방지용)
+    boolean existsByUserIdAndReferenceIdAndReferenceTypeAndActorId(
+            Long userId, Long referenceId, String referenceType, Long actorId);
+}

--- a/src/main/java/com/mzc/lp/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/mzc/lp/domain/notification/service/NotificationService.java
@@ -1,0 +1,65 @@
+package com.mzc.lp.domain.notification.service;
+
+import com.mzc.lp.domain.notification.constant.NotificationType;
+import com.mzc.lp.domain.notification.dto.response.NotificationListResponse;
+import com.mzc.lp.domain.notification.dto.response.NotificationResponse;
+import com.mzc.lp.domain.notification.dto.response.UnreadCountResponse;
+
+public interface NotificationService {
+
+    /**
+     * 알림 목록 조회
+     */
+    NotificationListResponse getNotifications(
+            Long userId,
+            NotificationType type,
+            Boolean isRead,
+            int page,
+            int pageSize
+    );
+
+    /**
+     * 알림 상세 조회
+     */
+    NotificationResponse getNotification(Long userId, Long notificationId);
+
+    /**
+     * 읽지 않은 알림 개수 조회
+     */
+    UnreadCountResponse getUnreadCount(Long userId);
+
+    /**
+     * 알림 읽음 처리
+     */
+    void markAsRead(Long userId, Long notificationId);
+
+    /**
+     * 모든 알림 읽음 처리
+     */
+    void markAllAsRead(Long userId);
+
+    /**
+     * 알림 삭제
+     */
+    void deleteNotification(Long userId, Long notificationId);
+
+    /**
+     * 읽은 알림 전체 삭제
+     */
+    void deleteReadNotifications(Long userId);
+
+    /**
+     * 알림 생성 (내부 사용)
+     */
+    void createNotification(
+            Long userId,
+            NotificationType type,
+            String title,
+            String message,
+            String link,
+            Long referenceId,
+            String referenceType,
+            Long actorId,
+            String actorName
+    );
+}

--- a/src/main/java/com/mzc/lp/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,130 @@
+package com.mzc.lp.domain.notification.service;
+
+import com.mzc.lp.domain.notification.constant.NotificationType;
+import com.mzc.lp.domain.notification.dto.response.NotificationListResponse;
+import com.mzc.lp.domain.notification.dto.response.NotificationResponse;
+import com.mzc.lp.domain.notification.dto.response.UnreadCountResponse;
+import com.mzc.lp.domain.notification.entity.Notification;
+import com.mzc.lp.domain.notification.exception.NotificationNotFoundException;
+import com.mzc.lp.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Override
+    public NotificationListResponse getNotifications(
+            Long userId,
+            NotificationType type,
+            Boolean isRead,
+            int page,
+            int pageSize
+    ) {
+        Pageable pageable = PageRequest.of(page, pageSize);
+        Page<Notification> notificationPage;
+
+        if (type != null && isRead != null) {
+            notificationPage = notificationRepository.findByUserIdAndTypeAndIsReadOrderByCreatedAtDesc(
+                    userId, type, isRead, pageable);
+        } else if (type != null) {
+            notificationPage = notificationRepository.findByUserIdAndTypeOrderByCreatedAtDesc(
+                    userId, type, pageable);
+        } else if (isRead != null) {
+            notificationPage = notificationRepository.findByUserIdAndIsReadOrderByCreatedAtDesc(
+                    userId, isRead, pageable);
+        } else {
+            notificationPage = notificationRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+        }
+
+        Page<NotificationResponse> responsePage = notificationPage.map(NotificationResponse::from);
+        long unreadCount = notificationRepository.countByUserIdAndIsRead(userId, false);
+
+        return NotificationListResponse.of(responsePage, unreadCount);
+    }
+
+    @Override
+    public NotificationResponse getNotification(Long userId, Long notificationId) {
+        Notification notification = notificationRepository.findByIdAndUserId(notificationId, userId)
+                .orElseThrow(() -> new NotificationNotFoundException(notificationId));
+        return NotificationResponse.from(notification);
+    }
+
+    @Override
+    public UnreadCountResponse getUnreadCount(Long userId) {
+        long count = notificationRepository.countByUserIdAndIsRead(userId, false);
+        return UnreadCountResponse.of(count);
+    }
+
+    @Override
+    @Transactional
+    public void markAsRead(Long userId, Long notificationId) {
+        Notification notification = notificationRepository.findByIdAndUserId(notificationId, userId)
+                .orElseThrow(() -> new NotificationNotFoundException(notificationId));
+        notification.markAsRead();
+    }
+
+    @Override
+    @Transactional
+    public void markAllAsRead(Long userId) {
+        int updated = notificationRepository.markAllAsReadByUserId(userId);
+        log.debug("Marked {} notifications as read for user {}", updated, userId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteNotification(Long userId, Long notificationId) {
+        Notification notification = notificationRepository.findByIdAndUserId(notificationId, userId)
+                .orElseThrow(() -> new NotificationNotFoundException(notificationId));
+        notificationRepository.delete(notification);
+    }
+
+    @Override
+    @Transactional
+    public void deleteReadNotifications(Long userId) {
+        int deleted = notificationRepository.deleteReadByUserId(userId);
+        log.debug("Deleted {} read notifications for user {}", deleted, userId);
+    }
+
+    @Override
+    @Transactional
+    public void createNotification(
+            Long userId,
+            NotificationType type,
+            String title,
+            String message,
+            String link,
+            Long referenceId,
+            String referenceType,
+            Long actorId,
+            String actorName
+    ) {
+        // 중복 알림 방지: 같은 사용자, 같은 참조, 같은 액터면 생성하지 않음
+        if (referenceId != null && actorId != null) {
+            boolean exists = notificationRepository.existsByUserIdAndReferenceIdAndReferenceTypeAndActorId(
+                    userId, referenceId, referenceType, actorId);
+            if (exists) {
+                log.debug("Duplicate notification skipped for user {} reference {} type {} actor {}",
+                        userId, referenceId, referenceType, actorId);
+                return;
+            }
+        }
+
+        Notification notification = Notification.create(
+                userId, type, title, message, link,
+                referenceId, referenceType, actorId, actorName
+        );
+        notificationRepository.save(notification);
+        log.debug("Created notification for user {}: {}", userId, title);
+    }
+}


### PR DESCRIPTION
## Summary
개인 알림 시스템의 백엔드 도메인을 구현했습니다. 사용자별 알림 생성, 조회, 읽음 처리, 삭제 기능과 댓글/좋아요 시 자동 알림 생성 기능을 포함합니다.

## Related Issue
- Closes #252
- Closes #253

## Changes
- `Notification` 엔티티 생성 (userId, type, title, message, isRead, link, referenceId, referenceType, actorId, actorName)
- `NotificationType` enum 정의 (COMMENT, LIKE, COURSE, SYSTEM, ASSIGNMENT)
- `NotificationRepository` 구현 (페이징 조회, 읽음 상태 필터, 일괄 읽음 처리, 읽은 알림 삭제)
- `NotificationService` 구현 (CRUD 및 중복 알림 방지 로직)
- `NotificationController` REST API 구현 (/api/tu/notifications)
- 댓글/좋아요 생성 시 자동 알림 생성 로직 추가
- 알림 관련 DTO 및 예외 클래스 생성

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
- 멀티테넌트 지원을 위해 TenantEntity 상속
- 인덱스 최적화: user_id, is_read, created_at 기준 인덱스 생성
- 중복 알림 방지: 동일 사용자/참조/액터 조합에 대해 중복 생성 방지