### PR TITLE
feat(user): TENANT_ADMIN 테넌트 기반 사용자 필터링 및 단체 계정 생성 기능

### DIFF
--- a/src/main/java/com/mzc/lp/common/security/UserPrincipal.java
+++ b/src/main/java/com/mzc/lp/common/security/UserPrincipal.java
@@ -4,12 +4,18 @@ import java.util.Set;
 
 public record UserPrincipal(
         Long id,
+        Long tenantId,
         String email,
         String role,
         Set<String> courseRoles  // DESIGNER, OWNER, INSTRUCTOR
 ) {
-    // 하위 호환성을 위한 생성자
+    // 하위 호환성을 위한 생성자 (tenantId 없이)
     public UserPrincipal(Long id, String email, String role) {
-        this(id, email, role, Set.of());
+        this(id, null, email, role, Set.of());
+    }
+
+    // 하위 호환성을 위한 생성자 (tenantId 없이, courseRoles 있음)
+    public UserPrincipal(Long id, String email, String role, Set<String> courseRoles) {
+        this(id, null, email, role, courseRoles);
     }
 }

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsServiceImpl.java
@@ -32,6 +32,7 @@ public class TenantSettingsServiceImpl implements TenantSettingsService {
     private final NavigationItemRepository navigationItemRepository;
 
     @Override
+    @Transactional
     public TenantSettingsResponse getSettings(Long tenantId) {
         TenantSettings settings = tenantSettingsRepository.findByTenantId(tenantId)
                 .orElseGet(() -> initializeAndGet(tenantId));
@@ -142,6 +143,7 @@ public class TenantSettingsServiceImpl implements TenantSettingsService {
     // ============================================
 
     @Override
+    @Transactional
     public List<NavigationItemResponse> getNavigationItems(Long tenantId) {
         // 네비게이션 항목이 없으면 기본 항목 초기화
         if (!navigationItemRepository.existsByTenantId(tenantId)) {

--- a/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
+++ b/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
@@ -107,13 +107,16 @@ public class UserController {
     @GetMapping
     @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<Page<UserListResponse>>> getUsers(
+            @AuthenticationPrincipal UserPrincipal principal,
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) TenantRole role,
             @RequestParam(required = false) UserStatus status,
             @RequestParam(required = false) Boolean hasCourseRole,
             @PageableDefault(size = 20) Pageable pageable
     ) {
-        Page<UserListResponse> response = userService.getUsers(keyword, role, status, hasCourseRole, pageable);
+        // TENANT_ADMIN은 자신의 테넌트 사용자만 조회 가능
+        Long tenantId = principal.tenantId();
+        Page<UserListResponse> response = userService.getUsers(tenantId, keyword, role, status, hasCourseRole, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
+++ b/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
@@ -5,12 +5,14 @@ import com.mzc.lp.common.security.UserPrincipal;
 import com.mzc.lp.domain.user.constant.TenantRole;
 import com.mzc.lp.domain.user.constant.UserStatus;
 import com.mzc.lp.domain.user.dto.request.AssignCourseRoleRequest;
+import com.mzc.lp.domain.user.dto.request.BulkCreateUsersRequest;
 import com.mzc.lp.domain.user.dto.request.ChangePasswordRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeRoleRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeStatusRequest;
 import com.mzc.lp.domain.user.dto.request.UpdateProfileRequest;
 import com.mzc.lp.domain.user.dto.request.UpdateUserRequest;
 import com.mzc.lp.domain.user.dto.request.WithdrawRequest;
+import com.mzc.lp.domain.user.dto.response.BulkCreateUsersResponse;
 import com.mzc.lp.domain.user.dto.response.CourseRoleResponse;
 import com.mzc.lp.domain.user.dto.response.UserDetailResponse;
 import com.mzc.lp.domain.user.dto.response.UserListResponse;
@@ -188,5 +190,17 @@ public class UserController {
     ) {
         userService.revokeCourseRole(userId, courseRoleId);
         return ResponseEntity.noContent().build();
+    }
+
+    // ========== 단체 계정 생성 API (TENANT_ADMIN 권한) ==========
+
+    @PostMapping("/bulk")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<BulkCreateUsersResponse>> bulkCreateUsers(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody BulkCreateUsersRequest request
+    ) {
+        BulkCreateUsersResponse response = userService.bulkCreateUsers(principal.tenantId(), request);
+        return ResponseEntity.status(201).body(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/BulkCreateUsersRequest.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/BulkCreateUsersRequest.java
@@ -1,0 +1,44 @@
+package com.mzc.lp.domain.user.dto.request;
+
+import com.mzc.lp.domain.user.constant.TenantRole;
+import jakarta.validation.constraints.*;
+
+public record BulkCreateUsersRequest(
+        @NotBlank(message = "이메일 접두사는 필수입니다")
+        @Size(max = 30, message = "이메일 접두사는 30자 이하여야 합니다")
+        @Pattern(regexp = "^[a-zA-Z0-9_-]+$", message = "이메일 접두사는 영문, 숫자, 밑줄, 하이픈만 사용 가능합니다")
+        String emailPrefix,
+
+        @NotBlank(message = "이메일 도메인은 필수입니다")
+        @Pattern(regexp = "^@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "올바른 이메일 도메인 형식이 아닙니다 (예: @company.com)")
+        String emailDomain,
+
+        @NotNull(message = "생성할 계정 수는 필수입니다")
+        @Min(value = 1, message = "최소 1개 이상의 계정을 생성해야 합니다")
+        @Max(value = 100, message = "한 번에 최대 100개까지 생성 가능합니다")
+        Integer count,
+
+        @NotBlank(message = "초기 비밀번호는 필수입니다")
+        @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다")
+        String password,
+
+        @Min(value = 1, message = "시작 번호는 1 이상이어야 합니다")
+        Integer startNumber,
+
+        TenantRole role
+) {
+    public BulkCreateUsersRequest {
+        if (emailPrefix != null) {
+            emailPrefix = emailPrefix.toLowerCase().trim();
+        }
+        if (emailDomain != null) {
+            emailDomain = emailDomain.toLowerCase().trim();
+        }
+        if (startNumber == null) {
+            startNumber = 1;
+        }
+        if (role == null) {
+            role = TenantRole.USER;
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/dto/response/BulkCreateUsersResponse.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/response/BulkCreateUsersResponse.java
@@ -1,0 +1,36 @@
+package com.mzc.lp.domain.user.dto.response;
+
+import java.util.List;
+
+public record BulkCreateUsersResponse(
+        int totalRequested,
+        int successCount,
+        int failedCount,
+        List<CreatedUserInfo> createdUsers,
+        List<FailedUserInfo> failedUsers
+) {
+    public record CreatedUserInfo(
+            Long id,
+            String email,
+            String name
+    ) {}
+
+    public record FailedUserInfo(
+            String email,
+            String reason
+    ) {}
+
+    public static BulkCreateUsersResponse of(
+            int totalRequested,
+            List<CreatedUserInfo> createdUsers,
+            List<FailedUserInfo> failedUsers
+    ) {
+        return new BulkCreateUsersResponse(
+                totalRequested,
+                createdUsers.size(),
+                failedUsers.size(),
+                createdUsers,
+                failedUsers
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/mzc/lp/domain/user/repository/UserRepository.java
@@ -16,6 +16,7 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     Optional<User> findByEmail(String email);
 
     boolean existsByEmail(String email);
+    boolean existsByTenantIdAndEmail(Long tenantId, String email);
 
     // ===== 통계 집계 쿼리 =====
 

--- a/src/main/java/com/mzc/lp/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/mzc/lp/domain/user/repository/UserRepositoryCustom.java
@@ -8,5 +8,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface UserRepositoryCustom {
 
-    Page<User> searchUsers(String keyword, TenantRole role, UserStatus status, Boolean hasCourseRole, Pageable pageable);
+    Page<User> searchUsers(Long tenantId, String keyword, TenantRole role, UserStatus status, Boolean hasCourseRole, Pageable pageable);
 }

--- a/src/main/java/com/mzc/lp/domain/user/service/UserService.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserService.java
@@ -3,12 +3,14 @@ package com.mzc.lp.domain.user.service;
 import com.mzc.lp.domain.user.constant.TenantRole;
 import com.mzc.lp.domain.user.constant.UserStatus;
 import com.mzc.lp.domain.user.dto.request.AssignCourseRoleRequest;
+import com.mzc.lp.domain.user.dto.request.BulkCreateUsersRequest;
 import com.mzc.lp.domain.user.dto.request.ChangePasswordRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeRoleRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeStatusRequest;
 import com.mzc.lp.domain.user.dto.request.UpdateProfileRequest;
 import com.mzc.lp.domain.user.dto.request.UpdateUserRequest;
 import com.mzc.lp.domain.user.dto.request.WithdrawRequest;
+import com.mzc.lp.domain.user.dto.response.BulkCreateUsersResponse;
 import com.mzc.lp.domain.user.dto.response.CourseRoleResponse;
 import com.mzc.lp.domain.user.dto.response.UserDetailResponse;
 import com.mzc.lp.domain.user.dto.response.UserListResponse;
@@ -56,4 +58,7 @@ public interface UserService {
     CourseRoleResponse assignCourseRole(Long userId, AssignCourseRoleRequest request);
 
     void revokeCourseRole(Long userId, Long courseRoleId);
+
+    // 단체 계정 생성 API (TENANT_ADMIN 권한)
+    BulkCreateUsersResponse bulkCreateUsers(Long tenantId, BulkCreateUsersRequest request);
 }

--- a/src/main/java/com/mzc/lp/domain/user/service/UserService.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserService.java
@@ -34,8 +34,8 @@ public interface UserService {
 
     ProfileImageResponse uploadProfileImage(Long userId, MultipartFile file);
 
-    // 관리 API (OPERATOR 권한)
-    Page<UserListResponse> getUsers(String keyword, TenantRole role, UserStatus status, Boolean hasCourseRole, Pageable pageable);
+    // 관리 API (OPERATOR 권한) - tenantId로 필터링
+    Page<UserListResponse> getUsers(Long tenantId, String keyword, TenantRole role, UserStatus status, Boolean hasCourseRole, Pageable pageable);
 
     UserDetailResponse getUser(Long userId);
 

--- a/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
@@ -3,13 +3,16 @@ package com.mzc.lp.domain.user.service;
 import com.mzc.lp.domain.user.constant.TenantRole;
 import com.mzc.lp.domain.user.constant.UserStatus;
 import com.mzc.lp.domain.user.constant.CourseRole;
+import com.mzc.lp.common.context.TenantContext;
 import com.mzc.lp.domain.user.dto.request.AssignCourseRoleRequest;
+import com.mzc.lp.domain.user.dto.request.BulkCreateUsersRequest;
 import com.mzc.lp.domain.user.dto.request.ChangePasswordRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeRoleRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeStatusRequest;
 import com.mzc.lp.domain.user.dto.request.UpdateProfileRequest;
 import com.mzc.lp.domain.user.dto.request.UpdateUserRequest;
 import com.mzc.lp.domain.user.dto.request.WithdrawRequest;
+import com.mzc.lp.domain.user.dto.response.BulkCreateUsersResponse;
 import com.mzc.lp.domain.user.dto.response.CourseRoleResponse;
 import com.mzc.lp.domain.user.dto.response.UserDetailResponse;
 import com.mzc.lp.domain.user.dto.response.UserListResponse;
@@ -27,6 +30,7 @@ import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
 import com.mzc.lp.domain.user.repository.UserRepository;
 import com.mzc.lp.common.service.FileStorageService;
 
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -284,5 +288,54 @@ public class UserServiceImpl implements UserService {
 
         userCourseRoleRepository.delete(courseRole);
         log.info("Course role revoked: userId={}, courseRoleId={}", userId, courseRoleId);
+    }
+
+    // ========== 단체 계정 생성 API (TENANT_ADMIN 권한) ==========
+
+    @Override
+    @Transactional
+    public BulkCreateUsersResponse bulkCreateUsers(Long tenantId, BulkCreateUsersRequest request) {
+        log.info("Bulk creating users: tenantId={}, prefix={}, count={}", tenantId, request.emailPrefix(), request.count());
+
+        List<BulkCreateUsersResponse.CreatedUserInfo> createdUsers = new ArrayList<>();
+        List<BulkCreateUsersResponse.FailedUserInfo> failedUsers = new ArrayList<>();
+
+        String encodedPassword = passwordEncoder.encode(request.password());
+
+        // TenantContext 설정 (User 엔티티 저장 시 tenantId 자동 설정)
+        TenantContext.setTenantId(tenantId);
+
+        try {
+            for (int i = 0; i < request.count(); i++) {
+                int number = request.startNumber() + i;
+                String email = request.emailPrefix() + number + request.emailDomain();
+                String name = request.emailPrefix() + number;
+
+                try {
+                    // 이메일 중복 체크
+                    if (userRepository.existsByTenantIdAndEmail(tenantId, email)) {
+                        failedUsers.add(new BulkCreateUsersResponse.FailedUserInfo(email, "이미 존재하는 이메일입니다"));
+                        continue;
+                    }
+
+                    User user = User.create(email, name, encodedPassword);
+                    User savedUser = userRepository.save(user);
+
+                    createdUsers.add(new BulkCreateUsersResponse.CreatedUserInfo(
+                            savedUser.getId(),
+                            savedUser.getEmail(),
+                            savedUser.getName()
+                    ));
+                } catch (Exception e) {
+                    log.warn("Failed to create user: email={}, error={}", email, e.getMessage());
+                    failedUsers.add(new BulkCreateUsersResponse.FailedUserInfo(email, e.getMessage()));
+                }
+            }
+        } finally {
+            TenantContext.clear();
+        }
+
+        log.info("Bulk user creation completed: created={}, failed={}", createdUsers.size(), failedUsers.size());
+        return BulkCreateUsersResponse.of(request.count(), createdUsers, failedUsers);
     }
 }

--- a/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
@@ -119,9 +119,9 @@ public class UserServiceImpl implements UserService {
     // ========== 관리 API (OPERATOR 권한) ==========
 
     @Override
-    public Page<UserListResponse> getUsers(String keyword, TenantRole role, UserStatus status, Boolean hasCourseRole, Pageable pageable) {
-        log.debug("Searching users: keyword={}, role={}, status={}, hasCourseRole={}", keyword, role, status, hasCourseRole);
-        return userRepository.searchUsers(keyword, role, status, hasCourseRole, pageable)
+    public Page<UserListResponse> getUsers(Long tenantId, String keyword, TenantRole role, UserStatus status, Boolean hasCourseRole, Pageable pageable) {
+        log.debug("Searching users: tenantId={}, keyword={}, role={}, status={}, hasCourseRole={}", tenantId, keyword, role, status, hasCourseRole);
+        return userRepository.searchUsers(tenantId, keyword, role, status, hasCourseRole, pageable)
                 .map(UserListResponse::from);
     }
 


### PR DESCRIPTION
## Summary

TENANT_ADMIN이 자신의 테넌트에 속한 사용자만 조회할 수 있도록 필터링 기능을 추가하고, 단체 계정 생성 API를 구현했습니다.

## Related Issue

- Closes #276

## Changes

- UserPrincipal에 tenantId 필드 추가
- JWT 토큰에 tenantId 포함하도록 JwtTokenProvider 수정
- UserController의 getUsers API에서 테넌트 기반 필터링 적용
- POST /api/users/bulk 단체 계정 생성 API 추가
- BulkCreateUsersRequest, BulkCreateUsersResponse DTO 추가
- UserRepository에 existsByTenantIdAndEmail 메서드 추가
- TenantContext를 활용한 테넌트별 사용자 생성 구현

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 단체 계정 생성 시 이메일 패턴: `{prefix}{number}{domain}` (예: sam_user1@company.com)
- 최대 100개 계정까지 일괄 생성 가능
- 중복 이메일은 자동으로 스킵되고 실패 목록에 포함됨
