### PR TITLE
feat(department): 부서 관리 API 구현 (#284)

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -137,7 +137,13 @@ public enum ErrorCode {
     // Certificate (CERT)
     CERTIFICATE_NOT_FOUND(HttpStatus.NOT_FOUND, "CERT001", "Certificate not found"),
     CERTIFICATE_ALREADY_ISSUED(HttpStatus.CONFLICT, "CERT002", "Certificate already issued for this enrollment"),
-    CERTIFICATE_REVOKED(HttpStatus.BAD_REQUEST, "CERT003", "Certificate has been revoked");
+    CERTIFICATE_REVOKED(HttpStatus.BAD_REQUEST, "CERT003", "Certificate has been revoked"),
+
+    // Department (DEPT)
+    DEPARTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "DEPT001", "Department not found"),
+    DEPARTMENT_CODE_DUPLICATE(HttpStatus.CONFLICT, "DEPT002", "Department code already exists"),
+    DEPARTMENT_HAS_CHILDREN(HttpStatus.BAD_REQUEST, "DEPT003", "Cannot delete department with sub-departments"),
+    DEPARTMENT_HAS_MEMBERS(HttpStatus.BAD_REQUEST, "DEPT004", "Cannot delete department with members");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/mzc/lp/domain/department/controller/DepartmentController.java
+++ b/src/main/java/com/mzc/lp/domain/department/controller/DepartmentController.java
@@ -1,0 +1,104 @@
+package com.mzc.lp.domain.department.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.department.dto.request.CreateDepartmentRequest;
+import com.mzc.lp.domain.department.dto.request.UpdateDepartmentRequest;
+import com.mzc.lp.domain.department.dto.response.DepartmentResponse;
+import com.mzc.lp.domain.department.service.DepartmentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/departments")
+@RequiredArgsConstructor
+@Validated
+public class DepartmentController {
+
+    private final DepartmentService departmentService;
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<DepartmentResponse>>> getAll(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<DepartmentResponse> response = departmentService.getAll(principal.tenantId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/tree")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<DepartmentResponse>>> getTree(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<DepartmentResponse> response = departmentService.getRootDepartments(principal.tenantId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/active")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<DepartmentResponse>>> getActiveDepartments(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<DepartmentResponse> response = departmentService.getActiveDepartments(principal.tenantId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/search")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<DepartmentResponse>>> search(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam String keyword
+    ) {
+        List<DepartmentResponse> response = departmentService.search(principal.tenantId(), keyword);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{departmentId}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<DepartmentResponse>> getById(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long departmentId
+    ) {
+        DepartmentResponse response = departmentService.getById(principal.tenantId(), departmentId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<DepartmentResponse>> create(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody CreateDepartmentRequest request
+    ) {
+        DepartmentResponse response = departmentService.create(principal.tenantId(), request);
+        return ResponseEntity.status(201).body(ApiResponse.success(response));
+    }
+
+    @PutMapping("/{departmentId}")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<DepartmentResponse>> update(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long departmentId,
+            @Valid @RequestBody UpdateDepartmentRequest request
+    ) {
+        DepartmentResponse response = departmentService.update(principal.tenantId(), departmentId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/{departmentId}")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long departmentId
+    ) {
+        departmentService.delete(principal.tenantId(), departmentId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/department/dto/request/CreateDepartmentRequest.java
+++ b/src/main/java/com/mzc/lp/domain/department/dto/request/CreateDepartmentRequest.java
@@ -1,0 +1,31 @@
+package com.mzc.lp.domain.department.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record CreateDepartmentRequest(
+        @NotBlank(message = "부서명은 필수입니다")
+        @Size(max = 100, message = "부서명은 100자 이하여야 합니다")
+        String name,
+
+        @NotBlank(message = "부서 코드는 필수입니다")
+        @Size(max = 50, message = "부서 코드는 50자 이하여야 합니다")
+        @Pattern(regexp = "^[A-Za-z0-9_-]+$", message = "부서 코드는 영문, 숫자, 밑줄, 하이픈만 사용 가능합니다")
+        String code,
+
+        @Size(max = 500, message = "설명은 500자 이하여야 합니다")
+        String description,
+
+        Long parentId,
+
+        Long managerId,
+
+        Integer sortOrder
+) {
+    public CreateDepartmentRequest {
+        if (sortOrder == null) {
+            sortOrder = 0;
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/department/dto/request/UpdateDepartmentRequest.java
+++ b/src/main/java/com/mzc/lp/domain/department/dto/request/UpdateDepartmentRequest.java
@@ -1,0 +1,22 @@
+package com.mzc.lp.domain.department.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UpdateDepartmentRequest(
+        @Size(max = 100, message = "부서명은 100자 이하여야 합니다")
+        String name,
+
+        @Size(max = 50, message = "부서 코드는 50자 이하여야 합니다")
+        @Pattern(regexp = "^[A-Za-z0-9_-]+$", message = "부서 코드는 영문, 숫자, 밑줄, 하이픈만 사용 가능합니다")
+        String code,
+
+        @Size(max = 500, message = "설명은 500자 이하여야 합니다")
+        String description,
+
+        Long parentId,
+
+        Long managerId,
+
+        Integer sortOrder
+) {}

--- a/src/main/java/com/mzc/lp/domain/department/dto/response/DepartmentResponse.java
+++ b/src/main/java/com/mzc/lp/domain/department/dto/response/DepartmentResponse.java
@@ -1,0 +1,71 @@
+package com.mzc.lp.domain.department.dto.response;
+
+import com.mzc.lp.domain.department.entity.Department;
+
+import java.time.Instant;
+import java.util.List;
+
+public record DepartmentResponse(
+        Long id,
+        String name,
+        String code,
+        String description,
+        Long parentId,
+        String parentName,
+        Long managerId,
+        String managerName,
+        Integer sortOrder,
+        Boolean isActive,
+        Integer memberCount,
+        List<DepartmentResponse> children,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    // Entity -> Response (단일)
+    public static DepartmentResponse from(Department department) {
+        return from(department, null, 0);
+    }
+
+    public static DepartmentResponse from(Department department, String managerName, int memberCount) {
+        return new DepartmentResponse(
+                department.getId(),
+                department.getName(),
+                department.getCode(),
+                department.getDescription(),
+                department.getParent() != null ? department.getParent().getId() : null,
+                department.getParent() != null ? department.getParent().getName() : null,
+                department.getManagerId(),
+                managerName,
+                department.getSortOrder(),
+                department.getIsActive(),
+                memberCount,
+                List.of(),
+                department.getCreatedAt(),
+                department.getUpdatedAt()
+        );
+    }
+
+    // Entity -> Response (계층 구조 포함)
+    public static DepartmentResponse fromWithChildren(Department department, String managerName, int memberCount) {
+        List<DepartmentResponse> childResponses = department.getChildren().stream()
+                .map(child -> fromWithChildren(child, null, 0))
+                .toList();
+
+        return new DepartmentResponse(
+                department.getId(),
+                department.getName(),
+                department.getCode(),
+                department.getDescription(),
+                department.getParent() != null ? department.getParent().getId() : null,
+                department.getParent() != null ? department.getParent().getName() : null,
+                department.getManagerId(),
+                managerName,
+                department.getSortOrder(),
+                department.getIsActive(),
+                memberCount,
+                childResponses,
+                department.getCreatedAt(),
+                department.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/department/entity/Department.java
+++ b/src/main/java/com/mzc/lp/domain/department/entity/Department.java
@@ -1,0 +1,112 @@
+package com.mzc.lp.domain.department.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 부서 엔티티
+ * 테넌트 내 조직 구조를 관리
+ */
+@Entity
+@Table(name = "departments", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"tenant_id", "code"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Department extends TenantEntity {
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false, length = 50)
+    private String code;
+
+    @Column(length = 500)
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Department parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+    private List<Department> children = new ArrayList<>();
+
+    @Column(name = "manager_id")
+    private Long managerId;
+
+    @Column(name = "sort_order")
+    private Integer sortOrder = 0;
+
+    @Column(nullable = false)
+    private Boolean isActive = true;
+
+    // 정적 팩토리 메서드
+    public static Department create(String name, String code, String description) {
+        Department department = new Department();
+        department.name = name;
+        department.code = code.toUpperCase();
+        department.description = description;
+        return department;
+    }
+
+    // 비즈니스 메서드
+    public void update(String name, String code, String description) {
+        if (name != null && !name.isBlank()) {
+            this.name = name;
+        }
+        if (code != null && !code.isBlank()) {
+            this.code = code.toUpperCase();
+        }
+        this.description = description;
+    }
+
+    public void setParent(Department parent) {
+        this.parent = parent;
+        if (parent != null && !parent.getChildren().contains(this)) {
+            parent.getChildren().add(this);
+        }
+    }
+
+    public void removeParent() {
+        if (this.parent != null) {
+            this.parent.getChildren().remove(this);
+            this.parent = null;
+        }
+    }
+
+    public void setManager(Long managerId) {
+        this.managerId = managerId;
+    }
+
+    public void setSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    public void activate() {
+        this.isActive = true;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    public boolean isRoot() {
+        return this.parent == null;
+    }
+
+    public int getDepth() {
+        int depth = 0;
+        Department current = this.parent;
+        while (current != null) {
+            depth++;
+            current = current.getParent();
+        }
+        return depth;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/department/exception/DepartmentCodeDuplicateException.java
+++ b/src/main/java/com/mzc/lp/domain/department/exception/DepartmentCodeDuplicateException.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.department.exception;
+
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.common.constant.ErrorCode;
+
+public class DepartmentCodeDuplicateException extends BusinessException {
+
+    public DepartmentCodeDuplicateException(String code) {
+        super(ErrorCode.DEPARTMENT_CODE_DUPLICATE, "이미 존재하는 부서 코드입니다: " + code);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/department/exception/DepartmentNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/department/exception/DepartmentNotFoundException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.department.exception;
+
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.common.constant.ErrorCode;
+
+public class DepartmentNotFoundException extends BusinessException {
+
+    public DepartmentNotFoundException() {
+        super(ErrorCode.DEPARTMENT_NOT_FOUND);
+    }
+
+    public DepartmentNotFoundException(Long departmentId) {
+        super(ErrorCode.DEPARTMENT_NOT_FOUND, "부서를 찾을 수 없습니다. ID: " + departmentId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/department/repository/DepartmentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/department/repository/DepartmentRepository.java
@@ -1,0 +1,48 @@
+package com.mzc.lp.domain.department.repository;
+
+import com.mzc.lp.domain.department.entity.Department;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DepartmentRepository extends JpaRepository<Department, Long> {
+
+    // 테넌트별 부서 목록 조회
+    List<Department> findByTenantIdOrderBySortOrderAsc(Long tenantId);
+
+    // 테넌트별 최상위 부서 목록 조회
+    List<Department> findByTenantIdAndParentIsNullOrderBySortOrderAsc(Long tenantId);
+
+    // 테넌트별 활성 부서 목록 조회
+    List<Department> findByTenantIdAndIsActiveTrueOrderBySortOrderAsc(Long tenantId);
+
+    // 테넌트별 부서 코드로 조회
+    Optional<Department> findByTenantIdAndCode(Long tenantId, String code);
+
+    // 테넌트별 부서 ID로 조회
+    Optional<Department> findByIdAndTenantId(Long id, Long tenantId);
+
+    // 부서 코드 중복 체크
+    boolean existsByTenantIdAndCode(Long tenantId, String code);
+
+    // 부서 코드 중복 체크 (자기 자신 제외)
+    boolean existsByTenantIdAndCodeAndIdNot(Long tenantId, String code, Long id);
+
+    // 하위 부서 조회
+    List<Department> findByParentIdOrderBySortOrderAsc(Long parentId);
+
+    // 하위 부서 존재 여부 확인
+    boolean existsByParentId(Long parentId);
+
+    // 부서 검색 (이름 또는 코드)
+    @Query("SELECT d FROM Department d WHERE d.tenantId = :tenantId " +
+           "AND (LOWER(d.name) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+           "OR LOWER(d.code) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+    List<Department> searchByKeyword(@Param("tenantId") Long tenantId, @Param("keyword") String keyword);
+
+    // 매니저별 부서 조회
+    List<Department> findByTenantIdAndManagerId(Long tenantId, Long managerId);
+}

--- a/src/main/java/com/mzc/lp/domain/department/service/DepartmentService.java
+++ b/src/main/java/com/mzc/lp/domain/department/service/DepartmentService.java
@@ -1,0 +1,50 @@
+package com.mzc.lp.domain.department.service;
+
+import com.mzc.lp.domain.department.dto.request.CreateDepartmentRequest;
+import com.mzc.lp.domain.department.dto.request.UpdateDepartmentRequest;
+import com.mzc.lp.domain.department.dto.response.DepartmentResponse;
+
+import java.util.List;
+
+public interface DepartmentService {
+
+    /**
+     * 부서 생성
+     */
+    DepartmentResponse create(Long tenantId, CreateDepartmentRequest request);
+
+    /**
+     * 부서 수정
+     */
+    DepartmentResponse update(Long tenantId, Long departmentId, UpdateDepartmentRequest request);
+
+    /**
+     * 부서 삭제
+     */
+    void delete(Long tenantId, Long departmentId);
+
+    /**
+     * 부서 상세 조회
+     */
+    DepartmentResponse getById(Long tenantId, Long departmentId);
+
+    /**
+     * 전체 부서 목록 조회 (계층 구조)
+     */
+    List<DepartmentResponse> getAll(Long tenantId);
+
+    /**
+     * 최상위 부서 목록 조회 (하위 포함)
+     */
+    List<DepartmentResponse> getRootDepartments(Long tenantId);
+
+    /**
+     * 부서 검색
+     */
+    List<DepartmentResponse> search(Long tenantId, String keyword);
+
+    /**
+     * 활성 부서 목록 조회
+     */
+    List<DepartmentResponse> getActiveDepartments(Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/department/service/DepartmentServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/department/service/DepartmentServiceImpl.java
@@ -1,0 +1,187 @@
+package com.mzc.lp.domain.department.service;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.domain.department.dto.request.CreateDepartmentRequest;
+import com.mzc.lp.domain.department.dto.request.UpdateDepartmentRequest;
+import com.mzc.lp.domain.department.dto.response.DepartmentResponse;
+import com.mzc.lp.domain.department.entity.Department;
+import com.mzc.lp.domain.department.exception.DepartmentCodeDuplicateException;
+import com.mzc.lp.domain.department.exception.DepartmentNotFoundException;
+import com.mzc.lp.domain.department.repository.DepartmentRepository;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DepartmentServiceImpl implements DepartmentService {
+
+    private final DepartmentRepository departmentRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public DepartmentResponse create(Long tenantId, CreateDepartmentRequest request) {
+        log.info("Creating department: tenantId={}, name={}, code={}", tenantId, request.name(), request.code());
+
+        // 코드 중복 체크
+        if (departmentRepository.existsByTenantIdAndCode(tenantId, request.code().toUpperCase())) {
+            throw new DepartmentCodeDuplicateException(request.code());
+        }
+
+        // TenantContext 설정
+        TenantContext.setTenantId(tenantId);
+
+        try {
+            Department department = Department.create(
+                    request.name(),
+                    request.code(),
+                    request.description()
+            );
+
+            // 상위 부서 설정
+            if (request.parentId() != null) {
+                Department parent = departmentRepository.findByIdAndTenantId(request.parentId(), tenantId)
+                        .orElseThrow(() -> new DepartmentNotFoundException(request.parentId()));
+                department.setParent(parent);
+            }
+
+            // 매니저 설정
+            if (request.managerId() != null) {
+                department.setManager(request.managerId());
+            }
+
+            // 정렬 순서 설정
+            if (request.sortOrder() != null) {
+                department.setSortOrder(request.sortOrder());
+            }
+
+            Department saved = departmentRepository.save(department);
+
+            String managerName = getManagerName(saved.getManagerId());
+            return DepartmentResponse.from(saved, managerName, 0);
+        } finally {
+            TenantContext.clear();
+        }
+    }
+
+    @Override
+    @Transactional
+    public DepartmentResponse update(Long tenantId, Long departmentId, UpdateDepartmentRequest request) {
+        log.info("Updating department: tenantId={}, departmentId={}", tenantId, departmentId);
+
+        Department department = departmentRepository.findByIdAndTenantId(departmentId, tenantId)
+                .orElseThrow(() -> new DepartmentNotFoundException(departmentId));
+
+        // 코드 중복 체크 (자기 자신 제외)
+        if (request.code() != null && !request.code().isBlank()) {
+            if (departmentRepository.existsByTenantIdAndCodeAndIdNot(tenantId, request.code().toUpperCase(), departmentId)) {
+                throw new DepartmentCodeDuplicateException(request.code());
+            }
+        }
+
+        // 기본 정보 업데이트
+        department.update(request.name(), request.code(), request.description());
+
+        // 상위 부서 변경
+        if (request.parentId() != null) {
+            // 자기 자신을 상위로 설정할 수 없음
+            if (request.parentId().equals(departmentId)) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "자기 자신을 상위 부서로 설정할 수 없습니다");
+            }
+            Department parent = departmentRepository.findByIdAndTenantId(request.parentId(), tenantId)
+                    .orElseThrow(() -> new DepartmentNotFoundException(request.parentId()));
+            department.setParent(parent);
+        }
+
+        // 매니저 변경
+        if (request.managerId() != null) {
+            department.setManager(request.managerId());
+        }
+
+        // 정렬 순서 변경
+        if (request.sortOrder() != null) {
+            department.setSortOrder(request.sortOrder());
+        }
+
+        String managerName = getManagerName(department.getManagerId());
+        return DepartmentResponse.from(department, managerName, 0);
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long tenantId, Long departmentId) {
+        log.info("Deleting department: tenantId={}, departmentId={}", tenantId, departmentId);
+
+        Department department = departmentRepository.findByIdAndTenantId(departmentId, tenantId)
+                .orElseThrow(() -> new DepartmentNotFoundException(departmentId));
+
+        // 하위 부서 존재 여부 확인
+        if (departmentRepository.existsByParentId(departmentId)) {
+            throw new BusinessException(ErrorCode.DEPARTMENT_HAS_CHILDREN, "하위 부서가 존재하여 삭제할 수 없습니다");
+        }
+
+        // TODO: 소속 멤버 존재 여부 확인 (Employee 도메인 구현 후 추가)
+
+        departmentRepository.delete(department);
+    }
+
+    @Override
+    public DepartmentResponse getById(Long tenantId, Long departmentId) {
+        Department department = departmentRepository.findByIdAndTenantId(departmentId, tenantId)
+                .orElseThrow(() -> new DepartmentNotFoundException(departmentId));
+
+        String managerName = getManagerName(department.getManagerId());
+        return DepartmentResponse.fromWithChildren(department, managerName, 0);
+    }
+
+    @Override
+    public List<DepartmentResponse> getAll(Long tenantId) {
+        List<Department> departments = departmentRepository.findByTenantIdOrderBySortOrderAsc(tenantId);
+        return departments.stream()
+                .map(d -> DepartmentResponse.from(d, getManagerName(d.getManagerId()), 0))
+                .toList();
+    }
+
+    @Override
+    public List<DepartmentResponse> getRootDepartments(Long tenantId) {
+        List<Department> rootDepartments = departmentRepository.findByTenantIdAndParentIsNullOrderBySortOrderAsc(tenantId);
+        return rootDepartments.stream()
+                .map(d -> DepartmentResponse.fromWithChildren(d, getManagerName(d.getManagerId()), 0))
+                .toList();
+    }
+
+    @Override
+    public List<DepartmentResponse> search(Long tenantId, String keyword) {
+        List<Department> departments = departmentRepository.searchByKeyword(tenantId, keyword);
+        return departments.stream()
+                .map(d -> DepartmentResponse.from(d, getManagerName(d.getManagerId()), 0))
+                .toList();
+    }
+
+    @Override
+    public List<DepartmentResponse> getActiveDepartments(Long tenantId) {
+        List<Department> departments = departmentRepository.findByTenantIdAndIsActiveTrueOrderBySortOrderAsc(tenantId);
+        return departments.stream()
+                .map(d -> DepartmentResponse.from(d, getManagerName(d.getManagerId()), 0))
+                .toList();
+    }
+
+    private String getManagerName(Long managerId) {
+        if (managerId == null) {
+            return null;
+        }
+        return userRepository.findById(managerId)
+                .map(User::getName)
+                .orElse(null);
+    }
+}


### PR DESCRIPTION
## Summary

테넌트 관리자(TA)용 부서 관리 API를 구현합니다. 부서의 CRUD, 계층 구조(트리) 조회, 검색 기능을 제공합니다.

## Related Issue

- Closes #284

## Changes

- Department 엔티티 생성 (계층 구조 지원 - parent/children 관계)
- DepartmentRepository 생성 (테넌트 기반 쿼리)
- CreateDepartmentRequest, UpdateDepartmentRequest DTO 생성
- DepartmentResponse DTO 생성 (트리 구조 변환 지원)
- DepartmentService 인터페이스 및 구현체 생성
- DepartmentController REST API 구현
- 부서 관련 예외 클래스 추가 (DepartmentNotFoundException, DepartmentCodeDuplicateException)
- ErrorCode에 부서 관련 에러 코드 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### API 엔드포인트

| Method | Endpoint | 설명 | 권한 |
|--------|----------|------|------|
| GET | /api/departments | 전체 목록 조회 | OPERATOR, TENANT_ADMIN |
| GET | /api/departments/tree | 트리 구조 조회 | OPERATOR, TENANT_ADMIN |
| GET | /api/departments/active | 활성 부서 조회 | OPERATOR, TENANT_ADMIN |
| GET | /api/departments/search | 검색 | OPERATOR, TENANT_ADMIN |
| GET | /api/departments/{id} | 상세 조회 | OPERATOR, TENANT_ADMIN |
| POST | /api/departments | 생성 | TENANT_ADMIN |
| PUT | /api/departments/{id} | 수정 | TENANT_ADMIN |
| DELETE | /api/departments/{id} | 삭제 | TENANT_ADMIN |