### PR TITLE
feat: 테넌트 브랜딩 세팅

### DIFF
--- a/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
@@ -2,7 +2,11 @@ package com.mzc.lp.domain.tenant.controller;
 
 import com.mzc.lp.common.context.TenantContext;
 import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.domain.tenant.dto.request.NavigationItemRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateDesignSettingsRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateLayoutSettingsRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateTenantSettingsRequest;
+import com.mzc.lp.domain.tenant.dto.response.NavigationItemResponse;
 import com.mzc.lp.domain.tenant.dto.response.TenantSettingsResponse;
 import com.mzc.lp.domain.tenant.service.TenantSettingsService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * 테넌트 설정 컨트롤러
@@ -24,6 +30,10 @@ import org.springframework.web.bind.annotation.*;
 public class TenantSettingsController {
 
     private final TenantSettingsService tenantSettingsService;
+
+    // ============================================
+    // 기본 설정 API
+    // ============================================
 
     @Operation(summary = "테넌트 설정 조회", description = "현재 테넌트의 설정을 조회합니다")
     @GetMapping
@@ -45,14 +55,28 @@ public class TenantSettingsController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @Operation(summary = "브랜딩 설정 업데이트", description = "로고, 색상 등 브랜딩 설정만 업데이트합니다")
+    // ============================================
+    // 디자인/브랜딩 설정 API
+    // ============================================
+
+    @Operation(summary = "디자인 설정 업데이트", description = "로고, 색상, 폰트 등 디자인 설정을 업데이트합니다")
+    @PutMapping("/design")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<TenantSettingsResponse>> updateDesignSettings(
+            @Valid @RequestBody UpdateDesignSettingsRequest request
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        TenantSettingsResponse response = tenantSettingsService.updateDesignSettings(tenantId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "브랜딩 설정 업데이트 (레거시)", description = "로고, 색상 등 브랜딩 설정만 업데이트합니다")
     @PatchMapping("/branding")
     @PreAuthorize("hasRole('TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<TenantSettingsResponse>> updateBranding(
             @Valid @RequestBody UpdateTenantSettingsRequest request
     ) {
         Long tenantId = TenantContext.getCurrentTenantId();
-        // 브랜딩 관련 필드만 포함된 요청 처리
         UpdateTenantSettingsRequest brandingRequest = new UpdateTenantSettingsRequest(
                 request.logoUrl(),
                 request.faviconUrl(),
@@ -66,6 +90,25 @@ public class TenantSettingsController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    // ============================================
+    // 레이아웃 설정 API
+    // ============================================
+
+    @Operation(summary = "레이아웃 설정 업데이트", description = "헤더, 사이드바, 푸터, 콘텐츠 영역 설정을 업데이트합니다")
+    @PutMapping("/layout")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<TenantSettingsResponse>> updateLayoutSettings(
+            @Valid @RequestBody UpdateLayoutSettingsRequest request
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        TenantSettingsResponse response = tenantSettingsService.updateLayoutSettings(tenantId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // ============================================
+    // 사용자 관리 설정 API
+    // ============================================
+
     @Operation(summary = "사용자 관리 설정 업데이트", description = "사용자 가입, 인증 관련 설정만 업데이트합니다")
     @PatchMapping("/user-management")
     @PreAuthorize("hasRole('TENANT_ADMIN')")
@@ -73,7 +116,6 @@ public class TenantSettingsController {
             @Valid @RequestBody UpdateTenantSettingsRequest request
     ) {
         Long tenantId = TenantContext.getCurrentTenantId();
-        // 사용자 관리 관련 필드만 포함된 요청 처리
         UpdateTenantSettingsRequest userManagementRequest = new UpdateTenantSettingsRequest(
                 null, null, null, null, null, null, null,
                 request.allowSelfRegistration(),
@@ -83,6 +125,71 @@ public class TenantSettingsController {
                 null, null, null, null, null, null, null
         );
         TenantSettingsResponse response = tenantSettingsService.updateSettings(tenantId, userManagementRequest);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // ============================================
+    // 네비게이션 관리 API
+    // ============================================
+
+    @Operation(summary = "네비게이션 항목 목록 조회", description = "현재 테넌트의 네비게이션 메뉴 항목을 조회합니다")
+    @GetMapping("/navigation")
+    @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'OPERATOR')")
+    public ResponseEntity<ApiResponse<List<NavigationItemResponse>>> getNavigationItems() {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        List<NavigationItemResponse> response = tenantSettingsService.getNavigationItems(tenantId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "네비게이션 항목 생성", description = "새로운 네비게이션 메뉴 항목을 추가합니다")
+    @PostMapping("/navigation")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<NavigationItemResponse>> createNavigationItem(
+            @Valid @RequestBody NavigationItemRequest request
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        NavigationItemResponse response = tenantSettingsService.createNavigationItem(tenantId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "네비게이션 항목 수정", description = "기존 네비게이션 메뉴 항목을 수정합니다")
+    @PutMapping("/navigation/{itemId}")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<NavigationItemResponse>> updateNavigationItem(
+            @PathVariable Long itemId,
+            @Valid @RequestBody NavigationItemRequest request
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        NavigationItemResponse response = tenantSettingsService.updateNavigationItem(tenantId, itemId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "네비게이션 항목 삭제", description = "네비게이션 메뉴 항목을 삭제합니다")
+    @DeleteMapping("/navigation/{itemId}")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<Void>> deleteNavigationItem(@PathVariable Long itemId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        tenantSettingsService.deleteNavigationItem(tenantId, itemId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @Operation(summary = "네비게이션 항목 순서 변경", description = "네비게이션 메뉴 항목의 순서를 변경합니다")
+    @PutMapping("/navigation/reorder")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<NavigationItemResponse>>> reorderNavigationItems(
+            @RequestBody List<Long> itemIds
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        List<NavigationItemResponse> response = tenantSettingsService.reorderNavigationItems(tenantId, itemIds);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "네비게이션 초기화", description = "네비게이션 메뉴를 기본값으로 초기화합니다")
+    @PostMapping("/navigation/reset")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<NavigationItemResponse>>> resetNavigationItems() {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        List<NavigationItemResponse> response = tenantSettingsService.initializeDefaultNavigationItems(tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/request/NavigationItemRequest.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/request/NavigationItemRequest.java
@@ -1,0 +1,29 @@
+package com.mzc.lp.domain.tenant.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 네비게이션 아이템 생성/수정 요청 DTO
+ */
+public record NavigationItemRequest(
+        @NotBlank(message = "메뉴 이름은 필수입니다")
+        @Size(max = 100)
+        String label,
+
+        @NotBlank(message = "아이콘은 필수입니다")
+        @Size(max = 50)
+        String icon,
+
+        @NotBlank(message = "경로는 필수입니다")
+        @Size(max = 500)
+        String path,
+
+        Boolean enabled,
+
+        Integer displayOrder,
+
+        @Size(max = 50)
+        String target
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateDesignSettingsRequest.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateDesignSettingsRequest.java
@@ -1,0 +1,36 @@
+package com.mzc.lp.domain.tenant.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+/**
+ * 디자인/브랜딩 설정 업데이트 요청 DTO
+ */
+public record UpdateDesignSettingsRequest(
+        // 로고
+        @Size(max = 500)
+        String logoUrl,
+
+        @Size(max = 500)
+        String darkLogoUrl,
+
+        @Size(max = 500)
+        String faviconUrl,
+
+        // 색상
+        @Size(max = 7)
+        String primaryColor,
+
+        @Size(max = 7)
+        String secondaryColor,
+
+        @Size(max = 7)
+        String accentColor,
+
+        // 폰트
+        @Size(max = 100)
+        String headingFont,
+
+        @Size(max = 100)
+        String bodyFont
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateLayoutSettingsRequest.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateLayoutSettingsRequest.java
@@ -1,0 +1,21 @@
+package com.mzc.lp.domain.tenant.dto.request;
+
+import java.util.Map;
+
+/**
+ * 레이아웃/UI 설정 업데이트 요청 DTO
+ */
+public record UpdateLayoutSettingsRequest(
+        // 헤더 설정 (style, showLogo, showSearch, showNotifications)
+        Map<String, Object> headerSettings,
+
+        // 사이드바 설정 (style, defaultCollapsed, showIcons)
+        Map<String, Object> sidebarSettings,
+
+        // 푸터 설정 (enabled, showLinks, showCopyright)
+        Map<String, Object> footerSettings,
+
+        // 콘텐츠 영역 설정 (maxWidth, padding)
+        Map<String, Object> contentSettings
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/response/NavigationItemResponse.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/response/NavigationItemResponse.java
@@ -1,0 +1,34 @@
+package com.mzc.lp.domain.tenant.dto.response;
+
+import com.mzc.lp.domain.tenant.entity.NavigationItem;
+
+import java.time.Instant;
+
+/**
+ * 네비게이션 아이템 응답 DTO
+ */
+public record NavigationItemResponse(
+        Long id,
+        String label,
+        String icon,
+        String path,
+        Boolean enabled,
+        Integer displayOrder,
+        String target,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static NavigationItemResponse from(NavigationItem item) {
+        return new NavigationItemResponse(
+                item.getId(),
+                item.getLabel(),
+                item.getIcon(),
+                item.getPath(),
+                item.getEnabled(),
+                item.getDisplayOrder(),
+                item.getTarget(),
+                item.getCreatedAt(),
+                item.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/response/TenantSettingsResponse.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/response/TenantSettingsResponse.java
@@ -3,6 +3,7 @@ package com.mzc.lp.domain.tenant.dto.response;
 import com.mzc.lp.domain.tenant.entity.TenantSettings;
 
 import java.time.Instant;
+import java.util.Map;
 
 /**
  * 테넌트 설정 응답 DTO
@@ -13,10 +14,20 @@ public record TenantSettingsResponse(
 
         // 브랜딩 설정
         String logoUrl,
+        String darkLogoUrl,
         String faviconUrl,
         String primaryColor,
         String secondaryColor,
+        String accentColor,
         String fontFamily,
+        String headingFont,
+        String bodyFont,
+
+        // 레이아웃 설정
+        Map<String, Object> headerSettings,
+        Map<String, Object> sidebarSettings,
+        Map<String, Object> footerSettings,
+        Map<String, Object> contentSettings,
 
         // 일반 설정
         String defaultLanguage,
@@ -47,10 +58,18 @@ public record TenantSettingsResponse(
                 settings.getId(),
                 settings.getTenant().getId(),
                 settings.getLogoUrl(),
+                settings.getDarkLogoUrl(),
                 settings.getFaviconUrl(),
                 settings.getPrimaryColor(),
                 settings.getSecondaryColor(),
+                settings.getAccentColor(),
                 settings.getFontFamily(),
+                settings.getHeadingFont(),
+                settings.getBodyFont(),
+                settings.getHeaderSettings(),
+                settings.getSidebarSettings(),
+                settings.getFooterSettings(),
+                settings.getContentSettings(),
                 settings.getDefaultLanguage(),
                 settings.getTimezone(),
                 settings.getAllowSelfRegistration(),

--- a/src/main/java/com/mzc/lp/domain/tenant/entity/NavigationItem.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/entity/NavigationItem.java
@@ -1,0 +1,84 @@
+package com.mzc.lp.domain.tenant.entity;
+
+import com.mzc.lp.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 네비게이션 아이템 엔티티
+ * 테넌트별 사이드바/네비게이션 메뉴 항목을 관리
+ */
+@Entity
+@Table(name = "navigation_items")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NavigationItem extends BaseTimeEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tenant_id", nullable = false)
+    private Tenant tenant;
+
+    @Column(nullable = false, length = 100)
+    private String label;
+
+    @Column(nullable = false, length = 50)
+    private String icon;
+
+    @Column(nullable = false, length = 500)
+    private String path;
+
+    @Column(nullable = false)
+    private Boolean enabled = true;
+
+    @Column(nullable = false)
+    private Integer displayOrder;
+
+    @Column(length = 50)
+    private String target; // _self, _blank
+
+    @Column(length = 50)
+    private String parentId; // 계층 구조 지원 (optional)
+
+    // 정적 팩토리 메서드
+    public static NavigationItem create(Tenant tenant, String label, String icon, String path, int displayOrder) {
+        NavigationItem item = new NavigationItem();
+        item.tenant = tenant;
+        item.label = label;
+        item.icon = icon;
+        item.path = path;
+        item.displayOrder = displayOrder;
+        item.enabled = true;
+        item.target = path.startsWith("http") ? "_blank" : "_self";
+        return item;
+    }
+
+    // 기본 네비게이션 항목 생성
+    public static NavigationItem createDefault(Tenant tenant, String label, String icon, String path, int order) {
+        return create(tenant, label, icon, path, order);
+    }
+
+    // 업데이트 메서드
+    public void update(String label, String icon, String path, Boolean enabled, Integer displayOrder, String target) {
+        if (label != null) this.label = label;
+        if (icon != null) this.icon = icon;
+        if (path != null) {
+            this.path = path;
+            this.target = path.startsWith("http") ? "_blank" : "_self";
+        }
+        if (enabled != null) this.enabled = enabled;
+        if (displayOrder != null) this.displayOrder = displayOrder;
+        if (target != null) this.target = target;
+    }
+
+    // 활성/비활성 토글
+    public void toggleEnabled() {
+        this.enabled = !this.enabled;
+    }
+
+    // 순서 변경
+    public void updateOrder(int newOrder) {
+        this.displayOrder = newOrder;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/entity/TenantSettings.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/entity/TenantSettings.java
@@ -5,6 +5,11 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * 테넌트 설정 엔티티
@@ -28,6 +33,9 @@ public class TenantSettings extends BaseTimeEntity {
     private String logoUrl;
 
     @Column(length = 500)
+    private String darkLogoUrl;
+
+    @Column(length = 500)
     private String faviconUrl;
 
     @Column(length = 7)
@@ -36,8 +44,37 @@ public class TenantSettings extends BaseTimeEntity {
     @Column(length = 7)
     private String secondaryColor;
 
+    @Column(length = 7)
+    private String accentColor;
+
     @Column(length = 100)
     private String fontFamily;
+
+    @Column(length = 100)
+    private String headingFont;
+
+    @Column(length = 100)
+    private String bodyFont;
+
+    // ============================================
+    // 레이아웃 설정 (JSON)
+    // ============================================
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json")
+    private Map<String, Object> headerSettings = new HashMap<>();
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json")
+    private Map<String, Object> sidebarSettings = new HashMap<>();
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json")
+    private Map<String, Object> footerSettings = new HashMap<>();
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json")
+    private Map<String, Object> contentSettings = new HashMap<>();
 
     // ============================================
     // 일반 설정
@@ -100,17 +137,61 @@ public class TenantSettings extends BaseTimeEntity {
         settings.tenant = tenant;
         settings.primaryColor = "#3B82F6";
         settings.secondaryColor = "#1E40AF";
+        settings.accentColor = "#10B981";
+        settings.headingFont = "Pretendard";
+        settings.bodyFont = "Pretendard";
+
+        // 기본 헤더 설정
+        settings.headerSettings = new HashMap<>();
+        settings.headerSettings.put("style", "fixed");
+        settings.headerSettings.put("showLogo", true);
+        settings.headerSettings.put("showSearch", true);
+        settings.headerSettings.put("showNotifications", true);
+
+        // 기본 사이드바 설정
+        settings.sidebarSettings = new HashMap<>();
+        settings.sidebarSettings.put("style", "collapsible");
+        settings.sidebarSettings.put("defaultCollapsed", false);
+        settings.sidebarSettings.put("showIcons", true);
+
+        // 기본 푸터 설정
+        settings.footerSettings = new HashMap<>();
+        settings.footerSettings.put("enabled", true);
+        settings.footerSettings.put("showLinks", true);
+        settings.footerSettings.put("showCopyright", true);
+
+        // 기본 콘텐츠 설정
+        settings.contentSettings = new HashMap<>();
+        settings.contentSettings.put("maxWidth", "full");
+        settings.contentSettings.put("padding", "normal");
+
         return settings;
     }
 
-    // 브랜딩 업데이트
-    public void updateBranding(String logoUrl, String faviconUrl,
-                               String primaryColor, String secondaryColor, String fontFamily) {
+    // 브랜딩 업데이트 (확장)
+    public void updateBranding(String logoUrl, String darkLogoUrl, String faviconUrl,
+                               String primaryColor, String secondaryColor, String accentColor,
+                               String fontFamily, String headingFont, String bodyFont) {
         this.logoUrl = logoUrl;
+        this.darkLogoUrl = darkLogoUrl;
         this.faviconUrl = faviconUrl;
         if (primaryColor != null) this.primaryColor = primaryColor;
         if (secondaryColor != null) this.secondaryColor = secondaryColor;
+        if (accentColor != null) this.accentColor = accentColor;
         this.fontFamily = fontFamily;
+        this.headingFont = headingFont;
+        this.bodyFont = bodyFont;
+    }
+
+    // 레이아웃 설정 업데이트
+    public void updateLayoutSettings(Map<String, Object> headerSettings,
+                                     Map<String, Object> sidebarSettings,
+                                     Map<String, Object> footerSettings,
+                                     Map<String, Object> contentSettings) {
+        if (headerSettings != null) this.headerSettings = headerSettings;
+        if (sidebarSettings != null) this.sidebarSettings = sidebarSettings;
+        if (footerSettings != null) this.footerSettings = footerSettings;
+        if (contentSettings != null) this.contentSettings = contentSettings;
     }
 
     // 일반 설정 업데이트

--- a/src/main/java/com/mzc/lp/domain/tenant/repository/NavigationItemRepository.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/repository/NavigationItemRepository.java
@@ -1,0 +1,56 @@
+package com.mzc.lp.domain.tenant.repository;
+
+import com.mzc.lp.domain.tenant.entity.NavigationItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 네비게이션 아이템 리포지토리
+ */
+@Repository
+public interface NavigationItemRepository extends JpaRepository<NavigationItem, Long> {
+
+    /**
+     * 테넌트의 모든 네비게이션 항목 조회 (정렬)
+     */
+    List<NavigationItem> findByTenantIdOrderByDisplayOrderAsc(Long tenantId);
+
+    /**
+     * 테넌트의 활성화된 네비게이션 항목만 조회 (정렬)
+     */
+    List<NavigationItem> findByTenantIdAndEnabledTrueOrderByDisplayOrderAsc(Long tenantId);
+
+    /**
+     * 특정 테넌트의 특정 네비게이션 항목 조회
+     */
+    Optional<NavigationItem> findByIdAndTenantId(Long id, Long tenantId);
+
+    /**
+     * 테넌트의 네비게이션 항목 개수
+     */
+    long countByTenantId(Long tenantId);
+
+    /**
+     * 테넌트의 최대 displayOrder 조회
+     */
+    @Query("SELECT COALESCE(MAX(n.displayOrder), 0) FROM NavigationItem n WHERE n.tenant.id = :tenantId")
+    int findMaxDisplayOrderByTenantId(@Param("tenantId") Long tenantId);
+
+    /**
+     * 테넌트의 모든 네비게이션 항목 삭제
+     */
+    @Modifying
+    @Query("DELETE FROM NavigationItem n WHERE n.tenant.id = :tenantId")
+    void deleteAllByTenantId(@Param("tenantId") Long tenantId);
+
+    /**
+     * 테넌트에 네비게이션 항목이 있는지 확인
+     */
+    boolean existsByTenantId(Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsService.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsService.java
@@ -1,7 +1,13 @@
 package com.mzc.lp.domain.tenant.service;
 
+import com.mzc.lp.domain.tenant.dto.request.NavigationItemRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateDesignSettingsRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateLayoutSettingsRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateTenantSettingsRequest;
+import com.mzc.lp.domain.tenant.dto.response.NavigationItemResponse;
 import com.mzc.lp.domain.tenant.dto.response.TenantSettingsResponse;
+
+import java.util.List;
 
 /**
  * 테넌트 설정 서비스 인터페이스
@@ -24,9 +30,75 @@ public interface TenantSettingsService {
     TenantSettingsResponse updateSettings(Long tenantId, UpdateTenantSettingsRequest request);
 
     /**
+     * 디자인/브랜딩 설정 업데이트
+     * @param tenantId 테넌트 ID
+     * @param request 디자인 설정 요청
+     * @return 업데이트된 설정
+     */
+    TenantSettingsResponse updateDesignSettings(Long tenantId, UpdateDesignSettingsRequest request);
+
+    /**
+     * 레이아웃 설정 업데이트
+     * @param tenantId 테넌트 ID
+     * @param request 레이아웃 설정 요청
+     * @return 업데이트된 설정
+     */
+    TenantSettingsResponse updateLayoutSettings(Long tenantId, UpdateLayoutSettingsRequest request);
+
+    /**
      * 테넌트 설정 초기화 (기본값으로 생성)
      * @param tenantId 테넌트 ID
      * @return 생성된 설정
      */
     TenantSettingsResponse initializeSettings(Long tenantId);
+
+    // ============================================
+    // 네비게이션 관리
+    // ============================================
+
+    /**
+     * 네비게이션 항목 목록 조회
+     * @param tenantId 테넌트 ID
+     * @return 네비게이션 항목 목록
+     */
+    List<NavigationItemResponse> getNavigationItems(Long tenantId);
+
+    /**
+     * 네비게이션 항목 생성
+     * @param tenantId 테넌트 ID
+     * @param request 생성 요청
+     * @return 생성된 항목
+     */
+    NavigationItemResponse createNavigationItem(Long tenantId, NavigationItemRequest request);
+
+    /**
+     * 네비게이션 항목 수정
+     * @param tenantId 테넌트 ID
+     * @param itemId 항목 ID
+     * @param request 수정 요청
+     * @return 수정된 항목
+     */
+    NavigationItemResponse updateNavigationItem(Long tenantId, Long itemId, NavigationItemRequest request);
+
+    /**
+     * 네비게이션 항목 삭제
+     * @param tenantId 테넌트 ID
+     * @param itemId 항목 ID
+     */
+    void deleteNavigationItem(Long tenantId, Long itemId);
+
+    /**
+     * 네비게이션 항목 순서 변경
+     * @param tenantId 테넌트 ID
+     * @param itemIds 순서대로 정렬된 항목 ID 목록
+     * @return 재정렬된 항목 목록
+     */
+    List<NavigationItemResponse> reorderNavigationItems(Long tenantId, List<Long> itemIds);
+
+    /**
+     * 기본 네비게이션 항목 초기화
+     * @param tenantId 테넌트 ID
+     * @return 초기화된 항목 목록
+     */
+    List<NavigationItemResponse> initializeDefaultNavigationItems(Long tenantId);
 }

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsServiceImpl.java
@@ -1,15 +1,24 @@
 package com.mzc.lp.domain.tenant.service;
 
+import com.mzc.lp.domain.tenant.dto.request.NavigationItemRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateDesignSettingsRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateLayoutSettingsRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateTenantSettingsRequest;
+import com.mzc.lp.domain.tenant.dto.response.NavigationItemResponse;
 import com.mzc.lp.domain.tenant.dto.response.TenantSettingsResponse;
+import com.mzc.lp.domain.tenant.entity.NavigationItem;
 import com.mzc.lp.domain.tenant.entity.Tenant;
 import com.mzc.lp.domain.tenant.entity.TenantSettings;
 import com.mzc.lp.domain.tenant.exception.TenantDomainNotFoundException;
+import com.mzc.lp.domain.tenant.repository.NavigationItemRepository;
 import com.mzc.lp.domain.tenant.repository.TenantRepository;
 import com.mzc.lp.domain.tenant.repository.TenantSettingsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +27,7 @@ public class TenantSettingsServiceImpl implements TenantSettingsService {
 
     private final TenantSettingsRepository tenantSettingsRepository;
     private final TenantRepository tenantRepository;
+    private final NavigationItemRepository navigationItemRepository;
 
     @Override
     public TenantSettingsResponse getSettings(Long tenantId) {
@@ -32,13 +42,17 @@ public class TenantSettingsServiceImpl implements TenantSettingsService {
         TenantSettings settings = tenantSettingsRepository.findByTenantId(tenantId)
                 .orElseGet(() -> initializeAndGet(tenantId));
 
-        // 브랜딩 설정 업데이트
+        // 브랜딩 설정 업데이트 (기존 호환성 유지)
         settings.updateBranding(
                 request.logoUrl(),
+                null, // darkLogoUrl
                 request.faviconUrl(),
                 request.primaryColor(),
                 request.secondaryColor(),
-                request.fontFamily()
+                null, // accentColor
+                request.fontFamily(),
+                null, // headingFont
+                null  // bodyFont
         );
 
         // 일반 설정 업데이트
@@ -75,6 +89,43 @@ public class TenantSettingsServiceImpl implements TenantSettingsService {
 
     @Override
     @Transactional
+    public TenantSettingsResponse updateDesignSettings(Long tenantId, UpdateDesignSettingsRequest request) {
+        TenantSettings settings = tenantSettingsRepository.findByTenantId(tenantId)
+                .orElseGet(() -> initializeAndGet(tenantId));
+
+        settings.updateBranding(
+                request.logoUrl(),
+                request.darkLogoUrl(),
+                request.faviconUrl(),
+                request.primaryColor(),
+                request.secondaryColor(),
+                request.accentColor(),
+                null, // fontFamily (legacy)
+                request.headingFont(),
+                request.bodyFont()
+        );
+
+        return TenantSettingsResponse.from(settings);
+    }
+
+    @Override
+    @Transactional
+    public TenantSettingsResponse updateLayoutSettings(Long tenantId, UpdateLayoutSettingsRequest request) {
+        TenantSettings settings = tenantSettingsRepository.findByTenantId(tenantId)
+                .orElseGet(() -> initializeAndGet(tenantId));
+
+        settings.updateLayoutSettings(
+                request.headerSettings(),
+                request.sidebarSettings(),
+                request.footerSettings(),
+                request.contentSettings()
+        );
+
+        return TenantSettingsResponse.from(settings);
+    }
+
+    @Override
+    @Transactional
     public TenantSettingsResponse initializeSettings(Long tenantId) {
         if (tenantSettingsRepository.existsByTenantId(tenantId)) {
             return getSettings(tenantId);
@@ -82,6 +133,127 @@ public class TenantSettingsServiceImpl implements TenantSettingsService {
 
         TenantSettings settings = initializeAndGet(tenantId);
         return TenantSettingsResponse.from(settings);
+    }
+
+    // ============================================
+    // 네비게이션 관리
+    // ============================================
+
+    @Override
+    public List<NavigationItemResponse> getNavigationItems(Long tenantId) {
+        // 네비게이션 항목이 없으면 기본 항목 초기화
+        if (!navigationItemRepository.existsByTenantId(tenantId)) {
+            return initializeDefaultNavigationItems(tenantId);
+        }
+
+        return navigationItemRepository.findByTenantIdOrderByDisplayOrderAsc(tenantId)
+                .stream()
+                .map(NavigationItemResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public NavigationItemResponse createNavigationItem(Long tenantId, NavigationItemRequest request) {
+        Tenant tenant = tenantRepository.findById(tenantId)
+                .orElseThrow(() -> new TenantDomainNotFoundException("Tenant not found: " + tenantId));
+
+        int maxOrder = navigationItemRepository.findMaxDisplayOrderByTenantId(tenantId);
+        int newOrder = request.displayOrder() != null ? request.displayOrder() : maxOrder + 1;
+
+        NavigationItem item = NavigationItem.create(
+                tenant,
+                request.label(),
+                request.icon(),
+                request.path(),
+                newOrder
+        );
+
+        if (request.enabled() != null) {
+            item.update(null, null, null, request.enabled(), null, request.target());
+        }
+
+        NavigationItem saved = navigationItemRepository.save(item);
+        return NavigationItemResponse.from(saved);
+    }
+
+    @Override
+    @Transactional
+    public NavigationItemResponse updateNavigationItem(Long tenantId, Long itemId, NavigationItemRequest request) {
+        NavigationItem item = navigationItemRepository.findByIdAndTenantId(itemId, tenantId)
+                .orElseThrow(() -> new TenantDomainNotFoundException("Navigation item not found: " + itemId));
+
+        item.update(
+                request.label(),
+                request.icon(),
+                request.path(),
+                request.enabled(),
+                request.displayOrder(),
+                request.target()
+        );
+
+        return NavigationItemResponse.from(item);
+    }
+
+    @Override
+    @Transactional
+    public void deleteNavigationItem(Long tenantId, Long itemId) {
+        NavigationItem item = navigationItemRepository.findByIdAndTenantId(itemId, tenantId)
+                .orElseThrow(() -> new TenantDomainNotFoundException("Navigation item not found: " + itemId));
+
+        navigationItemRepository.delete(item);
+    }
+
+    @Override
+    @Transactional
+    public List<NavigationItemResponse> reorderNavigationItems(Long tenantId, List<Long> itemIds) {
+        List<NavigationItem> items = navigationItemRepository.findByTenantIdOrderByDisplayOrderAsc(tenantId);
+
+        for (int i = 0; i < itemIds.size(); i++) {
+            Long itemId = itemIds.get(i);
+            items.stream()
+                    .filter(item -> item.getId().equals(itemId))
+                    .findFirst()
+                    .ifPresent(item -> item.updateOrder(itemIds.indexOf(item.getId()) + 1));
+        }
+
+        // 순서 재설정
+        for (int i = 0; i < itemIds.size(); i++) {
+            final int order = i + 1;
+            final Long id = itemIds.get(i);
+            items.stream()
+                    .filter(item -> item.getId().equals(id))
+                    .findFirst()
+                    .ifPresent(item -> item.updateOrder(order));
+        }
+
+        return items.stream()
+                .sorted((a, b) -> a.getDisplayOrder().compareTo(b.getDisplayOrder()))
+                .map(NavigationItemResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public List<NavigationItemResponse> initializeDefaultNavigationItems(Long tenantId) {
+        Tenant tenant = tenantRepository.findById(tenantId)
+                .orElseThrow(() -> new TenantDomainNotFoundException("Tenant not found: " + tenantId));
+
+        // 기존 항목 삭제
+        navigationItemRepository.deleteAllByTenantId(tenantId);
+
+        // 기본 네비게이션 항목 생성
+        List<NavigationItem> defaultItems = new ArrayList<>();
+        defaultItems.add(NavigationItem.createDefault(tenant, "홈", "Home", "/", 1));
+        defaultItems.add(NavigationItem.createDefault(tenant, "강좌", "BookOpen", "/courses", 2));
+        defaultItems.add(NavigationItem.createDefault(tenant, "내 학습", "Award", "/my-learning", 3));
+        defaultItems.add(NavigationItem.createDefault(tenant, "도움말", "HelpCircle", "/help", 4));
+
+        List<NavigationItem> saved = navigationItemRepository.saveAll(defaultItems);
+
+        return saved.stream()
+                .map(NavigationItemResponse::from)
+                .toList();
     }
 
     private TenantSettings initializeAndGet(Long tenantId) {


### PR DESCRIPTION
## Summary

테넌트 관리자(TA)가 설정할 수 있는 브랜딩 관련 기능을 확장했습니다. 네비게이션 메뉴, 디자인 설정, 레이아웃 설정 기능을 추가하여 TenantSettings 엔티티를 확장하고 관련 API를 구현했습니다.

## Related Issue

- Closes #261

## Changes

- TenantSettings 엔티티에 네비게이션, 디자인, 레이아웃 관련 필드 추가
- NavigationItem 엔티티 추가 및 Repository 구현
- TenantSettingsController에 네비게이션, 디자인, 레이아웃 설정 API 엔드포인트 추가
- NavigationItemRequest/Response, UpdateDesignSettingsRequest, UpdateLayoutSettingsRequest DTO 추가
- TenantSettingsResponse에 네비게이션 아이템 리스트 포함

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [ ] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

이 PR은 테넌트 브랜딩 기능의 기반이 되는 작업입니다. 다음 PR인 public-branding-api가 이 변경사항에 의존합니다.