### PR TITLE
feat: 수료증(Certificate) 관리 기능 구현

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -132,7 +132,12 @@ public enum ErrorCode {
     COMMUNITY_NOT_COMMENT_AUTHOR(HttpStatus.FORBIDDEN, "CMT005", "Not authorized to modify this comment"),
 
     // Notification (NF)
-    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NF001", "Notification not found");
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NF001", "Notification not found"),
+
+    // Certificate (CERT)
+    CERTIFICATE_NOT_FOUND(HttpStatus.NOT_FOUND, "CERT001", "Certificate not found"),
+    CERTIFICATE_ALREADY_ISSUED(HttpStatus.CONFLICT, "CERT002", "Certificate already issued for this enrollment"),
+    CERTIFICATE_REVOKED(HttpStatus.BAD_REQUEST, "CERT003", "Certificate has been revoked");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/mzc/lp/domain/certificate/constant/CertificateStatus.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/constant/CertificateStatus.java
@@ -1,0 +1,9 @@
+package com.mzc.lp.domain.certificate.constant;
+
+/**
+ * 수료증 상태
+ */
+public enum CertificateStatus {
+    ISSUED,     // 발급됨 (유효)
+    REVOKED     // 폐기됨 (무효)
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/controller/CertificateController.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/controller/CertificateController.java
@@ -1,0 +1,107 @@
+package com.mzc.lp.domain.certificate.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.certificate.dto.response.CertificateDetailResponse;
+import com.mzc.lp.domain.certificate.dto.response.CertificateResponse;
+import com.mzc.lp.domain.certificate.dto.response.CertificateVerifyResponse;
+import com.mzc.lp.domain.certificate.service.CertificateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@RestController
+@RequiredArgsConstructor
+public class CertificateController {
+
+    private final CertificateService certificateService;
+
+    /**
+     * 내 수료증 목록 조회
+     * GET /api/users/me/certificates
+     */
+    @GetMapping("/api/users/me/certificates")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<Page<CertificateResponse>>> getMyCertificates(
+            @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Page<CertificateResponse> response = certificateService.getMyCertificates(
+                principal.id(), pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 수료증 상세 조회
+     * GET /api/certificates/{id}
+     */
+    @GetMapping("/api/certificates/{id}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<CertificateDetailResponse>> getCertificate(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CertificateDetailResponse response = certificateService.getCertificate(id, principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 수료증 PDF 다운로드
+     * GET /api/certificates/{id}/download
+     */
+    @GetMapping("/api/certificates/{id}/download")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<byte[]> downloadCertificate(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        byte[] pdfBytes = certificateService.downloadCertificatePdf(id, principal.id());
+
+        String filename = "certificate_" + id + ".pdf";
+        String encodedFilename = URLEncoder.encode(filename, StandardCharsets.UTF_8)
+                .replaceAll("\\+", "%20");
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_PDF)
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename*=UTF-8''" + encodedFilename)
+                .body(pdfBytes);
+    }
+
+    /**
+     * 수료증 진위 확인
+     * GET /api/certificates/verify/{certificateNumber}
+     */
+    @GetMapping("/api/certificates/verify/{certificateNumber}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<CertificateVerifyResponse>> verifyCertificate(
+            @PathVariable String certificateNumber
+    ) {
+        CertificateVerifyResponse response = certificateService.verifyCertificate(certificateNumber);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 수료증 폐기 (관리자)
+     * DELETE /api/certificates/{id}
+     */
+    @DeleteMapping("/api/certificates/{id}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> revokeCertificate(
+            @PathVariable Long id,
+            @RequestParam String reason
+    ) {
+        certificateService.revokeCertificate(id, reason);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/dto/response/CertificateDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/dto/response/CertificateDetailResponse.java
@@ -1,0 +1,42 @@
+package com.mzc.lp.domain.certificate.dto.response;
+
+import com.mzc.lp.domain.certificate.constant.CertificateStatus;
+import com.mzc.lp.domain.certificate.entity.Certificate;
+
+import java.time.Instant;
+
+public record CertificateDetailResponse(
+        Long id,
+        String certificateNumber,
+        Long userId,
+        String userName,
+        Long enrollmentId,
+        Long courseTimeId,
+        String courseTimeTitle,
+        Long programId,
+        String programTitle,
+        Instant completedAt,
+        Instant issuedAt,
+        CertificateStatus status,
+        Instant revokedAt,
+        String revokedReason
+) {
+    public static CertificateDetailResponse from(Certificate certificate) {
+        return new CertificateDetailResponse(
+                certificate.getId(),
+                certificate.getCertificateNumber(),
+                certificate.getUserId(),
+                certificate.getUserName(),
+                certificate.getEnrollmentId(),
+                certificate.getCourseTimeId(),
+                certificate.getCourseTimeTitle(),
+                certificate.getProgramId(),
+                certificate.getProgramTitle(),
+                certificate.getCompletedAt(),
+                certificate.getIssuedAt(),
+                certificate.getStatus(),
+                certificate.getRevokedAt(),
+                certificate.getRevokedReason()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/dto/response/CertificateResponse.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/dto/response/CertificateResponse.java
@@ -1,0 +1,30 @@
+package com.mzc.lp.domain.certificate.dto.response;
+
+import com.mzc.lp.domain.certificate.constant.CertificateStatus;
+import com.mzc.lp.domain.certificate.entity.Certificate;
+
+import java.time.Instant;
+
+public record CertificateResponse(
+        Long id,
+        String certificateNumber,
+        String programTitle,
+        String courseTimeTitle,
+        String userName,
+        Instant completedAt,
+        Instant issuedAt,
+        CertificateStatus status
+) {
+    public static CertificateResponse from(Certificate certificate) {
+        return new CertificateResponse(
+                certificate.getId(),
+                certificate.getCertificateNumber(),
+                certificate.getProgramTitle(),
+                certificate.getCourseTimeTitle(),
+                certificate.getUserName(),
+                certificate.getCompletedAt(),
+                certificate.getIssuedAt(),
+                certificate.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/dto/response/CertificateVerifyResponse.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/dto/response/CertificateVerifyResponse.java
@@ -1,0 +1,51 @@
+package com.mzc.lp.domain.certificate.dto.response;
+
+import com.mzc.lp.domain.certificate.constant.CertificateStatus;
+import com.mzc.lp.domain.certificate.entity.Certificate;
+
+import java.time.Instant;
+
+public record CertificateVerifyResponse(
+        boolean valid,
+        String certificateNumber,
+        String userName,
+        String programTitle,
+        String courseTimeTitle,
+        Instant completedAt,
+        Instant issuedAt,
+        CertificateStatus status,
+        String message
+) {
+    public static CertificateVerifyResponse from(Certificate certificate) {
+        boolean isValid = certificate.isValid();
+        String message = isValid
+                ? "유효한 수료증입니다."
+                : "폐기된 수료증입니다. 사유: " + certificate.getRevokedReason();
+
+        return new CertificateVerifyResponse(
+                isValid,
+                certificate.getCertificateNumber(),
+                certificate.getUserName(),
+                certificate.getProgramTitle(),
+                certificate.getCourseTimeTitle(),
+                certificate.getCompletedAt(),
+                certificate.getIssuedAt(),
+                certificate.getStatus(),
+                message
+        );
+    }
+
+    public static CertificateVerifyResponse notFound(String certificateNumber) {
+        return new CertificateVerifyResponse(
+                false,
+                certificateNumber,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "존재하지 않는 수료증 번호입니다."
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/entity/Certificate.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/entity/Certificate.java
@@ -1,0 +1,116 @@
+package com.mzc.lp.domain.certificate.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import com.mzc.lp.domain.certificate.constant.CertificateStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "certificates",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_certificate_number",
+                        columnNames = {"tenant_id", "certificate_number"}
+                ),
+                @UniqueConstraint(
+                        name = "uk_certificate_enrollment",
+                        columnNames = {"tenant_id", "enrollment_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_certificate_user", columnList = "tenant_id, user_id"),
+                @Index(name = "idx_certificate_status", columnList = "tenant_id, status"),
+                @Index(name = "idx_certificate_issued_at", columnList = "tenant_id, issued_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Certificate extends TenantEntity {
+
+    @Version
+    private Long version;
+
+    @Column(name = "certificate_number", nullable = false, length = 50)
+    private String certificateNumber;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "user_name", nullable = false, length = 100)
+    private String userName;
+
+    @Column(name = "enrollment_id", nullable = false)
+    private Long enrollmentId;
+
+    @Column(name = "course_time_id", nullable = false)
+    private Long courseTimeId;
+
+    @Column(name = "course_time_title", nullable = false, length = 200)
+    private String courseTimeTitle;
+
+    @Column(name = "program_id")
+    private Long programId;
+
+    @Column(name = "program_title", length = 255)
+    private String programTitle;
+
+    @Column(name = "completed_at", nullable = false)
+    private Instant completedAt;
+
+    @Column(name = "issued_at", nullable = false)
+    private Instant issuedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private CertificateStatus status;
+
+    @Column(name = "revoked_at")
+    private Instant revokedAt;
+
+    @Column(name = "revoked_reason", length = 500)
+    private String revokedReason;
+
+    public static Certificate create(
+            String certificateNumber,
+            Long userId,
+            String userName,
+            Long enrollmentId,
+            Long courseTimeId,
+            String courseTimeTitle,
+            Long programId,
+            String programTitle,
+            Instant completedAt
+    ) {
+        Certificate certificate = new Certificate();
+        certificate.certificateNumber = certificateNumber;
+        certificate.userId = userId;
+        certificate.userName = userName;
+        certificate.enrollmentId = enrollmentId;
+        certificate.courseTimeId = courseTimeId;
+        certificate.courseTimeTitle = courseTimeTitle;
+        certificate.programId = programId;
+        certificate.programTitle = programTitle;
+        certificate.completedAt = completedAt;
+        certificate.issuedAt = Instant.now();
+        certificate.status = CertificateStatus.ISSUED;
+        return certificate;
+    }
+
+    public void revoke(String reason) {
+        this.status = CertificateStatus.REVOKED;
+        this.revokedAt = Instant.now();
+        this.revokedReason = reason;
+    }
+
+    public boolean isValid() {
+        return this.status == CertificateStatus.ISSUED;
+    }
+
+    public boolean isRevoked() {
+        return this.status == CertificateStatus.REVOKED;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/event/EnrollmentCompletedEvent.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/event/EnrollmentCompletedEvent.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.domain.certificate.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class EnrollmentCompletedEvent extends ApplicationEvent {
+
+    private final Long enrollmentId;
+    private final Long userId;
+    private final Long courseTimeId;
+
+    public EnrollmentCompletedEvent(Object source, Long enrollmentId, Long userId, Long courseTimeId) {
+        super(source);
+        this.enrollmentId = enrollmentId;
+        this.userId = userId;
+        this.courseTimeId = courseTimeId;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/exception/CertificateAlreadyIssuedException.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/exception/CertificateAlreadyIssuedException.java
@@ -1,0 +1,12 @@
+package com.mzc.lp.domain.certificate.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class CertificateAlreadyIssuedException extends BusinessException {
+
+    public CertificateAlreadyIssuedException(Long enrollmentId) {
+        super(ErrorCode.CERTIFICATE_ALREADY_ISSUED,
+                "Certificate already issued for enrollment: " + enrollmentId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/exception/CertificateNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/exception/CertificateNotFoundException.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.domain.certificate.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class CertificateNotFoundException extends BusinessException {
+
+    public CertificateNotFoundException() {
+        super(ErrorCode.CERTIFICATE_NOT_FOUND);
+    }
+
+    public CertificateNotFoundException(Long certificateId) {
+        super(ErrorCode.CERTIFICATE_NOT_FOUND, "Certificate not found with id: " + certificateId);
+    }
+
+    public CertificateNotFoundException(String certificateNumber) {
+        super(ErrorCode.CERTIFICATE_NOT_FOUND, "Certificate not found with number: " + certificateNumber);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/listener/CertificateEventListener.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/listener/CertificateEventListener.java
@@ -1,0 +1,30 @@
+package com.mzc.lp.domain.certificate.listener;
+
+import com.mzc.lp.domain.certificate.event.EnrollmentCompletedEvent;
+import com.mzc.lp.domain.certificate.service.CertificateService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CertificateEventListener {
+
+    private final CertificateService certificateService;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleEnrollmentCompleted(EnrollmentCompletedEvent event) {
+        log.info("EnrollmentCompletedEvent received: enrollmentId={}, userId={}, courseTimeId={}",
+                event.getEnrollmentId(), event.getUserId(), event.getCourseTimeId());
+
+        try {
+            certificateService.issueCertificate(event.getEnrollmentId());
+        } catch (Exception e) {
+            log.error("Failed to issue certificate for enrollment: {}", event.getEnrollmentId(), e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/repository/CertificateRepository.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/repository/CertificateRepository.java
@@ -1,0 +1,23 @@
+package com.mzc.lp.domain.certificate.repository;
+
+import com.mzc.lp.domain.certificate.entity.Certificate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CertificateRepository extends JpaRepository<Certificate, Long> {
+
+    Optional<Certificate> findByIdAndTenantId(Long id, Long tenantId);
+
+    Optional<Certificate> findByCertificateNumber(String certificateNumber);
+
+    Page<Certificate> findByUserIdAndTenantIdOrderByIssuedAtDesc(Long userId, Long tenantId, Pageable pageable);
+
+    boolean existsByEnrollmentIdAndTenantId(Long enrollmentId, Long tenantId);
+
+    Long countByTenantIdAndCertificateNumberStartingWith(Long tenantId, String prefix);
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/service/CertificateNumberGenerator.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/service/CertificateNumberGenerator.java
@@ -1,0 +1,31 @@
+package com.mzc.lp.domain.certificate.service;
+
+import com.mzc.lp.domain.certificate.repository.CertificateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class CertificateNumberGenerator {
+
+    private final CertificateRepository certificateRepository;
+
+    /**
+     * 테넌트별/연도별 Sequence 기반 수료증 번호 생성
+     * 형식: CERT-{tenantId(3자리)}-{year}-{sequence(6자리)}
+     * 예시: CERT-001-2026-000001
+     */
+    public String generate(Long tenantId) {
+        int currentYear = LocalDate.now().getYear();
+        String prefix = String.format("CERT-%03d-%d-", tenantId, currentYear);
+
+        Long currentSequence = certificateRepository
+                .countByTenantIdAndCertificateNumberStartingWith(tenantId, prefix);
+
+        long nextSequence = currentSequence + 1;
+
+        return String.format("CERT-%03d-%d-%06d", tenantId, currentYear, nextSequence);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/service/CertificatePdfService.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/service/CertificatePdfService.java
@@ -1,0 +1,13 @@
+package com.mzc.lp.domain.certificate.service;
+
+import com.mzc.lp.domain.certificate.entity.Certificate;
+
+public interface CertificatePdfService {
+
+    /**
+     * 수료증 PDF 생성
+     * @param certificate 수료증 엔티티
+     * @return PDF 바이트 배열
+     */
+    byte[] generatePdf(Certificate certificate);
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/service/CertificatePdfServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/service/CertificatePdfServiceImpl.java
@@ -1,0 +1,259 @@
+package com.mzc.lp.domain.certificate.service;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.domain.certificate.entity.Certificate;
+import com.mzc.lp.domain.tenant.entity.TenantSettings;
+import com.mzc.lp.domain.tenant.repository.TenantSettingsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDType0Font;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Service;
+
+import java.awt.Color;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CertificatePdfServiceImpl implements CertificatePdfService {
+
+    private final TenantSettingsRepository tenantSettingsRepository;
+    private final ResourceLoader resourceLoader;
+
+    private static final String REGULAR_FONT_PATH = "classpath:fonts/NotoSansKR-Regular.ttf";
+    private static final String BOLD_FONT_PATH = "classpath:fonts/NotoSansKR-Bold.ttf";
+
+    private static final float PAGE_WIDTH = PDRectangle.A4.getWidth();
+    private static final float PAGE_HEIGHT = PDRectangle.A4.getHeight();
+    private static final DateTimeFormatter DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy년 MM월 dd일").withZone(ZoneId.of("Asia/Seoul"));
+
+    @Override
+    public byte[] generatePdf(Certificate certificate) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        TenantSettings settings = tenantSettingsRepository.findByTenantId(tenantId).orElse(null);
+
+        try (PDDocument document = new PDDocument();
+             ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+
+            PDPage page = new PDPage(PDRectangle.A4);
+            document.addPage(page);
+
+            // 폰트 로드
+            PDType0Font regularFont = loadFont(document, REGULAR_FONT_PATH);
+            PDType0Font boldFont = loadFont(document, BOLD_FONT_PATH);
+
+            try (PDPageContentStream contentStream = new PDPageContentStream(document, page)) {
+                // 1. 배경 그리기
+                drawBackground(contentStream, settings);
+
+                // 2. 제목 (수료증)
+                drawTitle(contentStream, boldFont);
+
+                // 3. 수료자 이름
+                drawUserName(contentStream, boldFont, certificate.getUserName());
+
+                // 4. 본문 (과정명 및 수료 문구)
+                drawBody(contentStream, regularFont, boldFont, certificate);
+
+                // 5. 수료일
+                drawCompletionDate(contentStream, regularFont, certificate);
+
+                // 6. 발급일
+                drawIssuedDate(contentStream, regularFont, certificate);
+
+                // 7. 수료증 번호
+                drawCertificateNumber(contentStream, regularFont, certificate);
+
+                // 8. 테두리
+                drawBorder(contentStream, settings);
+            }
+
+            document.save(baos);
+            return baos.toByteArray();
+
+        } catch (IOException e) {
+            log.error("Failed to generate certificate PDF: certificateId={}", certificate.getId(), e);
+            throw new RuntimeException("PDF 생성 실패", e);
+        }
+    }
+
+    private PDType0Font loadFont(PDDocument document, String path) throws IOException {
+        Resource resource = resourceLoader.getResource(path);
+        try (InputStream is = resource.getInputStream()) {
+            return PDType0Font.load(document, is);
+        }
+    }
+
+    private void drawBackground(PDPageContentStream contentStream, TenantSettings settings) throws IOException {
+        String colorHex = settings != null && settings.getPrimaryColor() != null
+                ? settings.getPrimaryColor()
+                : "#3B82F6";
+        Color accentColor = Color.decode(colorHex);
+
+        // 상단 배너
+        contentStream.setNonStrokingColor(accentColor);
+        contentStream.addRect(0, PAGE_HEIGHT - 80, PAGE_WIDTH, 80);
+        contentStream.fill();
+
+        // 하단 배너
+        contentStream.addRect(0, 0, PAGE_WIDTH, 40);
+        contentStream.fill();
+
+        // 메인 배경 (흰색)
+        contentStream.setNonStrokingColor(Color.WHITE);
+        contentStream.addRect(40, 50, PAGE_WIDTH - 80, PAGE_HEIGHT - 180);
+        contentStream.fill();
+    }
+
+    private void drawTitle(PDPageContentStream contentStream, PDType0Font boldFont) throws IOException {
+        String title = "수 료 증";
+        contentStream.setNonStrokingColor(Color.BLACK);
+        contentStream.beginText();
+        contentStream.setFont(boldFont, 42);
+
+        float titleWidth = boldFont.getStringWidth(title) / 1000 * 42;
+        contentStream.newLineAtOffset((PAGE_WIDTH - titleWidth) / 2, PAGE_HEIGHT - 160);
+        contentStream.showText(title);
+        contentStream.endText();
+    }
+
+    private void drawUserName(PDPageContentStream contentStream, PDType0Font boldFont, String userName) throws IOException {
+        contentStream.setNonStrokingColor(Color.BLACK);
+
+        // 사용자 이름
+        contentStream.beginText();
+        contentStream.setFont(boldFont, 32);
+        float nameWidth = boldFont.getStringWidth(userName) / 1000 * 32;
+        contentStream.newLineAtOffset((PAGE_WIDTH - nameWidth - 30) / 2, PAGE_HEIGHT - 260);
+        contentStream.showText(userName);
+        contentStream.endText();
+
+        // "님" 추가
+        contentStream.beginText();
+        contentStream.setFont(boldFont, 20);
+        contentStream.newLineAtOffset((PAGE_WIDTH + nameWidth - 30) / 2 + 10, PAGE_HEIGHT - 260);
+        contentStream.showText("님");
+        contentStream.endText();
+
+        // 밑줄
+        contentStream.setStrokingColor(Color.BLACK);
+        contentStream.setLineWidth(1);
+        float underlineStart = (PAGE_WIDTH - nameWidth - 60) / 2;
+        contentStream.moveTo(underlineStart, PAGE_HEIGHT - 268);
+        contentStream.lineTo(underlineStart + nameWidth + 60, PAGE_HEIGHT - 268);
+        contentStream.stroke();
+    }
+
+    private void drawBody(PDPageContentStream contentStream, PDType0Font regularFont,
+                          PDType0Font boldFont, Certificate certificate) throws IOException {
+        String courseName = certificate.getProgramTitle() != null
+                ? certificate.getProgramTitle()
+                : certificate.getCourseTimeTitle();
+
+        // "위 사람은"
+        contentStream.beginText();
+        contentStream.setFont(regularFont, 16);
+        String prefix = "위 사람은";
+        float prefixWidth = regularFont.getStringWidth(prefix) / 1000 * 16;
+        contentStream.newLineAtOffset((PAGE_WIDTH - prefixWidth) / 2, PAGE_HEIGHT - 340);
+        contentStream.showText(prefix);
+        contentStream.endText();
+
+        // 과정명
+        contentStream.beginText();
+        contentStream.setFont(boldFont, 20);
+        float courseWidth = boldFont.getStringWidth(courseName) / 1000 * 20;
+        float courseX = (PAGE_WIDTH - courseWidth) / 2;
+        if (courseX < 60) courseX = 60;
+        contentStream.newLineAtOffset(courseX, PAGE_HEIGHT - 390);
+        contentStream.showText(courseName);
+        contentStream.endText();
+
+        // "과정을 성실히 이수하였기에"
+        contentStream.beginText();
+        contentStream.setFont(regularFont, 16);
+        String middle = "과정을 성실히 이수하였기에";
+        float middleWidth = regularFont.getStringWidth(middle) / 1000 * 16;
+        contentStream.newLineAtOffset((PAGE_WIDTH - middleWidth) / 2, PAGE_HEIGHT - 440);
+        contentStream.showText(middle);
+        contentStream.endText();
+
+        // "이 증서를 수여합니다."
+        contentStream.beginText();
+        contentStream.setFont(regularFont, 16);
+        String suffix = "이 증서를 수여합니다.";
+        float suffixWidth = regularFont.getStringWidth(suffix) / 1000 * 16;
+        contentStream.newLineAtOffset((PAGE_WIDTH - suffixWidth) / 2, PAGE_HEIGHT - 470);
+        contentStream.showText(suffix);
+        contentStream.endText();
+    }
+
+    private void drawCompletionDate(PDPageContentStream contentStream, PDType0Font regularFont,
+                                    Certificate certificate) throws IOException {
+        String completedDate = DATE_FORMATTER.format(certificate.getCompletedAt());
+        String text = "수료일: " + completedDate;
+
+        contentStream.beginText();
+        contentStream.setFont(regularFont, 14);
+        contentStream.setNonStrokingColor(Color.DARK_GRAY);
+        float textWidth = regularFont.getStringWidth(text) / 1000 * 14;
+        contentStream.newLineAtOffset((PAGE_WIDTH - textWidth) / 2, PAGE_HEIGHT - 550);
+        contentStream.showText(text);
+        contentStream.endText();
+    }
+
+    private void drawIssuedDate(PDPageContentStream contentStream, PDType0Font regularFont,
+                                Certificate certificate) throws IOException {
+        String issuedDate = DATE_FORMATTER.format(certificate.getIssuedAt());
+        String text = "발급일: " + issuedDate;
+
+        contentStream.beginText();
+        contentStream.setFont(regularFont, 14);
+        contentStream.setNonStrokingColor(Color.DARK_GRAY);
+        float textWidth = regularFont.getStringWidth(text) / 1000 * 14;
+        contentStream.newLineAtOffset((PAGE_WIDTH - textWidth) / 2, PAGE_HEIGHT - 580);
+        contentStream.showText(text);
+        contentStream.endText();
+    }
+
+    private void drawCertificateNumber(PDPageContentStream contentStream, PDType0Font regularFont,
+                                       Certificate certificate) throws IOException {
+        String text = "수료증 번호: " + certificate.getCertificateNumber();
+
+        contentStream.beginText();
+        contentStream.setFont(regularFont, 10);
+        contentStream.setNonStrokingColor(Color.GRAY);
+        contentStream.newLineAtOffset(60, 60);
+        contentStream.showText(text);
+        contentStream.endText();
+    }
+
+    private void drawBorder(PDPageContentStream contentStream, TenantSettings settings) throws IOException {
+        String colorHex = settings != null && settings.getSecondaryColor() != null
+                ? settings.getSecondaryColor()
+                : "#1E40AF";
+        Color borderColor = Color.decode(colorHex);
+
+        contentStream.setStrokingColor(borderColor);
+        contentStream.setLineWidth(3);
+        contentStream.addRect(30, 30, PAGE_WIDTH - 60, PAGE_HEIGHT - 60);
+        contentStream.stroke();
+
+        // 내부 테두리 (골드)
+        contentStream.setStrokingColor(new Color(212, 175, 55));
+        contentStream.setLineWidth(1);
+        contentStream.addRect(35, 35, PAGE_WIDTH - 70, PAGE_HEIGHT - 70);
+        contentStream.stroke();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/service/CertificateService.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/service/CertificateService.java
@@ -1,0 +1,40 @@
+package com.mzc.lp.domain.certificate.service;
+
+import com.mzc.lp.domain.certificate.dto.response.CertificateDetailResponse;
+import com.mzc.lp.domain.certificate.dto.response.CertificateResponse;
+import com.mzc.lp.domain.certificate.dto.response.CertificateVerifyResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CertificateService {
+
+    /**
+     * 수료 시 수료증 자동 발급
+     */
+    CertificateDetailResponse issueCertificate(Long enrollmentId);
+
+    /**
+     * 내 수료증 목록 조회
+     */
+    Page<CertificateResponse> getMyCertificates(Long userId, Pageable pageable);
+
+    /**
+     * 수료증 상세 조회
+     */
+    CertificateDetailResponse getCertificate(Long certificateId, Long userId);
+
+    /**
+     * 수료증 PDF 다운로드
+     */
+    byte[] downloadCertificatePdf(Long certificateId, Long userId);
+
+    /**
+     * 수료증 진위 확인
+     */
+    CertificateVerifyResponse verifyCertificate(String certificateNumber);
+
+    /**
+     * 수료증 폐기 (관리자)
+     */
+    void revokeCertificate(Long certificateId, String reason);
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/service/CertificateServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/service/CertificateServiceImpl.java
@@ -1,0 +1,144 @@
+package com.mzc.lp.domain.certificate.service;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.domain.certificate.dto.response.CertificateDetailResponse;
+import com.mzc.lp.domain.certificate.dto.response.CertificateResponse;
+import com.mzc.lp.domain.certificate.dto.response.CertificateVerifyResponse;
+import com.mzc.lp.domain.certificate.entity.Certificate;
+import com.mzc.lp.domain.certificate.exception.CertificateAlreadyIssuedException;
+import com.mzc.lp.domain.certificate.exception.CertificateNotFoundException;
+import com.mzc.lp.domain.certificate.repository.CertificateRepository;
+import com.mzc.lp.domain.student.entity.Enrollment;
+import com.mzc.lp.domain.student.exception.EnrollmentNotFoundException;
+import com.mzc.lp.domain.student.exception.UnauthorizedEnrollmentAccessException;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.ts.exception.CourseTimeNotFoundException;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.exception.UserNotFoundException;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CertificateServiceImpl implements CertificateService {
+
+    private final CertificateRepository certificateRepository;
+    private final EnrollmentRepository enrollmentRepository;
+    private final CourseTimeRepository courseTimeRepository;
+    private final UserRepository userRepository;
+    private final CertificateNumberGenerator certificateNumberGenerator;
+    private final CertificatePdfService certificatePdfService;
+
+    @Override
+    @Transactional
+    public CertificateDetailResponse issueCertificate(Long enrollmentId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        log.info("Issuing certificate: enrollmentId={}, tenantId={}", enrollmentId, tenantId);
+
+        // 중복 발급 체크
+        if (certificateRepository.existsByEnrollmentIdAndTenantId(enrollmentId, tenantId)) {
+            throw new CertificateAlreadyIssuedException(enrollmentId);
+        }
+
+        // Enrollment 조회
+        Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, tenantId)
+                .orElseThrow(() -> new EnrollmentNotFoundException(enrollmentId));
+
+        // CourseTime 조회 (프로그램 정보 포함)
+        CourseTime courseTime = courseTimeRepository.findByIdAndTenantId(
+                enrollment.getCourseTimeId(), tenantId
+        ).orElseThrow(() -> new CourseTimeNotFoundException(enrollment.getCourseTimeId()));
+
+        // User 조회 (이름)
+        User user = userRepository.findById(enrollment.getUserId())
+                .orElseThrow(() -> new UserNotFoundException(enrollment.getUserId()));
+
+        // 수료증 번호 생성
+        String certificateNumber = certificateNumberGenerator.generate(tenantId);
+
+        // Certificate 생성
+        Certificate certificate = Certificate.create(
+                certificateNumber,
+                enrollment.getUserId(),
+                user.getName(),
+                enrollmentId,
+                courseTime.getId(),
+                courseTime.getTitle(),
+                courseTime.getProgram() != null ? courseTime.getProgram().getId() : null,
+                courseTime.getProgram() != null ? courseTime.getProgram().getTitle() : null,
+                enrollment.getCompletedAt()
+        );
+
+        Certificate saved = certificateRepository.save(certificate);
+        log.info("Certificate issued: certificateId={}, certificateNumber={}",
+                saved.getId(), saved.getCertificateNumber());
+
+        return CertificateDetailResponse.from(saved);
+    }
+
+    @Override
+    public Page<CertificateResponse> getMyCertificates(Long userId, Pageable pageable) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        return certificateRepository
+                .findByUserIdAndTenantIdOrderByIssuedAtDesc(userId, tenantId, pageable)
+                .map(CertificateResponse::from);
+    }
+
+    @Override
+    public CertificateDetailResponse getCertificate(Long certificateId, Long userId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        Certificate certificate = certificateRepository.findByIdAndTenantId(certificateId, tenantId)
+                .orElseThrow(() -> new CertificateNotFoundException(certificateId));
+
+        // 본인 소유 확인
+        if (!certificate.getUserId().equals(userId)) {
+            throw new UnauthorizedEnrollmentAccessException(certificateId, userId);
+        }
+
+        return CertificateDetailResponse.from(certificate);
+    }
+
+    @Override
+    public byte[] downloadCertificatePdf(Long certificateId, Long userId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        Certificate certificate = certificateRepository.findByIdAndTenantId(certificateId, tenantId)
+                .orElseThrow(() -> new CertificateNotFoundException(certificateId));
+
+        // 본인 소유 확인
+        if (!certificate.getUserId().equals(userId)) {
+            throw new UnauthorizedEnrollmentAccessException(certificateId, userId);
+        }
+
+        return certificatePdfService.generatePdf(certificate);
+    }
+
+    @Override
+    public CertificateVerifyResponse verifyCertificate(String certificateNumber) {
+        return certificateRepository.findByCertificateNumber(certificateNumber)
+                .map(CertificateVerifyResponse::from)
+                .orElse(CertificateVerifyResponse.notFound(certificateNumber));
+    }
+
+    @Override
+    @Transactional
+    public void revokeCertificate(Long certificateId, String reason) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        Certificate certificate = certificateRepository.findByIdAndTenantId(certificateId, tenantId)
+                .orElseThrow(() -> new CertificateNotFoundException(certificateId));
+
+        certificate.revoke(reason);
+        log.info("Certificate revoked: certificateId={}, reason={}", certificateId, reason);
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/certificate/service/CertificateServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/certificate/service/CertificateServiceTest.java
@@ -1,0 +1,398 @@
+package com.mzc.lp.domain.certificate.service;
+
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.certificate.constant.CertificateStatus;
+import com.mzc.lp.domain.certificate.dto.response.CertificateDetailResponse;
+import com.mzc.lp.domain.certificate.dto.response.CertificateResponse;
+import com.mzc.lp.domain.certificate.dto.response.CertificateVerifyResponse;
+import com.mzc.lp.domain.certificate.entity.Certificate;
+import com.mzc.lp.domain.certificate.exception.CertificateAlreadyIssuedException;
+import com.mzc.lp.domain.certificate.exception.CertificateNotFoundException;
+import com.mzc.lp.domain.certificate.repository.CertificateRepository;
+import com.mzc.lp.domain.program.entity.Program;
+import com.mzc.lp.domain.student.entity.Enrollment;
+import com.mzc.lp.domain.student.exception.UnauthorizedEnrollmentAccessException;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CertificateServiceTest extends TenantTestSupport {
+
+    @InjectMocks
+    private CertificateServiceImpl certificateService;
+
+    @Mock
+    private CertificateRepository certificateRepository;
+
+    @Mock
+    private EnrollmentRepository enrollmentRepository;
+
+    @Mock
+    private CourseTimeRepository courseTimeRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CertificateNumberGenerator certificateNumberGenerator;
+
+    @Mock
+    private CertificatePdfService certificatePdfService;
+
+    private static final Long TENANT_ID = 1L;
+
+    private Certificate createTestCertificate(Long userId, String certificateNumber) {
+        Certificate certificate = Certificate.create(
+                certificateNumber,
+                userId,
+                "테스트 사용자",
+                1L,
+                1L,
+                "테스트 차수",
+                1L,
+                "테스트 프로그램",
+                Instant.now()
+        );
+
+        // tenantId 설정
+        try {
+            var tenantIdField = com.mzc.lp.common.entity.TenantEntity.class.getDeclaredField("tenantId");
+            tenantIdField.setAccessible(true);
+            tenantIdField.set(certificate, TENANT_ID);
+
+            var idField = com.mzc.lp.common.entity.BaseEntity.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(certificate, 1L);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        return certificate;
+    }
+
+    // ==================== 수료증 발급 테스트 ====================
+
+    @Nested
+    @DisplayName("issueCertificate - 수료증 발급")
+    class IssueCertificate {
+
+        @Test
+        @DisplayName("성공 - 수료증 자동 발급")
+        void issueCertificate_success() {
+            // given
+            Long enrollmentId = 1L;
+            Long userId = 1L;
+            Long courseTimeId = 1L;
+
+            Enrollment enrollment = mock(Enrollment.class);
+            given(enrollment.getUserId()).willReturn(userId);
+            given(enrollment.getCourseTimeId()).willReturn(courseTimeId);
+            given(enrollment.getCompletedAt()).willReturn(Instant.now());
+
+            CourseTime courseTime = mock(CourseTime.class);
+            given(courseTime.getId()).willReturn(courseTimeId);
+            given(courseTime.getTitle()).willReturn("테스트 차수");
+            Program program = mock(Program.class);
+            given(program.getId()).willReturn(1L);
+            given(program.getTitle()).willReturn("테스트 프로그램");
+            given(courseTime.getProgram()).willReturn(program);
+
+            User user = mock(User.class);
+            given(user.getName()).willReturn("테스트 사용자");
+
+            given(certificateRepository.existsByEnrollmentIdAndTenantId(enrollmentId, TENANT_ID))
+                    .willReturn(false);
+            given(enrollmentRepository.findByIdAndTenantId(enrollmentId, TENANT_ID))
+                    .willReturn(Optional.of(enrollment));
+            given(courseTimeRepository.findByIdAndTenantId(courseTimeId, TENANT_ID))
+                    .willReturn(Optional.of(courseTime));
+            given(userRepository.findById(userId))
+                    .willReturn(Optional.of(user));
+            given(certificateNumberGenerator.generate(TENANT_ID))
+                    .willReturn("CERT-001-2026-000001");
+            given(certificateRepository.save(any(Certificate.class)))
+                    .willAnswer(invocation -> {
+                        Certificate cert = invocation.getArgument(0);
+                        try {
+                            var idField = com.mzc.lp.common.entity.BaseEntity.class.getDeclaredField("id");
+                            idField.setAccessible(true);
+                            idField.set(cert, 1L);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                        return cert;
+                    });
+
+            // when
+            CertificateDetailResponse response = certificateService.issueCertificate(enrollmentId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.certificateNumber()).isEqualTo("CERT-001-2026-000001");
+            assertThat(response.userName()).isEqualTo("테스트 사용자");
+            assertThat(response.status()).isEqualTo(CertificateStatus.ISSUED);
+
+            verify(certificateRepository).save(any(Certificate.class));
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 발급된 수료증")
+        void issueCertificate_fail_alreadyIssued() {
+            // given
+            Long enrollmentId = 1L;
+
+            given(certificateRepository.existsByEnrollmentIdAndTenantId(enrollmentId, TENANT_ID))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> certificateService.issueCertificate(enrollmentId))
+                    .isInstanceOf(CertificateAlreadyIssuedException.class);
+
+            verify(certificateRepository, never()).save(any());
+        }
+    }
+
+    // ==================== 내 수료증 목록 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("getMyCertificates - 내 수료증 목록 조회")
+    class GetMyCertificates {
+
+        @Test
+        @DisplayName("성공 - 내 수료증 목록 조회")
+        void getMyCertificates_success() {
+            // given
+            Long userId = 1L;
+            Pageable pageable = PageRequest.of(0, 20);
+            List<Certificate> certificates = List.of(
+                    createTestCertificate(userId, "CERT-001-2026-000001"),
+                    createTestCertificate(userId, "CERT-001-2026-000002")
+            );
+            Page<Certificate> page = new PageImpl<>(certificates, pageable, certificates.size());
+
+            given(certificateRepository.findByUserIdAndTenantIdOrderByIssuedAtDesc(userId, TENANT_ID, pageable))
+                    .willReturn(page);
+
+            // when
+            Page<CertificateResponse> response = certificateService.getMyCertificates(userId, pageable);
+
+            // then
+            assertThat(response.getContent()).hasSize(2);
+        }
+    }
+
+    // ==================== 수료증 상세 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("getCertificate - 수료증 상세 조회")
+    class GetCertificate {
+
+        @Test
+        @DisplayName("성공 - 본인 수료증 조회")
+        void getCertificate_success() {
+            // given
+            Long certificateId = 1L;
+            Long userId = 1L;
+            Certificate certificate = createTestCertificate(userId, "CERT-001-2026-000001");
+
+            given(certificateRepository.findByIdAndTenantId(certificateId, TENANT_ID))
+                    .willReturn(Optional.of(certificate));
+
+            // when
+            CertificateDetailResponse response = certificateService.getCertificate(certificateId, userId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.certificateNumber()).isEqualTo("CERT-001-2026-000001");
+        }
+
+        @Test
+        @DisplayName("실패 - 다른 사용자 수료증 조회 시도")
+        void getCertificate_fail_unauthorized() {
+            // given
+            Long certificateId = 1L;
+            Long ownerUserId = 1L;
+            Long otherUserId = 999L;
+            Certificate certificate = createTestCertificate(ownerUserId, "CERT-001-2026-000001");
+
+            given(certificateRepository.findByIdAndTenantId(certificateId, TENANT_ID))
+                    .willReturn(Optional.of(certificate));
+
+            // when & then
+            assertThatThrownBy(() -> certificateService.getCertificate(certificateId, otherUserId))
+                    .isInstanceOf(UnauthorizedEnrollmentAccessException.class);
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 수료증")
+        void getCertificate_fail_notFound() {
+            // given
+            Long certificateId = 999L;
+
+            given(certificateRepository.findByIdAndTenantId(certificateId, TENANT_ID))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> certificateService.getCertificate(certificateId, 1L))
+                    .isInstanceOf(CertificateNotFoundException.class);
+        }
+    }
+
+    // ==================== PDF 다운로드 테스트 ====================
+
+    @Nested
+    @DisplayName("downloadCertificatePdf - PDF 다운로드")
+    class DownloadCertificatePdf {
+
+        @Test
+        @DisplayName("성공 - PDF 다운로드")
+        void downloadCertificatePdf_success() {
+            // given
+            Long certificateId = 1L;
+            Long userId = 1L;
+            Certificate certificate = createTestCertificate(userId, "CERT-001-2026-000001");
+            byte[] pdfBytes = "PDF_CONTENT".getBytes();
+
+            given(certificateRepository.findByIdAndTenantId(certificateId, TENANT_ID))
+                    .willReturn(Optional.of(certificate));
+            given(certificatePdfService.generatePdf(certificate))
+                    .willReturn(pdfBytes);
+
+            // when
+            byte[] result = certificateService.downloadCertificatePdf(certificateId, userId);
+
+            // then
+            assertThat(result).isEqualTo(pdfBytes);
+            verify(certificatePdfService).generatePdf(certificate);
+        }
+    }
+
+    // ==================== 수료증 진위 확인 테스트 ====================
+
+    @Nested
+    @DisplayName("verifyCertificate - 수료증 진위 확인")
+    class VerifyCertificate {
+
+        @Test
+        @DisplayName("성공 - 유효한 수료증 확인")
+        void verifyCertificate_success_valid() {
+            // given
+            String certificateNumber = "CERT-001-2026-000001";
+            Certificate certificate = createTestCertificate(1L, certificateNumber);
+
+            given(certificateRepository.findByCertificateNumber(certificateNumber))
+                    .willReturn(Optional.of(certificate));
+
+            // when
+            CertificateVerifyResponse response = certificateService.verifyCertificate(certificateNumber);
+
+            // then
+            assertThat(response.valid()).isTrue();
+            assertThat(response.certificateNumber()).isEqualTo(certificateNumber);
+            assertThat(response.message()).contains("유효한");
+        }
+
+        @Test
+        @DisplayName("성공 - 폐기된 수료증 확인")
+        void verifyCertificate_success_revoked() {
+            // given
+            String certificateNumber = "CERT-001-2026-000001";
+            Certificate certificate = createTestCertificate(1L, certificateNumber);
+            certificate.revoke("테스트 폐기 사유");
+
+            given(certificateRepository.findByCertificateNumber(certificateNumber))
+                    .willReturn(Optional.of(certificate));
+
+            // when
+            CertificateVerifyResponse response = certificateService.verifyCertificate(certificateNumber);
+
+            // then
+            assertThat(response.valid()).isFalse();
+            assertThat(response.status()).isEqualTo(CertificateStatus.REVOKED);
+            assertThat(response.message()).contains("폐기");
+        }
+
+        @Test
+        @DisplayName("성공 - 존재하지 않는 수료증 번호")
+        void verifyCertificate_success_notFound() {
+            // given
+            String certificateNumber = "CERT-999-2026-999999";
+
+            given(certificateRepository.findByCertificateNumber(certificateNumber))
+                    .willReturn(Optional.empty());
+
+            // when
+            CertificateVerifyResponse response = certificateService.verifyCertificate(certificateNumber);
+
+            // then
+            assertThat(response.valid()).isFalse();
+            assertThat(response.certificateNumber()).isEqualTo(certificateNumber);
+            assertThat(response.message()).contains("존재하지 않는");
+        }
+    }
+
+    // ==================== 수료증 폐기 테스트 ====================
+
+    @Nested
+    @DisplayName("revokeCertificate - 수료증 폐기")
+    class RevokeCertificate {
+
+        @Test
+        @DisplayName("성공 - 수료증 폐기")
+        void revokeCertificate_success() {
+            // given
+            Long certificateId = 1L;
+            String reason = "부정 수료";
+            Certificate certificate = createTestCertificate(1L, "CERT-001-2026-000001");
+
+            given(certificateRepository.findByIdAndTenantId(certificateId, TENANT_ID))
+                    .willReturn(Optional.of(certificate));
+
+            // when
+            certificateService.revokeCertificate(certificateId, reason);
+
+            // then
+            assertThat(certificate.isRevoked()).isTrue();
+            assertThat(certificate.getRevokedReason()).isEqualTo(reason);
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 수료증 폐기 시도")
+        void revokeCertificate_fail_notFound() {
+            // given
+            Long certificateId = 999L;
+
+            given(certificateRepository.findByIdAndTenantId(certificateId, TENANT_ID))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> certificateService.revokeCertificate(certificateId, "테스트"))
+                    .isInstanceOf(CertificateNotFoundException.class);
+        }
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/student/service/EnrollmentServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/student/service/EnrollmentServiceTest.java
@@ -25,6 +25,7 @@ import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
 import com.mzc.lp.domain.ts.entity.CourseTime;
 import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
 import com.mzc.lp.domain.ts.service.CourseTimeService;
+import org.springframework.context.ApplicationEventPublisher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -67,6 +68,9 @@ class EnrollmentServiceTest extends TenantTestSupport {
 
     @Mock
     private InstructorAssignmentRepository instructorAssignmentRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     private static final Long TENANT_ID = 1L;
 


### PR DESCRIPTION
## Summary
- 수료증(Certificate) 도메인 신규 구현
- Enrollment 수료 시 수료증 자동 발급 (이벤트 기반)
- 수료증 PDF 다운로드 및 진위 확인 API 제공

## 주요 변경사항
### 신규 파일
- `Certificate` 엔티티 및 `CertificateStatus` enum
- `CertificateRepository`, `CertificateService`, `CertificateController`
- `CertificatePdfService` (PDFBox 기반 PDF 생성, 테넌트 브랜딩 적용)
- `EnrollmentCompletedEvent` 및 `CertificateEventListener`

### 수정 파일
- `ErrorCode.java` - Certificate 관련 에러 코드 추가
- `EnrollmentServiceImpl.java` - 수료 시 이벤트 발행 추가

## API 엔드포인트
| Method | Endpoint | 설명 |
|--------|----------|------|
| GET | `/api/users/me/certificates` | 내 수료증 목록 |
| GET | `/api/certificates/{id}` | 수료증 상세 |
| GET | `/api/certificates/{id}/download` | PDF 다운로드 |
| GET | `/api/certificates/verify/{number}` | 진위 확인 |
| DELETE | `/api/certificates/{id}` | 폐기 (관리자) |

## Test plan
- [x] 수강 완료 시 수료증 자동 생성 확인
- [x] 내 수료증 목록 API 테스트
- [x] PDF 다운로드 정상 동작 확인
- [x] 수료증 번호로 진위 확인 테스트
- [x] 관리자 폐기 기능 테스트

## 추가 작업 필요
- `src/main/resources/fonts/`에 NotoSansKR 폰트 파일 추가 필요
  - `NotoSansKR-Regular.ttf`
  - `NotoSansKR-Bold.ttf`