### PR TITLE
Feat/266 user detail course roles

### DIFF
--- a/src/main/java/com/mzc/lp/domain/student/dto/response/EnrollmentResponse.java
+++ b/src/main/java/com/mzc/lp/domain/student/dto/response/EnrollmentResponse.java
@@ -9,6 +9,8 @@ import java.time.Instant;
 public record EnrollmentResponse(
         Long id,
         Long userId,
+        String userName,
+        String userEmail,
         Long courseTimeId,
         Instant enrolledAt,
         EnrollmentType type,
@@ -21,6 +23,24 @@ public record EnrollmentResponse(
         return new EnrollmentResponse(
                 enrollment.getId(),
                 enrollment.getUserId(),
+                null,
+                null,
+                enrollment.getCourseTimeId(),
+                enrollment.getEnrolledAt(),
+                enrollment.getType(),
+                enrollment.getStatus(),
+                enrollment.getProgressPercent(),
+                enrollment.getScore(),
+                enrollment.getCompletedAt()
+        );
+    }
+
+    public static EnrollmentResponse from(Enrollment enrollment, String userName, String userEmail) {
+        return new EnrollmentResponse(
+                enrollment.getId(),
+                enrollment.getUserId(),
+                userName,
+                userEmail,
                 enrollment.getCourseTimeId(),
                 enrollment.getEnrolledAt(),
                 enrollment.getType(),

--- a/src/main/java/com/mzc/lp/domain/user/dto/response/UserDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/response/UserDetailResponse.java
@@ -3,6 +3,8 @@ package com.mzc.lp.domain.user.dto.response;
 import com.mzc.lp.domain.user.entity.User;
 
 import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
 
 public record UserDetailResponse(
         Long userId,
@@ -14,7 +16,8 @@ public record UserDetailResponse(
         String status,
         Long tenantId,
         Instant createdAt,
-        Instant updatedAt
+        Instant updatedAt,
+        List<CourseRoleResponse> courseRoles
 ) {
     public static UserDetailResponse from(User user) {
         return new UserDetailResponse(
@@ -27,7 +30,24 @@ public record UserDetailResponse(
                 user.getStatus().name(),
                 user.getTenantId(),
                 user.getCreatedAt(),
-                user.getUpdatedAt()
+                user.getUpdatedAt(),
+                Collections.emptyList()
+        );
+    }
+
+    public static UserDetailResponse from(User user, List<CourseRoleResponse> courseRoles) {
+        return new UserDetailResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getPhone(),
+                user.getProfileImageUrl(),
+                user.getRole().name(),
+                user.getStatus().name(),
+                user.getTenantId(),
+                user.getCreatedAt(),
+                user.getUpdatedAt(),
+                courseRoles != null ? courseRoles : Collections.emptyList()
         );
     }
 }

--- a/src/main/java/com/mzc/lp/domain/user/repository/UserCourseRoleRepository.java
+++ b/src/main/java/com/mzc/lp/domain/user/repository/UserCourseRoleRepository.java
@@ -3,6 +3,8 @@ package com.mzc.lp.domain.user.repository;
 import com.mzc.lp.domain.user.constant.CourseRole;
 import com.mzc.lp.domain.user.entity.UserCourseRole;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,6 +12,15 @@ import java.util.Optional;
 public interface UserCourseRoleRepository extends JpaRepository<UserCourseRole, Long> {
 
     List<UserCourseRole> findByUserId(Long userId);
+
+    /**
+     * 사용자의 CourseRole 목록을 Program title과 함께 조회
+     * courseId는 실제로 Program ID를 저장하므로 Program 테이블과 조인
+     */
+    @Query("SELECT ucr, p.title FROM UserCourseRole ucr " +
+           "LEFT JOIN Program p ON ucr.courseId = p.id " +
+           "WHERE ucr.user.id = :userId")
+    List<Object[]> findByUserIdWithProgramTitle(@Param("userId") Long userId);
 
     Optional<UserCourseRole> findByUserIdAndCourseIdIsNullAndRole(Long userId, CourseRole role);
 

--- a/src/test/java/com/mzc/lp/domain/student/service/EnrollmentServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/student/service/EnrollmentServiceTest.java
@@ -25,6 +25,8 @@ import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
 import com.mzc.lp.domain.ts.entity.CourseTime;
 import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
 import com.mzc.lp.domain.ts.service.CourseTimeService;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.UserRepository;
 import org.springframework.context.ApplicationEventPublisher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -72,7 +74,16 @@ class EnrollmentServiceTest extends TenantTestSupport {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
+    @Mock
+    private UserRepository userRepository;
+
     private static final Long TENANT_ID = 1L;
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+        // userRepository.findAllById() 기본 mock 설정 (빈 리스트 반환)
+        org.mockito.Mockito.lenient().when(userRepository.findAllById(any())).thenReturn(java.util.Collections.emptyList());
+    }
 
     private CourseTime createTestCourseTime(boolean canEnroll) {
         LocalDate enrollStart = LocalDate.now().minusDays(1);


### PR DESCRIPTION
## Summary
- UserDetailResponse에 사용자의 CourseRole 목록 포함
- EnrollmentResponse에 사용자 이름, 이메일 정보 포함

## Related Issue
- Closes #266
- Closes #267

## Changes
### #266 - UserDetailResponse에 courseRoles 필드 추가
- `UserDetailResponse`에 `List<CourseRoleResponse> courseRoles` 필드 추가
- `UserCourseRoleRepository`에 Program title을 조인하는 쿼리 추가
- `UserServiceImpl`의 사용자 조회 메서드들에서 courseRoles 포함하여 반환

### #267 - EnrollmentResponse에 userName, userEmail 필드 추가
- `EnrollmentResponse`에 `userName`, `userEmail` 필드 추가
- `EnrollmentServiceImpl`에 배치 조회 로직 추가 (N+1 방지)
- 테스트 파일에 UserRepository mock 설정 추가

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] 코드 컨벤션 준수
- [x] 기존 테스트 통과 (655 tests passed)
- [x] 빌드 성공

## Test plan
- [x] `./gradlew test` 전체 테스트 통과 확인
- [ ] API 테스트: `GET /api/users/me` courseRoles 포함 확인
- [ ] API 테스트: `GET /api/times/{timeId}/enrollments` userName, userEmail 포함 확인

## Additional Notes
- #266: courseName은 실제로 Program의 title을 의미 (courseId가 Program ID를 저장)
- #267: N+1 문제 방지를 위해 배치 조회 사용 (findAllById)