### PR TITLE
feat(user): 파일 기반 단체 계정 생성 API 구현 (#287)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,10 @@ dependencies {
     // Thumbnail generation
     implementation 'org.apache.pdfbox:pdfbox:3.0.3'
 
+    // Excel parsing (Apache POI)
+    implementation 'org.apache.poi:poi:5.2.5'
+    implementation 'org.apache.poi:poi-ooxml:5.2.5'
+
     // OpenAPI / Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 

--- a/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
+++ b/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.mzc.lp.domain.user.constant.TenantRole;
 import com.mzc.lp.domain.user.constant.UserStatus;
 import com.mzc.lp.domain.user.dto.request.AssignCourseRoleRequest;
 import com.mzc.lp.domain.user.dto.request.BulkCreateUsersRequest;
+import com.mzc.lp.domain.user.dto.request.FileBulkCreateUsersRequest;
 import com.mzc.lp.domain.user.dto.request.ChangePasswordRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeRoleRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeStatusRequest;
@@ -201,6 +202,19 @@ public class UserController {
             @Valid @RequestBody BulkCreateUsersRequest request
     ) {
         BulkCreateUsersResponse response = userService.bulkCreateUsers(principal.tenantId(), request);
+        return ResponseEntity.status(201).body(ApiResponse.success(response));
+    }
+
+    @PostMapping("/bulk/file")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<BulkCreateUsersResponse>> fileBulkCreateUsers(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam("file") MultipartFile file,
+            @RequestParam(value = "defaultPassword", required = false) String defaultPassword,
+            @RequestParam(value = "role", required = false) TenantRole role
+    ) {
+        FileBulkCreateUsersRequest request = new FileBulkCreateUsersRequest(defaultPassword, role);
+        BulkCreateUsersResponse response = userService.fileBulkCreateUsers(principal.tenantId(), file, request);
         return ResponseEntity.status(201).body(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/FileBulkCreateUsersRequest.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/FileBulkCreateUsersRequest.java
@@ -1,0 +1,14 @@
+package com.mzc.lp.domain.user.dto.request;
+
+import com.mzc.lp.domain.user.constant.TenantRole;
+
+public record FileBulkCreateUsersRequest(
+        String defaultPassword,
+        TenantRole role
+) {
+    public FileBulkCreateUsersRequest {
+        if (role == null) {
+            role = TenantRole.USER;
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/FileUserRow.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/FileUserRow.java
@@ -1,0 +1,8 @@
+package com.mzc.lp.domain.user.dto.request;
+
+public record FileUserRow(
+        String email,
+        String name,
+        String password,
+        String phone
+) {}

--- a/src/main/java/com/mzc/lp/domain/user/service/UserService.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.mzc.lp.domain.user.constant.TenantRole;
 import com.mzc.lp.domain.user.constant.UserStatus;
 import com.mzc.lp.domain.user.dto.request.AssignCourseRoleRequest;
 import com.mzc.lp.domain.user.dto.request.BulkCreateUsersRequest;
+import com.mzc.lp.domain.user.dto.request.FileBulkCreateUsersRequest;
 import com.mzc.lp.domain.user.dto.request.ChangePasswordRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeRoleRequest;
 import com.mzc.lp.domain.user.dto.request.ChangeStatusRequest;
@@ -61,4 +62,7 @@ public interface UserService {
 
     // 단체 계정 생성 API (TENANT_ADMIN 권한)
     BulkCreateUsersResponse bulkCreateUsers(Long tenantId, BulkCreateUsersRequest request);
+
+    // 파일 기반 단체 계정 생성 API (TENANT_ADMIN 권한)
+    BulkCreateUsersResponse fileBulkCreateUsers(Long tenantId, MultipartFile file, FileBulkCreateUsersRequest request);
 }

--- a/src/main/java/com/mzc/lp/domain/user/util/UserExcelParser.java
+++ b/src/main/java/com/mzc/lp/domain/user/util/UserExcelParser.java
@@ -1,0 +1,150 @@
+package com.mzc.lp.domain.user.util;
+
+import com.mzc.lp.domain.user.dto.request.FileUserRow;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+public class UserExcelParser {
+
+    private static final int MAX_ROWS = 500;
+
+    public List<FileUserRow> parseExcel(MultipartFile file) throws IOException {
+        List<FileUserRow> users = new ArrayList<>();
+
+        try (InputStream is = file.getInputStream();
+             Workbook workbook = new XSSFWorkbook(is)) {
+
+            Sheet sheet = workbook.getSheetAt(0);
+            int rowCount = 0;
+
+            for (Row row : sheet) {
+                // 첫 번째 행은 헤더로 스킵
+                if (row.getRowNum() == 0) {
+                    continue;
+                }
+
+                if (rowCount >= MAX_ROWS) {
+                    log.warn("Maximum row limit ({}) exceeded, stopping parsing", MAX_ROWS);
+                    break;
+                }
+
+                FileUserRow userRow = parseRow(row);
+                if (userRow != null && userRow.email() != null && !userRow.email().isBlank()) {
+                    users.add(userRow);
+                    rowCount++;
+                }
+            }
+        }
+
+        return users;
+    }
+
+    public List<FileUserRow> parseCsv(MultipartFile file) throws IOException {
+        List<FileUserRow> users = new ArrayList<>();
+
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8))) {
+
+            String line;
+            int lineNum = 0;
+            int rowCount = 0;
+
+            while ((line = reader.readLine()) != null) {
+                lineNum++;
+
+                // 첫 번째 줄은 헤더로 스킵
+                if (lineNum == 1) {
+                    continue;
+                }
+
+                if (rowCount >= MAX_ROWS) {
+                    log.warn("Maximum row limit ({}) exceeded, stopping parsing", MAX_ROWS);
+                    break;
+                }
+
+                FileUserRow userRow = parseCsvLine(line);
+                if (userRow != null && userRow.email() != null && !userRow.email().isBlank()) {
+                    users.add(userRow);
+                    rowCount++;
+                }
+            }
+        }
+
+        return users;
+    }
+
+    private FileUserRow parseRow(Row row) {
+        try {
+            String email = getCellValueAsString(row.getCell(0));
+            String name = getCellValueAsString(row.getCell(1));
+            String password = getCellValueAsString(row.getCell(2));
+            String phone = getCellValueAsString(row.getCell(3));
+
+            if (email == null || email.isBlank()) {
+                return null;
+            }
+
+            return new FileUserRow(
+                    email.trim().toLowerCase(),
+                    name != null ? name.trim() : null,
+                    password != null ? password.trim() : null,
+                    phone != null ? phone.trim() : null
+            );
+        } catch (Exception e) {
+            log.warn("Failed to parse row {}: {}", row.getRowNum(), e.getMessage());
+            return null;
+        }
+    }
+
+    private FileUserRow parseCsvLine(String line) {
+        try {
+            String[] parts = line.split(",", -1);
+
+            String email = parts.length > 0 ? parts[0].trim() : null;
+            String name = parts.length > 1 ? parts[1].trim() : null;
+            String password = parts.length > 2 ? parts[2].trim() : null;
+            String phone = parts.length > 3 ? parts[3].trim() : null;
+
+            if (email == null || email.isBlank()) {
+                return null;
+            }
+
+            return new FileUserRow(
+                    email.toLowerCase(),
+                    name,
+                    password,
+                    phone
+            );
+        } catch (Exception e) {
+            log.warn("Failed to parse CSV line: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private String getCellValueAsString(Cell cell) {
+        if (cell == null) {
+            return null;
+        }
+
+        return switch (cell.getCellType()) {
+            case STRING -> cell.getStringCellValue();
+            case NUMERIC -> String.valueOf((long) cell.getNumericCellValue());
+            case BOOLEAN -> String.valueOf(cell.getBooleanCellValue());
+            case FORMULA -> cell.getCellFormula();
+            default -> null;
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Excel/CSV 파일을 업로드하여 다수의 사용자 계정을 일괄 생성하는 API를 구현합니다.

## Related Issue

- Closes #287

## Changes

- Apache POI 의존성 추가 (Excel 파싱)
- UserExcelParser 유틸리티 구현 (Excel/CSV 지원)
- FileUserRow, FileBulkCreateUsersRequest DTO 생성
- UserService에 fileBulkCreateUsers 메소드 추가
- POST /api/users/bulk/file 엔드포인트 추가
- 최대 500개 계정 일괄 생성 지원

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### API 엔드포인트

| Method | Endpoint | 설명 | 권한 |
|--------|----------|------|------|
| POST | /api/users/bulk/file | 파일 기반 단체 계정 생성 | TENANT_ADMIN |

### 파일 형식
- 지원 형식: Excel (.xlsx), CSV (.csv)
- 컬럼 순서: 이메일, 이름, 비밀번호, 전화번호
- 첫 번째 행은 헤더로 스킵
- 최대 500개 행까지 처리

### 요청 파라미터
- `file`: 업로드할 Excel/CSV 파일 (필수)
- `defaultPassword`: 파일에 비밀번호가 없을 경우 사용할 기본 비밀번호
- `role`: 생성할 사용자의 역할 (기본값: USER)
