### PR TITLE
feat: 찜/장바구니 API CourseTime(차수)기반으로 변경

### DIFF
--- a/src/main/java/com/mzc/lp/domain/cart/controller/CartController.java
+++ b/src/main/java/com/mzc/lp/domain/cart/controller/CartController.java
@@ -39,7 +39,7 @@ public class CartController {
     }
 
     /**
-     * 장바구니에 강의 추가
+     * 장바구니에 차수 추가
      */
     @PostMapping("/items")
     @PreAuthorize("isAuthenticated()")
@@ -52,20 +52,20 @@ public class CartController {
     }
 
     /**
-     * 장바구니에서 강의 삭제
+     * 장바구니에서 차수 삭제
      */
-    @DeleteMapping("/items/{courseId}")
+    @DeleteMapping("/items/{courseTimeId}")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<Void> removeFromCart(
-            @PathVariable Long courseId,
+            @PathVariable Long courseTimeId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        cartService.removeFromCart(principal.id(), courseId);
+        cartService.removeFromCart(principal.id(), courseTimeId);
         return ResponseEntity.noContent().build();
     }
 
     /**
-     * 장바구니에서 여러 강의 삭제 (선택 삭제)
+     * 장바구니에서 여러 차수 삭제 (선택 삭제)
      */
     @DeleteMapping("/items")
     @PreAuthorize("isAuthenticated()")
@@ -90,15 +90,15 @@ public class CartController {
     }
 
     /**
-     * 특정 강의 장바구니 여부 확인
+     * 특정 차수 장바구니 여부 확인
      */
-    @GetMapping("/items/{courseId}/check")
+    @GetMapping("/items/{courseTimeId}/check")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<Boolean>> checkCartStatus(
-            @PathVariable Long courseId,
+            @PathVariable Long courseTimeId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        boolean isInCart = cartService.isInCart(principal.id(), courseId);
+        boolean isInCart = cartService.isInCart(principal.id(), courseTimeId);
         return ResponseEntity.ok(ApiResponse.success(isInCart));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/cart/dto/request/CartAddRequest.java
+++ b/src/main/java/com/mzc/lp/domain/cart/dto/request/CartAddRequest.java
@@ -3,7 +3,7 @@ package com.mzc.lp.domain.cart.dto.request;
 import jakarta.validation.constraints.NotNull;
 
 public record CartAddRequest(
-        @NotNull(message = "강의 ID는 필수입니다")
-        Long courseId
+        @NotNull(message = "차수 ID는 필수입니다")
+        Long courseTimeId
 ) {
 }

--- a/src/main/java/com/mzc/lp/domain/cart/dto/request/CartRemoveRequest.java
+++ b/src/main/java/com/mzc/lp/domain/cart/dto/request/CartRemoveRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 
 public record CartRemoveRequest(
-        @NotEmpty(message = "삭제할 강의 ID 목록은 필수입니다")
-        List<Long> courseIds
+        @NotEmpty(message = "삭제할 차수 ID 목록은 필수입니다")
+        List<Long> courseTimeIds
 ) {
 }

--- a/src/main/java/com/mzc/lp/domain/cart/dto/response/CartItemResponse.java
+++ b/src/main/java/com/mzc/lp/domain/cart/dto/response/CartItemResponse.java
@@ -1,31 +1,28 @@
 package com.mzc.lp.domain.cart.dto.response;
 
 import com.mzc.lp.domain.cart.entity.CartItem;
-import com.mzc.lp.domain.course.entity.Course;
+import com.mzc.lp.domain.program.entity.Program;
+import com.mzc.lp.domain.ts.entity.CourseTime;
 
 import java.time.Instant;
 
 public record CartItemResponse(
         Long cartItemId,
-        Long courseId,
-        String courseTitle,
-        String courseDescription,
+        Long courseTimeId,
+        String courseTimeTitle,
         String thumbnailUrl,
         String level,
-        String type,
         Integer estimatedHours,
         Instant addedAt
 ) {
-    public static CartItemResponse from(CartItem cartItem, Course course) {
+    public static CartItemResponse from(CartItem cartItem, CourseTime courseTime, Program program) {
         return new CartItemResponse(
                 cartItem.getId(),
-                course.getId(),
-                course.getTitle(),
-                course.getDescription(),
-                course.getThumbnailUrl(),
-                course.getLevel() != null ? course.getLevel().name() : null,
-                course.getType() != null ? course.getType().name() : null,
-                course.getEstimatedHours(),
+                courseTime.getId(),
+                courseTime.getTitle(),
+                program != null ? program.getThumbnailUrl() : null,
+                program != null && program.getLevel() != null ? program.getLevel().name() : null,
+                program != null ? program.getEstimatedHours() : null,
                 cartItem.getAddedAt()
         );
     }

--- a/src/main/java/com/mzc/lp/domain/cart/dto/response/CartItemResponse.java
+++ b/src/main/java/com/mzc/lp/domain/cart/dto/response/CartItemResponse.java
@@ -13,6 +13,8 @@ public record CartItemResponse(
         String thumbnailUrl,
         String level,
         Integer estimatedHours,
+        Boolean isFree,
+        String price,
         Instant addedAt
 ) {
     public static CartItemResponse from(CartItem cartItem, CourseTime courseTime, Program program) {
@@ -23,6 +25,8 @@ public record CartItemResponse(
                 program != null ? program.getThumbnailUrl() : null,
                 program != null && program.getLevel() != null ? program.getLevel().name() : null,
                 program != null ? program.getEstimatedHours() : null,
+                courseTime.isFree(),
+                courseTime.getPrice() != null ? courseTime.getPrice().toString() : null,
                 cartItem.getAddedAt()
         );
     }

--- a/src/main/java/com/mzc/lp/domain/cart/entity/CartItem.java
+++ b/src/main/java/com/mzc/lp/domain/cart/entity/CartItem.java
@@ -11,8 +11,8 @@ import java.time.Instant;
 @Entity
 @Table(name = "cart_items",
         uniqueConstraints = @UniqueConstraint(
-                name = "uk_cart_user_course",
-                columnNames = {"tenant_id", "user_id", "course_id"}
+                name = "uk_cart_user_course_time",
+                columnNames = {"tenant_id", "user_id", "course_time_id"}
         ),
         indexes = {
                 @Index(name = "idx_cart_tenant_user", columnList = "tenant_id, user_id"),
@@ -25,17 +25,17 @@ public class CartItem extends TenantEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "course_id", nullable = false)
-    private Long courseId;
+    @Column(name = "course_time_id", nullable = false)
+    private Long courseTimeId;
 
     @Column(name = "added_at", nullable = false)
     private Instant addedAt;
 
     // ===== 정적 팩토리 메서드 =====
-    public static CartItem create(Long userId, Long courseId) {
+    public static CartItem create(Long userId, Long courseTimeId) {
         CartItem cartItem = new CartItem();
         cartItem.userId = userId;
-        cartItem.courseId = courseId;
+        cartItem.courseTimeId = courseTimeId;
         cartItem.addedAt = Instant.now();
         return cartItem;
     }

--- a/src/main/java/com/mzc/lp/domain/cart/exception/AlreadyInCartException.java
+++ b/src/main/java/com/mzc/lp/domain/cart/exception/AlreadyInCartException.java
@@ -9,7 +9,7 @@ public class AlreadyInCartException extends BusinessException {
         super(ErrorCode.ALREADY_IN_CART);
     }
 
-    public AlreadyInCartException(Long courseId) {
-        super(ErrorCode.ALREADY_IN_CART, "Course already in cart: " + courseId);
+    public AlreadyInCartException(Long courseTimeId) {
+        super(ErrorCode.ALREADY_IN_CART, "CourseTime already in cart: " + courseTimeId);
     }
 }

--- a/src/main/java/com/mzc/lp/domain/cart/exception/CartItemNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/cart/exception/CartItemNotFoundException.java
@@ -9,7 +9,7 @@ public class CartItemNotFoundException extends BusinessException {
         super(ErrorCode.CART_ITEM_NOT_FOUND);
     }
 
-    public CartItemNotFoundException(Long courseId) {
-        super(ErrorCode.CART_ITEM_NOT_FOUND, "Cart item not found for courseId: " + courseId);
+    public CartItemNotFoundException(Long courseTimeId) {
+        super(ErrorCode.CART_ITEM_NOT_FOUND, "Cart item not found for courseTimeId: " + courseTimeId);
     }
 }

--- a/src/main/java/com/mzc/lp/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/mzc/lp/domain/cart/repository/CartRepository.java
@@ -18,28 +18,28 @@ public interface CartRepository extends JpaRepository<CartItem, Long> {
     List<CartItem> findByUserIdOrderByAddedAtDesc(@Param("userId") Long userId);
 
     /**
-     * 특정 사용자의 특정 강의 장바구니 항목 조회
+     * 특정 사용자의 특정 차수 장바구니 항목 조회
      */
-    Optional<CartItem> findByUserIdAndCourseId(Long userId, Long courseId);
+    Optional<CartItem> findByUserIdAndCourseTimeId(Long userId, Long courseTimeId);
 
     /**
-     * 특정 사용자의 특정 강의 장바구니 존재 여부
+     * 특정 사용자의 특정 차수 장바구니 존재 여부
      */
-    boolean existsByUserIdAndCourseId(Long userId, Long courseId);
+    boolean existsByUserIdAndCourseTimeId(Long userId, Long courseTimeId);
 
     /**
      * 장바구니 항목 삭제
      */
     @Modifying
-    @Query("DELETE FROM CartItem c WHERE c.userId = :userId AND c.courseId = :courseId")
-    void deleteByUserIdAndCourseId(@Param("userId") Long userId, @Param("courseId") Long courseId);
+    @Query("DELETE FROM CartItem c WHERE c.userId = :userId AND c.courseTimeId = :courseTimeId")
+    void deleteByUserIdAndCourseTimeId(@Param("userId") Long userId, @Param("courseTimeId") Long courseTimeId);
 
     /**
-     * 여러 강의 장바구니 항목 일괄 삭제
+     * 여러 차수 장바구니 항목 일괄 삭제
      */
     @Modifying
-    @Query("DELETE FROM CartItem c WHERE c.userId = :userId AND c.courseId IN :courseIds")
-    void deleteByUserIdAndCourseIdIn(@Param("userId") Long userId, @Param("courseIds") List<Long> courseIds);
+    @Query("DELETE FROM CartItem c WHERE c.userId = :userId AND c.courseTimeId IN :courseTimeIds")
+    void deleteByUserIdAndCourseTimeIdIn(@Param("userId") Long userId, @Param("courseTimeIds") List<Long> courseTimeIds);
 
     /**
      * 사용자의 장바구니 개수 조회
@@ -47,8 +47,8 @@ public interface CartRepository extends JpaRepository<CartItem, Long> {
     long countByUserId(Long userId);
 
     /**
-     * 특정 강의들의 장바구니 존재 여부 조회
+     * 특정 차수들의 장바구니 존재 여부 조회
      */
-    @Query("SELECT c.courseId FROM CartItem c WHERE c.userId = :userId AND c.courseId IN :courseIds")
-    List<Long> findCourseIdsByUserIdAndCourseIdIn(@Param("userId") Long userId, @Param("courseIds") List<Long> courseIds);
+    @Query("SELECT c.courseTimeId FROM CartItem c WHERE c.userId = :userId AND c.courseTimeId IN :courseTimeIds")
+    List<Long> findCourseTimeIdsByUserIdAndCourseTimeIdIn(@Param("userId") Long userId, @Param("courseTimeIds") List<Long> courseTimeIds);
 }

--- a/src/main/java/com/mzc/lp/domain/student/controller/EnrollmentController.java
+++ b/src/main/java/com/mzc/lp/domain/student/controller/EnrollmentController.java
@@ -3,10 +3,12 @@ package com.mzc.lp.domain.student.controller;
 import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.common.security.UserPrincipal;
 import com.mzc.lp.domain.student.constant.EnrollmentStatus;
+import com.mzc.lp.domain.student.dto.request.BulkEnrollmentRequest;
 import com.mzc.lp.domain.student.dto.request.CompleteEnrollmentRequest;
 import com.mzc.lp.domain.student.dto.request.ForceEnrollRequest;
 import com.mzc.lp.domain.student.dto.request.UpdateEnrollmentStatusRequest;
 import com.mzc.lp.domain.student.dto.request.UpdateProgressRequest;
+import com.mzc.lp.domain.student.dto.response.BulkEnrollmentResponse;
 import com.mzc.lp.domain.student.dto.response.CourseTimeEnrollmentStatsResponse;
 import com.mzc.lp.domain.student.dto.response.EnrollmentDetailResponse;
 import com.mzc.lp.domain.student.dto.response.EnrollmentResponse;
@@ -81,6 +83,19 @@ public class EnrollmentController {
         Page<EnrollmentResponse> response = enrollmentService.getEnrollmentsByCourseTime(
                 courseTimeId, status, pageable, principal.id(), hasAdminRole(principal));
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 일괄 수강 신청
+     */
+    @PostMapping("/api/enrollments/bulk")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<BulkEnrollmentResponse>> bulkEnroll(
+            @Valid @RequestBody BulkEnrollmentRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        BulkEnrollmentResponse response = enrollmentService.bulkEnroll(request, principal.id());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 
     // ========== 수강 관리 API ==========

--- a/src/main/java/com/mzc/lp/domain/student/dto/request/BulkEnrollmentRequest.java
+++ b/src/main/java/com/mzc/lp/domain/student/dto/request/BulkEnrollmentRequest.java
@@ -1,0 +1,13 @@
+package com.mzc.lp.domain.student.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record BulkEnrollmentRequest(
+        @NotEmpty(message = "courseTimeIds는 필수입니다")
+        @Size(max = 100, message = "한 번에 최대 100개까지 수강신청 가능합니다")
+        List<Long> courseTimeIds
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/student/dto/response/BulkEnrollmentResponse.java
+++ b/src/main/java/com/mzc/lp/domain/student/dto/response/BulkEnrollmentResponse.java
@@ -1,0 +1,51 @@
+package com.mzc.lp.domain.student.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class BulkEnrollmentResponse {
+
+    private List<EnrollmentResult> results;
+    private int successCount;
+    private int failureCount;
+
+    @Getter
+    @Builder
+    public static class EnrollmentResult {
+        private Long courseTimeId;
+        private boolean success;
+        private Long enrollmentId;
+        private String errorMessage;
+
+        public static EnrollmentResult success(Long courseTimeId, Long enrollmentId) {
+            return EnrollmentResult.builder()
+                    .courseTimeId(courseTimeId)
+                    .success(true)
+                    .enrollmentId(enrollmentId)
+                    .build();
+        }
+
+        public static EnrollmentResult failure(Long courseTimeId, String errorMessage) {
+            return EnrollmentResult.builder()
+                    .courseTimeId(courseTimeId)
+                    .success(false)
+                    .errorMessage(errorMessage)
+                    .build();
+        }
+    }
+
+    public static BulkEnrollmentResponse of(List<EnrollmentResult> results) {
+        int successCount = (int) results.stream().filter(EnrollmentResult::isSuccess).count();
+        int failureCount = results.size() - successCount;
+
+        return BulkEnrollmentResponse.builder()
+                .results(results)
+                .successCount(successCount)
+                .failureCount(failureCount)
+                .build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/student/service/EnrollmentService.java
+++ b/src/main/java/com/mzc/lp/domain/student/service/EnrollmentService.java
@@ -1,10 +1,12 @@
 package com.mzc.lp.domain.student.service;
 
 import com.mzc.lp.domain.student.constant.EnrollmentStatus;
+import com.mzc.lp.domain.student.dto.request.BulkEnrollmentRequest;
 import com.mzc.lp.domain.student.dto.request.CompleteEnrollmentRequest;
 import com.mzc.lp.domain.student.dto.request.ForceEnrollRequest;
 import com.mzc.lp.domain.student.dto.request.UpdateEnrollmentStatusRequest;
 import com.mzc.lp.domain.student.dto.request.UpdateProgressRequest;
+import com.mzc.lp.domain.student.dto.response.BulkEnrollmentResponse;
 import com.mzc.lp.domain.student.dto.response.EnrollmentDetailResponse;
 import com.mzc.lp.domain.student.dto.response.EnrollmentResponse;
 import com.mzc.lp.domain.student.dto.response.ForceEnrollResultResponse;
@@ -42,4 +44,7 @@ public interface EnrollmentService {
 
     // 수강 취소
     void cancelEnrollment(Long enrollmentId, Long userId, boolean isAdmin);
+
+    // 일괄 수강 신청
+    BulkEnrollmentResponse bulkEnroll(BulkEnrollmentRequest request, Long userId);
 }

--- a/src/main/java/com/mzc/lp/domain/student/service/EnrollmentServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/student/service/EnrollmentServiceImpl.java
@@ -2,10 +2,12 @@ package com.mzc.lp.domain.student.service;
 
 import com.mzc.lp.common.context.TenantContext;
 import com.mzc.lp.domain.student.constant.EnrollmentStatus;
+import com.mzc.lp.domain.student.dto.request.BulkEnrollmentRequest;
 import com.mzc.lp.domain.student.dto.request.CompleteEnrollmentRequest;
 import com.mzc.lp.domain.student.dto.request.ForceEnrollRequest;
 import com.mzc.lp.domain.student.dto.request.UpdateEnrollmentStatusRequest;
 import com.mzc.lp.domain.student.dto.request.UpdateProgressRequest;
+import com.mzc.lp.domain.student.dto.response.BulkEnrollmentResponse;
 import com.mzc.lp.domain.student.dto.response.EnrollmentDetailResponse;
 import com.mzc.lp.domain.student.dto.response.EnrollmentResponse;
 import com.mzc.lp.domain.student.dto.response.ForceEnrollResultResponse;
@@ -329,6 +331,70 @@ public class EnrollmentServiceImpl implements EnrollmentService {
         enrollment.drop();
 
         log.info("Enrollment cancelled: enrollmentId={}", enrollmentId);
+    }
+
+    @Override
+    @Transactional
+    public BulkEnrollmentResponse bulkEnroll(BulkEnrollmentRequest request, Long userId) {
+        log.info("Bulk enrolling user: userId={}, courseTimeCount={}", userId, request.courseTimeIds().size());
+
+        Long tenantId = TenantContext.getCurrentTenantId();
+        List<BulkEnrollmentResponse.EnrollmentResult> results = new ArrayList<>();
+
+        for (Long courseTimeId : request.courseTimeIds()) {
+            try {
+                // 각 차수에 대해 개별적으로 수강신청 처리
+                CourseTime courseTime = courseTimeRepository.findByIdWithLock(courseTimeId)
+                        .orElseThrow(() -> new CourseTimeNotFoundException(courseTimeId));
+
+                // 테넌트 검증
+                if (!courseTime.getTenantId().equals(tenantId)) {
+                    results.add(BulkEnrollmentResponse.EnrollmentResult.failure(courseTimeId, "차수를 찾을 수 없습니다"));
+                    continue;
+                }
+
+                // 수강 신청 가능 여부 체크
+                if (!courseTime.canEnroll()) {
+                    results.add(BulkEnrollmentResponse.EnrollmentResult.failure(courseTimeId, "수강신청 기간이 아닙니다"));
+                    continue;
+                }
+
+                // 중복 수강 체크
+                if (enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, tenantId)) {
+                    results.add(BulkEnrollmentResponse.EnrollmentResult.failure(courseTimeId, "이미 수강 중입니다"));
+                    continue;
+                }
+
+                // 정원 체크
+                if (!courseTime.hasUnlimitedCapacity() && !courseTime.hasAvailableSeats()) {
+                    results.add(BulkEnrollmentResponse.EnrollmentResult.failure(courseTimeId, "정원이 마감되었습니다"));
+                    continue;
+                }
+
+                // 정원 증가
+                courseTime.incrementEnrollment();
+
+                // 수강 생성
+                Enrollment enrollment = Enrollment.createVoluntary(userId, courseTimeId);
+                Enrollment savedEnrollment = enrollmentRepository.save(enrollment);
+
+                results.add(BulkEnrollmentResponse.EnrollmentResult.success(courseTimeId, savedEnrollment.getId()));
+
+                log.debug("Bulk enrollment success: userId={}, courseTimeId={}, enrollmentId={}",
+                        userId, courseTimeId, savedEnrollment.getId());
+            } catch (CourseTimeNotFoundException e) {
+                results.add(BulkEnrollmentResponse.EnrollmentResult.failure(courseTimeId, "차수를 찾을 수 없습니다"));
+            } catch (Exception e) {
+                log.warn("Bulk enrollment failed: userId={}, courseTimeId={}, error={}", userId, courseTimeId, e.getMessage());
+                results.add(BulkEnrollmentResponse.EnrollmentResult.failure(courseTimeId, e.getMessage()));
+            }
+        }
+
+        BulkEnrollmentResponse response = BulkEnrollmentResponse.of(results);
+        log.info("Bulk enrollment completed: userId={}, successCount={}, failureCount={}",
+                userId, response.getSuccessCount(), response.getFailureCount());
+
+        return response;
     }
 
     // ========== Private Helper Methods ==========

--- a/src/main/java/com/mzc/lp/domain/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/controller/WishlistController.java
@@ -44,13 +44,13 @@ public class WishlistController {
     /**
      * 찜 삭제
      */
-    @DeleteMapping("/courses/{courseId}")
+    @DeleteMapping("/course-times/{courseTimeId}")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<Void> removeFromWishlist(
-            @PathVariable Long courseId,
+            @PathVariable Long courseTimeId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        wishlistService.removeFromWishlist(principal.id(), courseId);
+        wishlistService.removeFromWishlist(principal.id(), courseTimeId);
         return ResponseEntity.noContent().build();
     }
 
@@ -68,20 +68,20 @@ public class WishlistController {
     }
 
     /**
-     * 특정 강의 찜 여부 확인
+     * 특정 차수 찜 여부 확인
      */
-    @GetMapping("/courses/{courseId}/check")
+    @GetMapping("/course-times/{courseTimeId}/check")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<Boolean>> checkWishlistStatus(
-            @PathVariable Long courseId,
+            @PathVariable Long courseTimeId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        boolean isInWishlist = wishlistService.isInWishlist(principal.id(), courseId);
+        boolean isInWishlist = wishlistService.isInWishlist(principal.id(), courseTimeId);
         return ResponseEntity.ok(ApiResponse.success(isInWishlist));
     }
 
     /**
-     * 여러 강의 찜 여부 일괄 확인
+     * 여러 차수 찜 여부 일괄 확인
      */
     @PostMapping("/check")
     @PreAuthorize("isAuthenticated()")
@@ -106,13 +106,13 @@ public class WishlistController {
     }
 
     /**
-     * 특정 강의의 찜 개수 조회 (공개)
+     * 특정 차수의 찜 개수 조회 (공개)
      */
-    @GetMapping("/courses/{courseId}/count")
-    public ResponseEntity<ApiResponse<WishlistCountResponse>> getCourseWishlistCount(
-            @PathVariable Long courseId
+    @GetMapping("/course-times/{courseTimeId}/count")
+    public ResponseEntity<ApiResponse<WishlistCountResponse>> getCourseTimeWishlistCount(
+            @PathVariable Long courseTimeId
     ) {
-        WishlistCountResponse response = wishlistService.getCourseWishlistCount(courseId);
+        WishlistCountResponse response = wishlistService.getCourseTimeWishlistCount(courseTimeId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/wishlist/dto/request/WishlistAddRequest.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/dto/request/WishlistAddRequest.java
@@ -8,10 +8,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class WishlistAddRequest {
 
-    @NotNull(message = "강의 ID는 필수입니다")
-    private Long courseId;
+    @NotNull(message = "차수 ID는 필수입니다")
+    private Long courseTimeId;
 
-    public WishlistAddRequest(Long courseId) {
-        this.courseId = courseId;
+    public WishlistAddRequest(Long courseTimeId) {
+        this.courseTimeId = courseTimeId;
     }
 }

--- a/src/main/java/com/mzc/lp/domain/wishlist/dto/request/WishlistCheckRequest.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/dto/request/WishlistCheckRequest.java
@@ -10,10 +10,10 @@ import java.util.List;
 @NoArgsConstructor
 public class WishlistCheckRequest {
 
-    @NotEmpty(message = "강의 ID 목록은 필수입니다")
-    private List<Long> courseIds;
+    @NotEmpty(message = "차수 ID 목록은 필수입니다")
+    private List<Long> courseTimeIds;
 
-    public WishlistCheckRequest(List<Long> courseIds) {
-        this.courseIds = courseIds;
+    public WishlistCheckRequest(List<Long> courseTimeIds) {
+        this.courseTimeIds = courseTimeIds;
     }
 }

--- a/src/main/java/com/mzc/lp/domain/wishlist/dto/response/WishlistItemResponse.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/dto/response/WishlistItemResponse.java
@@ -15,9 +15,11 @@ public class WishlistItemResponse {
     private Long id;
     private Long courseTimeId;
     private String courseTimeTitle;
-    private String courseThumbnailUrl;
-    private String courseLevel;
-    private Integer courseEstimatedHours;
+    private String thumbnailUrl;
+    private String level;
+    private Integer estimatedHours;
+    private Boolean isFree;
+    private String price;
     private Instant addedAt;
 
     public static WishlistItemResponse from(WishlistItem item) {
@@ -33,9 +35,11 @@ public class WishlistItemResponse {
                 .id(item.getId())
                 .courseTimeId(item.getCourseTimeId())
                 .courseTimeTitle(courseTime.getTitle())
-                .courseThumbnailUrl(program != null ? program.getThumbnailUrl() : null)
-                .courseLevel(program != null && program.getLevel() != null ? program.getLevel().name() : null)
-                .courseEstimatedHours(program != null ? program.getEstimatedHours() : null)
+                .thumbnailUrl(program != null ? program.getThumbnailUrl() : null)
+                .level(program != null && program.getLevel() != null ? program.getLevel().name() : null)
+                .estimatedHours(program != null ? program.getEstimatedHours() : null)
+                .isFree(courseTime.isFree())
+                .price(courseTime.getPrice() != null ? courseTime.getPrice().toString() : null)
                 .addedAt(item.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/mzc/lp/domain/wishlist/dto/response/WishlistItemResponse.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/dto/response/WishlistItemResponse.java
@@ -1,5 +1,7 @@
 package com.mzc.lp.domain.wishlist.dto.response;
 
+import com.mzc.lp.domain.program.entity.Program;
+import com.mzc.lp.domain.ts.entity.CourseTime;
 import com.mzc.lp.domain.wishlist.entity.WishlistItem;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,38 +13,29 @@ import java.time.Instant;
 public class WishlistItemResponse {
 
     private Long id;
-    private Long courseId;
-    private String courseTitle;
+    private Long courseTimeId;
+    private String courseTimeTitle;
     private String courseThumbnailUrl;
     private String courseLevel;
-    private String courseType;
     private Integer courseEstimatedHours;
     private Instant addedAt;
 
     public static WishlistItemResponse from(WishlistItem item) {
         return WishlistItemResponse.builder()
                 .id(item.getId())
-                .courseId(item.getCourseId())
+                .courseTimeId(item.getCourseTimeId())
                 .addedAt(item.getCreatedAt())
                 .build();
     }
 
-    public static WishlistItemResponse of(
-            WishlistItem item,
-            String courseTitle,
-            String courseThumbnailUrl,
-            String courseLevel,
-            String courseType,
-            Integer courseEstimatedHours
-    ) {
+    public static WishlistItemResponse of(WishlistItem item, CourseTime courseTime, Program program) {
         return WishlistItemResponse.builder()
                 .id(item.getId())
-                .courseId(item.getCourseId())
-                .courseTitle(courseTitle)
-                .courseThumbnailUrl(courseThumbnailUrl)
-                .courseLevel(courseLevel)
-                .courseType(courseType)
-                .courseEstimatedHours(courseEstimatedHours)
+                .courseTimeId(item.getCourseTimeId())
+                .courseTimeTitle(courseTime.getTitle())
+                .courseThumbnailUrl(program != null ? program.getThumbnailUrl() : null)
+                .courseLevel(program != null && program.getLevel() != null ? program.getLevel().name() : null)
+                .courseEstimatedHours(program != null ? program.getEstimatedHours() : null)
                 .addedAt(item.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/mzc/lp/domain/wishlist/entity/WishlistItem.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/entity/WishlistItem.java
@@ -8,20 +8,20 @@ import lombok.NoArgsConstructor;
 
 /**
  * 찜(위시리스트) 아이템 엔티티
- * 사용자가 관심 있는 강의를 저장하는 기능
+ * 사용자가 관심 있는 차수(CourseTime)를 저장하는 기능
  */
 @Entity
 @Table(
     name = "cm_wishlist_items",
     uniqueConstraints = {
         @UniqueConstraint(
-            name = "uk_wishlist_user_course",
-            columnNames = {"tenant_id", "user_id", "course_id"}
+            name = "uk_wishlist_user_course_time",
+            columnNames = {"tenant_id", "user_id", "course_time_id"}
         )
     },
     indexes = {
         @Index(name = "idx_wishlist_user", columnList = "tenant_id, user_id"),
-        @Index(name = "idx_wishlist_course", columnList = "tenant_id, course_id")
+        @Index(name = "idx_wishlist_course_time", columnList = "tenant_id, course_time_id")
     }
 )
 @Getter
@@ -31,14 +31,14 @@ public class WishlistItem extends TenantEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "course_id", nullable = false)
-    private Long courseId;
+    @Column(name = "course_time_id", nullable = false)
+    private Long courseTimeId;
 
     // ===== 정적 팩토리 메서드 =====
-    public static WishlistItem create(Long userId, Long courseId) {
+    public static WishlistItem create(Long userId, Long courseTimeId) {
         WishlistItem item = new WishlistItem();
         item.userId = userId;
-        item.courseId = courseId;
+        item.courseTimeId = courseTimeId;
         return item;
     }
 }

--- a/src/main/java/com/mzc/lp/domain/wishlist/exception/AlreadyInWishlistException.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/exception/AlreadyInWishlistException.java
@@ -9,8 +9,8 @@ public class AlreadyInWishlistException extends BusinessException {
         super(ErrorCode.ALREADY_IN_WISHLIST);
     }
 
-    public AlreadyInWishlistException(Long userId, Long courseId) {
+    public AlreadyInWishlistException(Long userId, Long courseTimeId) {
         super(ErrorCode.ALREADY_IN_WISHLIST,
-              "Course " + courseId + " is already in wishlist for user " + userId);
+              "CourseTime " + courseTimeId + " is already in wishlist for user " + userId);
     }
 }

--- a/src/main/java/com/mzc/lp/domain/wishlist/exception/WishlistItemNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/exception/WishlistItemNotFoundException.java
@@ -9,8 +9,8 @@ public class WishlistItemNotFoundException extends BusinessException {
         super(ErrorCode.WISHLIST_ITEM_NOT_FOUND);
     }
 
-    public WishlistItemNotFoundException(Long userId, Long courseId) {
+    public WishlistItemNotFoundException(Long userId, Long courseTimeId) {
         super(ErrorCode.WISHLIST_ITEM_NOT_FOUND,
-              "Wishlist item not found for user " + userId + " and course " + courseId);
+              "Wishlist item not found for user " + userId + " and courseTime " + courseTimeId);
     }
 }

--- a/src/main/java/com/mzc/lp/domain/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/mzc/lp/domain/wishlist/repository/WishlistRepository.java
@@ -25,19 +25,19 @@ public interface WishlistRepository extends JpaRepository<WishlistItem, Long> {
     List<WishlistItem> findByUserId(Long userId);
 
     /**
-     * 특정 사용자의 특정 강의 찜 여부 확인
+     * 특정 사용자의 특정 차수 찜 여부 확인
      */
-    Optional<WishlistItem> findByUserIdAndCourseId(Long userId, Long courseId);
+    Optional<WishlistItem> findByUserIdAndCourseTimeId(Long userId, Long courseTimeId);
 
     /**
-     * 특정 사용자의 특정 강의 찜 존재 여부
+     * 특정 사용자의 특정 차수 찜 존재 여부
      */
-    boolean existsByUserIdAndCourseId(Long userId, Long courseId);
+    boolean existsByUserIdAndCourseTimeId(Long userId, Long courseTimeId);
 
     /**
-     * 특정 사용자의 특정 강의 찜 삭제
+     * 특정 사용자의 특정 차수 찜 삭제
      */
-    void deleteByUserIdAndCourseId(Long userId, Long courseId);
+    void deleteByUserIdAndCourseTimeId(Long userId, Long courseTimeId);
 
     /**
      * 사용자의 찜 개수 조회
@@ -45,13 +45,13 @@ public interface WishlistRepository extends JpaRepository<WishlistItem, Long> {
     long countByUserId(Long userId);
 
     /**
-     * 특정 강의의 찜 개수 조회
+     * 특정 차수의 찜 개수 조회
      */
-    long countByCourseId(Long courseId);
+    long countByCourseTimeId(Long courseTimeId);
 
     /**
-     * 사용자의 여러 강의 찜 여부 일괄 확인
+     * 사용자의 여러 차수 찜 여부 일괄 확인
      */
-    @Query("SELECT w.courseId FROM WishlistItem w WHERE w.userId = :userId AND w.courseId IN :courseIds")
-    List<Long> findWishlistedCourseIds(@Param("userId") Long userId, @Param("courseIds") List<Long> courseIds);
+    @Query("SELECT w.courseTimeId FROM WishlistItem w WHERE w.userId = :userId AND w.courseTimeId IN :courseTimeIds")
+    List<Long> findWishlistedCourseTimeIds(@Param("userId") Long userId, @Param("courseTimeIds") List<Long> courseTimeIds);
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -41,49 +41,49 @@ UPDATE cm_snapshot_los SET version = 0 WHERE version IS NULL;
 -- ============================================
 
 -- Program 1: Next.js 완벽 마스터
-INSERT INTO cm_programs (id, tenant_id, version, title, description, thumbnail_url, level, type, estimated_hours, status, created_by, creator_id, approved_by, approved_at, created_at, updated_at)
+INSERT INTO cm_programs (id, tenant_id, version, title, description, thumbnail_url, level, type, estimated_hours, status, created_by, approved_by, approved_at, created_at, updated_at)
 SELECT 1, 1, 0, '실전! Next.js 15 완벽 마스터',
        'Next.js 15의 새로운 기능과 함께 실전 프로젝트를 만들어봅니다. App Router, Server Actions, 그리고 최신 React 패턴을 학습합니다.',
        'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=250&fit=crop',
-       'INTERMEDIATE', 'ONLINE', 32, 'APPROVED', 1, 1, 1, NOW(), NOW(), NOW()
+       'INTERMEDIATE', 'ONLINE', 32, 'APPROVED', 1, 1, NOW(), NOW(), NOW()
 WHERE NOT EXISTS (SELECT 1 FROM cm_programs WHERE id = 1);
 
 -- Program 2: ChatGPT API 활용
-INSERT INTO cm_programs (id, tenant_id, version, title, description, thumbnail_url, level, type, estimated_hours, status, created_by, creator_id, approved_by, approved_at, created_at, updated_at)
+INSERT INTO cm_programs (id, tenant_id, version, title, description, thumbnail_url, level, type, estimated_hours, status, created_by, approved_by, approved_at, created_at, updated_at)
 SELECT 2, 1, 0, 'ChatGPT API 활용 실무 프로젝트',
        'OpenAI API를 활용한 실무 프로젝트를 진행합니다. 챗봇, 문서 분석, 코드 생성 등 다양한 활용법을 배웁니다.',
        'https://images.unsplash.com/photo-1677442136019-21780ecad995?w=400&h=250&fit=crop',
-       'INTERMEDIATE', 'ONLINE', 28, 'APPROVED', 1, 1, 1, NOW(), NOW(), NOW()
+       'INTERMEDIATE', 'ONLINE', 28, 'APPROVED', 1, 1, NOW(), NOW(), NOW()
 WHERE NOT EXISTS (SELECT 1 FROM cm_programs WHERE id = 2);
 
 -- Program 3: 데이터 분석 with Python
-INSERT INTO cm_programs (id, tenant_id, version, title, description, thumbnail_url, level, type, estimated_hours, status, created_by, creator_id, approved_by, approved_at, created_at, updated_at)
+INSERT INTO cm_programs (id, tenant_id, version, title, description, thumbnail_url, level, type, estimated_hours, status, created_by, approved_by, approved_at, created_at, updated_at)
 SELECT 3, 1, 0, '데이터 분석 with Python',
        'Pandas, NumPy, Matplotlib를 활용한 데이터 분석 기초부터 실무까지. 실제 데이터셋으로 분석 프로젝트를 진행합니다.',
        'https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=400&h=250&fit=crop',
-       'BEGINNER', 'ONLINE', 24, 'APPROVED', 1, 1, 1, NOW(), NOW(), NOW()
+       'BEGINNER', 'ONLINE', 24, 'APPROVED', 1, 1, NOW(), NOW(), NOW()
 WHERE NOT EXISTS (SELECT 1 FROM cm_programs WHERE id = 3);
 
 -- Program 4: Figma 마스터 클래스
-INSERT INTO cm_programs (id, tenant_id, version, title, description, thumbnail_url, level, type, estimated_hours, status, created_by, creator_id, approved_by, approved_at, created_at, updated_at)
+INSERT INTO cm_programs (id, tenant_id, version, title, description, thumbnail_url, level, type, estimated_hours, status, created_by, approved_by, approved_at, created_at, updated_at)
 SELECT 4, 1, 0, 'Figma 마스터 클래스',
        'UI/UX 디자인 도구 Figma의 기초부터 고급 기능까지. 컴포넌트, 프로토타이핑, 디자인 시스템을 배웁니다.',
        'https://images.unsplash.com/photo-1561070791-2526d30994b5?w=400&h=250&fit=crop',
-       'BEGINNER', 'ONLINE', 18, 'APPROVED', 1, 1, 1, NOW(), NOW(), NOW()
+       'BEGINNER', 'ONLINE', 18, 'APPROVED', 1, 1, NOW(), NOW(), NOW()
 WHERE NOT EXISTS (SELECT 1 FROM cm_programs WHERE id = 4);
 
 -- Program 5: AWS 클라우드 실무
-INSERT INTO cm_programs (id, tenant_id, version, title, description, thumbnail_url, level, type, estimated_hours, status, created_by, creator_id, approved_by, approved_at, created_at, updated_at)
+INSERT INTO cm_programs (id, tenant_id, version, title, description, thumbnail_url, level, type, estimated_hours, status, created_by, approved_by, approved_at, created_at, updated_at)
 SELECT 5, 1, 0, 'AWS 클라우드 실무',
        'EC2, S3, Lambda, RDS 등 AWS 핵심 서비스를 실습합니다. 실제 서비스 배포까지 경험해봅니다.',
        'https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=400&h=250&fit=crop',
-       'ADVANCED', 'ONLINE', 30, 'APPROVED', 1, 1, 1, NOW(), NOW(), NOW()
+       'ADVANCED', 'ONLINE', 30, 'APPROVED', 1, 1, NOW(), NOW(), NOW()
 WHERE NOT EXISTS (SELECT 1 FROM cm_programs WHERE id = 5);
 
 -- Program 6: Spring Boot 3.0 실전
-INSERT INTO cm_programs (id, tenant_id, version, title, description, thumbnail_url, level, type, estimated_hours, status, created_by, creator_id, approved_by, approved_at, created_at, updated_at)
+INSERT INTO cm_programs (id, tenant_id, version, title, description, thumbnail_url, level, type, estimated_hours, status, created_by, approved_by, approved_at, created_at, updated_at)
 SELECT 6, 1, 0, 'Spring Boot 3.0 실전',
        'Spring Boot 3.0의 새로운 기능과 함께 RESTful API를 구축합니다. JPA, Security, 테스트 코드까지.',
        'https://images.unsplash.com/photo-1517694712202-14dd9538aa97?w=400&h=250&fit=crop',
-       'INTERMEDIATE', 'ONLINE', 35, 'APPROVED', 1, 1, 1, NOW(), NOW(), NOW()
+       'INTERMEDIATE', 'ONLINE', 35, 'APPROVED', 1, 1, NOW(), NOW(), NOW()
 WHERE NOT EXISTS (SELECT 1 FROM cm_programs WHERE id = 6);


### PR DESCRIPTION
## Summary

찜(Wishlist) 및 장바구니(Cart) API를 Course 기반에서 CourseTime(차수) 기반으로 변경하고, 레거시 DB 컬럼으로 인한 오류를 수정했습니다.

## Related Issue

- Closes #255

## Changes

- 찜/장바구니 Entity를 `courseId` 대신 `courseTimeId` 기반으로 변경
- 찜/장바구니 응답에 가격 정보(price, isFree) 추가
- data.sql에서 `cm_wishlist_items`, `cart_items` 테이블 재생성 로직 추가 (레거시 `course_id` 컬럼 제거)

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 기존 DB에 레거시 `course_id` 컬럼이 남아있어 INSERT 시 오류 발생