### PR TITLE
feat(banner): 배너 관리 API 구현 (#286)

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -148,7 +148,10 @@ public enum ErrorCode {
     // Employee (EMP)
     EMPLOYEE_NOT_FOUND(HttpStatus.NOT_FOUND, "EMP001", "Employee not found"),
     EMPLOYEE_NUMBER_DUPLICATE(HttpStatus.CONFLICT, "EMP002", "Employee number already exists"),
-    EMPLOYEE_USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "EMP003", "User is already registered as employee");
+    EMPLOYEE_USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "EMP003", "User is already registered as employee"),
+
+    // Banner (BNR)
+    BANNER_NOT_FOUND(HttpStatus.NOT_FOUND, "BNR001", "Banner not found");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/mzc/lp/domain/banner/constant/BannerPosition.java
+++ b/src/main/java/com/mzc/lp/domain/banner/constant/BannerPosition.java
@@ -1,0 +1,9 @@
+package com.mzc.lp.domain.banner.constant;
+
+public enum BannerPosition {
+    MAIN_TOP,           // 메인 페이지 상단
+    MAIN_MIDDLE,        // 메인 페이지 중간
+    COURSE_LIST,        // 과정 목록 페이지
+    LEARNING_HOME,      // 학습 홈
+    LOGIN               // 로그인 페이지
+}

--- a/src/main/java/com/mzc/lp/domain/banner/controller/BannerController.java
+++ b/src/main/java/com/mzc/lp/domain/banner/controller/BannerController.java
@@ -1,0 +1,138 @@
+package com.mzc.lp.domain.banner.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.banner.constant.BannerPosition;
+import com.mzc.lp.domain.banner.dto.request.CreateBannerRequest;
+import com.mzc.lp.domain.banner.dto.request.UpdateBannerRequest;
+import com.mzc.lp.domain.banner.dto.response.BannerResponse;
+import com.mzc.lp.domain.banner.service.BannerService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/banners")
+@RequiredArgsConstructor
+@Validated
+public class BannerController {
+
+    private final BannerService bannerService;
+
+    // ========== 관리자 API (TENANT_ADMIN 권한) ==========
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<BannerResponse>>> getAll(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<BannerResponse> response = bannerService.getAll(principal.tenantId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/position/{position}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<BannerResponse>>> getByPosition(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable BannerPosition position
+    ) {
+        List<BannerResponse> response = bannerService.getByPosition(principal.tenantId(), position);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/active")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<BannerResponse>>> getActiveBanners(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<BannerResponse> response = bannerService.getActiveBanners(principal.tenantId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{bannerId}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<BannerResponse>> getById(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long bannerId
+    ) {
+        BannerResponse response = bannerService.getById(principal.tenantId(), bannerId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<BannerResponse>> create(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody CreateBannerRequest request
+    ) {
+        BannerResponse response = bannerService.create(principal.tenantId(), request);
+        return ResponseEntity.status(201).body(ApiResponse.success(response));
+    }
+
+    @PutMapping("/{bannerId}")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<BannerResponse>> update(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long bannerId,
+            @Valid @RequestBody UpdateBannerRequest request
+    ) {
+        BannerResponse response = bannerService.update(principal.tenantId(), bannerId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PutMapping("/{bannerId}/activate")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<BannerResponse>> activate(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long bannerId
+    ) {
+        BannerResponse response = bannerService.activate(principal.tenantId(), bannerId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PutMapping("/{bannerId}/deactivate")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<BannerResponse>> deactivate(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long bannerId
+    ) {
+        BannerResponse response = bannerService.deactivate(principal.tenantId(), bannerId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/{bannerId}")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long bannerId
+    ) {
+        bannerService.delete(principal.tenantId(), bannerId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ========== 공개 API (인증 불필요) ==========
+
+    @GetMapping("/public/displayable")
+    public ResponseEntity<ApiResponse<List<BannerResponse>>> getDisplayableBanners(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<BannerResponse> response = bannerService.getDisplayableBanners(principal.tenantId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/public/displayable/{position}")
+    public ResponseEntity<ApiResponse<List<BannerResponse>>> getDisplayableBannersByPosition(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable BannerPosition position
+    ) {
+        List<BannerResponse> response = bannerService.getDisplayableBannersByPosition(
+                principal.tenantId(), position);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/banner/dto/request/CreateBannerRequest.java
+++ b/src/main/java/com/mzc/lp/domain/banner/dto/request/CreateBannerRequest.java
@@ -1,0 +1,36 @@
+package com.mzc.lp.domain.banner.dto.request;
+
+import com.mzc.lp.domain.banner.constant.BannerPosition;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record CreateBannerRequest(
+        @NotBlank(message = "배너 제목은 필수입니다")
+        @Size(max = 200, message = "배너 제목은 200자 이하여야 합니다")
+        String title,
+
+        @NotBlank(message = "이미지 URL은 필수입니다")
+        @Size(max = 500, message = "이미지 URL은 500자 이하여야 합니다")
+        String imageUrl,
+
+        @Size(max = 500, message = "링크 URL은 500자 이하여야 합니다")
+        String linkUrl,
+
+        @Size(max = 20, message = "링크 타겟은 20자 이하여야 합니다")
+        String linkTarget,
+
+        @NotNull(message = "배너 위치는 필수입니다")
+        BannerPosition position,
+
+        Integer sortOrder,
+
+        LocalDate startDate,
+
+        LocalDate endDate,
+
+        @Size(max = 500, message = "설명은 500자 이하여야 합니다")
+        String description
+) {}

--- a/src/main/java/com/mzc/lp/domain/banner/dto/request/UpdateBannerRequest.java
+++ b/src/main/java/com/mzc/lp/domain/banner/dto/request/UpdateBannerRequest.java
@@ -1,0 +1,31 @@
+package com.mzc.lp.domain.banner.dto.request;
+
+import com.mzc.lp.domain.banner.constant.BannerPosition;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record UpdateBannerRequest(
+        @Size(max = 200, message = "배너 제목은 200자 이하여야 합니다")
+        String title,
+
+        @Size(max = 500, message = "이미지 URL은 500자 이하여야 합니다")
+        String imageUrl,
+
+        @Size(max = 500, message = "링크 URL은 500자 이하여야 합니다")
+        String linkUrl,
+
+        @Size(max = 20, message = "링크 타겟은 20자 이하여야 합니다")
+        String linkTarget,
+
+        BannerPosition position,
+
+        Integer sortOrder,
+
+        LocalDate startDate,
+
+        LocalDate endDate,
+
+        @Size(max = 500, message = "설명은 500자 이하여야 합니다")
+        String description
+) {}

--- a/src/main/java/com/mzc/lp/domain/banner/dto/response/BannerResponse.java
+++ b/src/main/java/com/mzc/lp/domain/banner/dto/response/BannerResponse.java
@@ -1,0 +1,43 @@
+package com.mzc.lp.domain.banner.dto.response;
+
+import com.mzc.lp.domain.banner.constant.BannerPosition;
+import com.mzc.lp.domain.banner.entity.Banner;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+public record BannerResponse(
+        Long id,
+        String title,
+        String imageUrl,
+        String linkUrl,
+        String linkTarget,
+        BannerPosition position,
+        Integer sortOrder,
+        Boolean isActive,
+        LocalDate startDate,
+        LocalDate endDate,
+        String description,
+        Boolean isDisplayable,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static BannerResponse from(Banner banner) {
+        return new BannerResponse(
+                banner.getId(),
+                banner.getTitle(),
+                banner.getImageUrl(),
+                banner.getLinkUrl(),
+                banner.getLinkTarget(),
+                banner.getPosition(),
+                banner.getSortOrder(),
+                banner.getIsActive(),
+                banner.getStartDate(),
+                banner.getEndDate(),
+                banner.getDescription(),
+                banner.isDisplayable(),
+                banner.getCreatedAt(),
+                banner.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/banner/entity/Banner.java
+++ b/src/main/java/com/mzc/lp/domain/banner/entity/Banner.java
@@ -1,0 +1,114 @@
+package com.mzc.lp.domain.banner.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import com.mzc.lp.domain.banner.constant.BannerPosition;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "banners")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Banner extends TenantEntity {
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "image_url", nullable = false, length = 500)
+    private String imageUrl;
+
+    @Column(name = "link_url", length = 500)
+    private String linkUrl;
+
+    @Column(name = "link_target", length = 20)
+    private String linkTarget = "_self";
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private BannerPosition position;
+
+    @Column(name = "sort_order")
+    private Integer sortOrder = 0;
+
+    @Column(name = "is_active")
+    private Boolean isActive = true;
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    @Column(length = 500)
+    private String description;
+
+    // 정적 팩토리 메서드
+    public static Banner create(String title, String imageUrl, BannerPosition position) {
+        Banner banner = new Banner();
+        banner.title = title;
+        banner.imageUrl = imageUrl;
+        banner.position = position;
+        return banner;
+    }
+
+    public static Banner create(String title, String imageUrl, BannerPosition position,
+                                 String linkUrl, LocalDate startDate, LocalDate endDate) {
+        Banner banner = create(title, imageUrl, position);
+        banner.linkUrl = linkUrl;
+        banner.startDate = startDate;
+        banner.endDate = endDate;
+        return banner;
+    }
+
+    // 비즈니스 메서드
+    public void update(String title, String imageUrl, String linkUrl, String linkTarget,
+                       BannerPosition position, String description) {
+        if (title != null && !title.isBlank()) {
+            this.title = title;
+        }
+        if (imageUrl != null && !imageUrl.isBlank()) {
+            this.imageUrl = imageUrl;
+        }
+        this.linkUrl = linkUrl;
+        this.linkTarget = linkTarget != null ? linkTarget : "_self";
+        if (position != null) {
+            this.position = position;
+        }
+        this.description = description;
+    }
+
+    public void updatePeriod(LocalDate startDate, LocalDate endDate) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public void setSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder != null ? sortOrder : 0;
+    }
+
+    public void activate() {
+        this.isActive = true;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    public boolean isDisplayable() {
+        if (!this.isActive) {
+            return false;
+        }
+        LocalDate today = LocalDate.now();
+        if (startDate != null && today.isBefore(startDate)) {
+            return false;
+        }
+        if (endDate != null && today.isAfter(endDate)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/banner/exception/BannerNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/banner/exception/BannerNotFoundException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.banner.exception;
+
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.common.constant.ErrorCode;
+
+public class BannerNotFoundException extends BusinessException {
+
+    public BannerNotFoundException() {
+        super(ErrorCode.BANNER_NOT_FOUND);
+    }
+
+    public BannerNotFoundException(Long bannerId) {
+        super(ErrorCode.BANNER_NOT_FOUND, "배너를 찾을 수 없습니다. ID: " + bannerId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/banner/repository/BannerRepository.java
+++ b/src/main/java/com/mzc/lp/domain/banner/repository/BannerRepository.java
@@ -1,0 +1,46 @@
+package com.mzc.lp.domain.banner.repository;
+
+import com.mzc.lp.domain.banner.constant.BannerPosition;
+import com.mzc.lp.domain.banner.entity.Banner;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+
+    // 테넌트별 전체 조회
+    List<Banner> findByTenantIdOrderBySortOrderAsc(Long tenantId);
+
+    // 테넌트별 위치별 조회
+    List<Banner> findByTenantIdAndPositionOrderBySortOrderAsc(Long tenantId, BannerPosition position);
+
+    // 테넌트별 활성 배너 조회
+    List<Banner> findByTenantIdAndIsActiveTrueOrderBySortOrderAsc(Long tenantId);
+
+    // 단건 조회
+    Optional<Banner> findByIdAndTenantId(Long id, Long tenantId);
+
+    // 현재 표시 가능한 배너 조회 (활성 + 기간 내)
+    @Query("SELECT b FROM Banner b WHERE b.tenantId = :tenantId " +
+           "AND b.isActive = true " +
+           "AND (b.startDate IS NULL OR b.startDate <= :today) " +
+           "AND (b.endDate IS NULL OR b.endDate >= :today) " +
+           "ORDER BY b.sortOrder ASC")
+    List<Banner> findDisplayableBanners(@Param("tenantId") Long tenantId,
+                                        @Param("today") LocalDate today);
+
+    // 위치별 현재 표시 가능한 배너 조회
+    @Query("SELECT b FROM Banner b WHERE b.tenantId = :tenantId " +
+           "AND b.position = :position " +
+           "AND b.isActive = true " +
+           "AND (b.startDate IS NULL OR b.startDate <= :today) " +
+           "AND (b.endDate IS NULL OR b.endDate >= :today) " +
+           "ORDER BY b.sortOrder ASC")
+    List<Banner> findDisplayableBannersByPosition(@Param("tenantId") Long tenantId,
+                                                   @Param("position") BannerPosition position,
+                                                   @Param("today") LocalDate today);
+}

--- a/src/main/java/com/mzc/lp/domain/banner/service/BannerService.java
+++ b/src/main/java/com/mzc/lp/domain/banner/service/BannerService.java
@@ -1,0 +1,33 @@
+package com.mzc.lp.domain.banner.service;
+
+import com.mzc.lp.domain.banner.constant.BannerPosition;
+import com.mzc.lp.domain.banner.dto.request.CreateBannerRequest;
+import com.mzc.lp.domain.banner.dto.request.UpdateBannerRequest;
+import com.mzc.lp.domain.banner.dto.response.BannerResponse;
+
+import java.util.List;
+
+public interface BannerService {
+
+    BannerResponse create(Long tenantId, CreateBannerRequest request);
+
+    BannerResponse update(Long tenantId, Long bannerId, UpdateBannerRequest request);
+
+    void delete(Long tenantId, Long bannerId);
+
+    BannerResponse getById(Long tenantId, Long bannerId);
+
+    List<BannerResponse> getAll(Long tenantId);
+
+    List<BannerResponse> getByPosition(Long tenantId, BannerPosition position);
+
+    List<BannerResponse> getActiveBanners(Long tenantId);
+
+    List<BannerResponse> getDisplayableBanners(Long tenantId);
+
+    List<BannerResponse> getDisplayableBannersByPosition(Long tenantId, BannerPosition position);
+
+    BannerResponse activate(Long tenantId, Long bannerId);
+
+    BannerResponse deactivate(Long tenantId, Long bannerId);
+}

--- a/src/main/java/com/mzc/lp/domain/banner/service/BannerServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/banner/service/BannerServiceImpl.java
@@ -1,0 +1,172 @@
+package com.mzc.lp.domain.banner.service;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.domain.banner.constant.BannerPosition;
+import com.mzc.lp.domain.banner.dto.request.CreateBannerRequest;
+import com.mzc.lp.domain.banner.dto.request.UpdateBannerRequest;
+import com.mzc.lp.domain.banner.dto.response.BannerResponse;
+import com.mzc.lp.domain.banner.entity.Banner;
+import com.mzc.lp.domain.banner.exception.BannerNotFoundException;
+import com.mzc.lp.domain.banner.repository.BannerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BannerServiceImpl implements BannerService {
+
+    private final BannerRepository bannerRepository;
+
+    @Override
+    @Transactional
+    public BannerResponse create(Long tenantId, CreateBannerRequest request) {
+        log.info("Creating banner: tenantId={}, title={}, position={}",
+                tenantId, request.title(), request.position());
+
+        TenantContext.setTenantId(tenantId);
+
+        try {
+            Banner banner = Banner.create(
+                    request.title(),
+                    request.imageUrl(),
+                    request.position(),
+                    request.linkUrl(),
+                    request.startDate(),
+                    request.endDate()
+            );
+
+            if (request.linkTarget() != null) {
+                banner.update(null, null, null, request.linkTarget(), null, request.description());
+            }
+
+            if (request.sortOrder() != null) {
+                banner.setSortOrder(request.sortOrder());
+            }
+
+            if (request.description() != null) {
+                banner.update(null, null, null, null, null, request.description());
+            }
+
+            Banner saved = bannerRepository.save(banner);
+            return BannerResponse.from(saved);
+        } finally {
+            TenantContext.clear();
+        }
+    }
+
+    @Override
+    @Transactional
+    public BannerResponse update(Long tenantId, Long bannerId, UpdateBannerRequest request) {
+        log.info("Updating banner: tenantId={}, bannerId={}", tenantId, bannerId);
+
+        Banner banner = bannerRepository.findByIdAndTenantId(bannerId, tenantId)
+                .orElseThrow(() -> new BannerNotFoundException(bannerId));
+
+        banner.update(
+                request.title(),
+                request.imageUrl(),
+                request.linkUrl(),
+                request.linkTarget(),
+                request.position(),
+                request.description()
+        );
+
+        banner.updatePeriod(request.startDate(), request.endDate());
+
+        if (request.sortOrder() != null) {
+            banner.setSortOrder(request.sortOrder());
+        }
+
+        return BannerResponse.from(banner);
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long tenantId, Long bannerId) {
+        log.info("Deleting banner: tenantId={}, bannerId={}", tenantId, bannerId);
+
+        Banner banner = bannerRepository.findByIdAndTenantId(bannerId, tenantId)
+                .orElseThrow(() -> new BannerNotFoundException(bannerId));
+
+        bannerRepository.delete(banner);
+    }
+
+    @Override
+    public BannerResponse getById(Long tenantId, Long bannerId) {
+        Banner banner = bannerRepository.findByIdAndTenantId(bannerId, tenantId)
+                .orElseThrow(() -> new BannerNotFoundException(bannerId));
+
+        return BannerResponse.from(banner);
+    }
+
+    @Override
+    public List<BannerResponse> getAll(Long tenantId) {
+        return bannerRepository.findByTenantIdOrderBySortOrderAsc(tenantId)
+                .stream()
+                .map(BannerResponse::from)
+                .toList();
+    }
+
+    @Override
+    public List<BannerResponse> getByPosition(Long tenantId, BannerPosition position) {
+        return bannerRepository.findByTenantIdAndPositionOrderBySortOrderAsc(tenantId, position)
+                .stream()
+                .map(BannerResponse::from)
+                .toList();
+    }
+
+    @Override
+    public List<BannerResponse> getActiveBanners(Long tenantId) {
+        return bannerRepository.findByTenantIdAndIsActiveTrueOrderBySortOrderAsc(tenantId)
+                .stream()
+                .map(BannerResponse::from)
+                .toList();
+    }
+
+    @Override
+    public List<BannerResponse> getDisplayableBanners(Long tenantId) {
+        return bannerRepository.findDisplayableBanners(tenantId, LocalDate.now())
+                .stream()
+                .map(BannerResponse::from)
+                .toList();
+    }
+
+    @Override
+    public List<BannerResponse> getDisplayableBannersByPosition(Long tenantId, BannerPosition position) {
+        return bannerRepository.findDisplayableBannersByPosition(tenantId, position, LocalDate.now())
+                .stream()
+                .map(BannerResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public BannerResponse activate(Long tenantId, Long bannerId) {
+        log.info("Activating banner: tenantId={}, bannerId={}", tenantId, bannerId);
+
+        Banner banner = bannerRepository.findByIdAndTenantId(bannerId, tenantId)
+                .orElseThrow(() -> new BannerNotFoundException(bannerId));
+
+        banner.activate();
+        return BannerResponse.from(banner);
+    }
+
+    @Override
+    @Transactional
+    public BannerResponse deactivate(Long tenantId, Long bannerId) {
+        log.info("Deactivating banner: tenantId={}, bannerId={}", tenantId, bannerId);
+
+        Banner banner = bannerRepository.findByIdAndTenantId(bannerId, tenantId)
+                .orElseThrow(() -> new BannerNotFoundException(bannerId));
+
+        banner.deactivate();
+        return BannerResponse.from(banner);
+    }
+}


### PR DESCRIPTION
## Summary

테넌트 관리자(TA)용 배너 관리 API를 구현합니다. 메인 페이지, 과정 목록 등 다양한 위치에 배너를 등록하고 관리할 수 있습니다.

## Related Issue

- Closes #286

## Changes

- Banner 엔티티 생성 (위치, 기간, 활성화 상태 지원)
- BannerPosition enum 생성 (MAIN_TOP, MAIN_MIDDLE, COURSE_LIST, LEARNING_HOME, LOGIN)
- BannerRepository 생성 (테넌트 기반 쿼리, 기간 기반 조회)
- CreateBannerRequest, UpdateBannerRequest DTO 생성
- BannerResponse DTO 생성 (표시 가능 여부 포함)
- BannerService 인터페이스 및 구현체 생성
- BannerController REST API 구현
- 배너 관련 예외 클래스 추가 (BannerNotFoundException)
- ErrorCode에 배너 관련 에러 코드 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### API 엔드포인트

| Method | Endpoint | 설명 | 권한 |
|--------|----------|------|------|
| GET | /api/banners | 전체 목록 조회 | OPERATOR, TENANT_ADMIN |
| GET | /api/banners/position/{pos} | 위치별 조회 | OPERATOR, TENANT_ADMIN |
| GET | /api/banners/active | 활성 배너 조회 | OPERATOR, TENANT_ADMIN |
| GET | /api/banners/{id} | 상세 조회 | OPERATOR, TENANT_ADMIN |
| POST | /api/banners | 생성 | TENANT_ADMIN |
| PUT | /api/banners/{id} | 수정 | TENANT_ADMIN |
| PUT | /api/banners/{id}/activate | 활성화 | TENANT_ADMIN |
| PUT | /api/banners/{id}/deactivate | 비활성화 | TENANT_ADMIN |
| DELETE | /api/banners/{id} | 삭제 | TENANT_ADMIN |
| GET | /api/banners/public/displayable | 표시 가능 배너 | 인증 필요 |
| GET | /api/banners/public/displayable/{pos} | 위치별 표시 가능 배너 | 인증 필요 |
