### PR TITLE
feat(course): CourseResponse에 isComplete 필드 추가

### DIFF
--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseDetailResponse.java
@@ -21,11 +21,31 @@ public record CourseDetailResponse(
         LocalDate endDate,
         List<String> tags,
         List<CourseItemResponse> items,
-        long itemCount,
+        int itemCount,
+        boolean isComplete,
         Instant createdAt,
         Instant updatedAt
 ) {
+    /**
+     * 완성도 판단 기준:
+     * - title (필수, DB에서 NOT NULL)
+     * - description (필수)
+     * - categoryId (필수)
+     * - 커리큘럼(items) 1개 이상
+     */
+    private static boolean checkCompleteness(Course course, int itemCount) {
+        return course.getTitle() != null && !course.getTitle().isBlank()
+                && course.getDescription() != null && !course.getDescription().isBlank()
+                && course.getCategoryId() != null
+                && itemCount > 0;
+    }
+
     public static CourseDetailResponse from(Course course, List<CourseItemResponse> items) {
+        int count = items != null ? items.size() : 0;
+        return from(course, items, count);
+    }
+
+    public static CourseDetailResponse from(Course course, List<CourseItemResponse> items, int itemCount) {
         return new CourseDetailResponse(
                 course.getId(),
                 course.getTitle(),
@@ -39,7 +59,8 @@ public record CourseDetailResponse(
                 course.getEndDate(),
                 course.getTags(),
                 items,
-                items != null ? items.size() : 0,
+                itemCount,
+                checkCompleteness(course, itemCount),
                 course.getCreatedAt(),
                 course.getUpdatedAt()
         );

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseResponse.java
@@ -21,9 +21,29 @@ public record CourseResponse(
         LocalDate endDate,
         List<String> tags,
         Instant createdAt,
-        Instant updatedAt
+        Instant updatedAt,
+        boolean isComplete,
+        int itemCount
 ) {
+    /**
+     * 완성도 판단 기준:
+     * - title (필수, DB에서 NOT NULL)
+     * - description (필수)
+     * - categoryId (필수)
+     * - 커리큘럼(items) 1개 이상
+     */
+    private static boolean checkCompleteness(Course course, int itemCount) {
+        return course.getTitle() != null && !course.getTitle().isBlank()
+                && course.getDescription() != null && !course.getDescription().isBlank()
+                && course.getCategoryId() != null
+                && itemCount > 0;
+    }
+
     public static CourseResponse from(Course course) {
+        return from(course, 0);
+    }
+
+    public static CourseResponse from(Course course, int itemCount) {
         return new CourseResponse(
                 course.getId(),
                 course.getTitle(),
@@ -37,7 +57,9 @@ public record CourseResponse(
                 course.getEndDate(),
                 course.getTags(),
                 course.getCreatedAt(),
-                course.getUpdatedAt()
+                course.getUpdatedAt(),
+                checkCompleteness(course, itemCount),
+                itemCount
         );
     }
 }

--- a/src/main/java/com/mzc/lp/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/mzc/lp/domain/course/repository/CourseRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
@@ -27,4 +28,7 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     boolean existsByIdAndTenantId(Long id, Long tenantId);
 
     Page<Course> findByTenantIdAndCreatedBy(Long tenantId, Long createdBy, Pageable pageable);
+
+    @Query("SELECT c.id, COUNT(i) FROM Course c LEFT JOIN c.items i WHERE c.id IN :courseIds GROUP BY c.id")
+    List<Object[]> countItemsByCourseIds(@Param("courseIds") List<Long> courseIds);
 }


### PR DESCRIPTION
## Summary
- CourseResponse, CourseDetailResponse에 `isComplete`, `itemCount` 필드 추가
- 완성도 판단 로직 구현 (title, description, categoryId, items 1개 이상)
- N+1 방지를 위한 itemCount 일괄 조회 쿼리 추가

## 완성도 판단 기준
| 필드 | 조건 |
|------|------|
| title | 필수 (NOT NULL) |
| description | 필수 |
| categoryId | 필수 |
| items | 1개 이상 |

## 변경 파일
- `CourseResponse.java` - isComplete, itemCount 필드 추가
- `CourseDetailResponse.java` - isComplete 필드 추가
- `CourseRepository.java` - countItemsByCourseIds 쿼리 추가
- `CourseServiceImpl.java` - getMyCourses에서 itemCount 조회
- `CourseControllerTest.java` - isComplete 관련 테스트 추가

## Test plan
- [x] 기존 테스트 통과 확인
- [x] isComplete=true 케이스 테스트
- [x] isComplete=false 케이스 테스트 (description 없음)
- [x] getMyCourses API에서 isComplete 필드 확인

## 관련 이슈
- Closes #279
- 프론트엔드 연동: mzcATU/mzc-lp-frontend#253