### PR TITLE
feat(ta): 자동 수강신청 규칙 관리 API 추가

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -148,7 +148,13 @@ public enum ErrorCode {
     // Employee (EMP)
     EMPLOYEE_NOT_FOUND(HttpStatus.NOT_FOUND, "EMP001", "Employee not found"),
     EMPLOYEE_NUMBER_DUPLICATE(HttpStatus.CONFLICT, "EMP002", "Employee number already exists"),
-    EMPLOYEE_USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "EMP003", "User is already registered as employee");
+    EMPLOYEE_USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "EMP003", "User is already registered as employee"),
+
+    // Banner (BNR)
+    BANNER_NOT_FOUND(HttpStatus.NOT_FOUND, "BNR001", "Banner not found"),
+
+    // Auto Enrollment Rule (AER)
+    AUTO_ENROLLMENT_RULE_NOT_FOUND(HttpStatus.NOT_FOUND, "AER001", "Auto enrollment rule not found");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/mzc/lp/domain/enrollment/constant/AutoEnrollmentTrigger.java
+++ b/src/main/java/com/mzc/lp/domain/enrollment/constant/AutoEnrollmentTrigger.java
@@ -1,0 +1,7 @@
+package com.mzc.lp.domain.enrollment.constant;
+
+public enum AutoEnrollmentTrigger {
+    USER_JOIN,           // 사용자 가입 시
+    DEPARTMENT_ASSIGN,   // 부서 배정 시
+    ROLE_CHANGE          // 역할 변경 시
+}

--- a/src/main/java/com/mzc/lp/domain/enrollment/controller/AutoEnrollmentRuleController.java
+++ b/src/main/java/com/mzc/lp/domain/enrollment/controller/AutoEnrollmentRuleController.java
@@ -1,0 +1,116 @@
+package com.mzc.lp.domain.enrollment.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.enrollment.constant.AutoEnrollmentTrigger;
+import com.mzc.lp.domain.enrollment.dto.request.CreateAutoEnrollmentRuleRequest;
+import com.mzc.lp.domain.enrollment.dto.request.UpdateAutoEnrollmentRuleRequest;
+import com.mzc.lp.domain.enrollment.dto.response.AutoEnrollmentRuleResponse;
+import com.mzc.lp.domain.enrollment.service.AutoEnrollmentRuleService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/auto-enrollment-rules")
+@RequiredArgsConstructor
+@Validated
+public class AutoEnrollmentRuleController {
+
+    private final AutoEnrollmentRuleService autoEnrollmentRuleService;
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<AutoEnrollmentRuleResponse>>> getAll(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<AutoEnrollmentRuleResponse> response = autoEnrollmentRuleService.getAll(principal.tenantId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/active")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<AutoEnrollmentRuleResponse>>> getActiveRules(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<AutoEnrollmentRuleResponse> response = autoEnrollmentRuleService.getActiveRules(principal.tenantId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/trigger/{trigger}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<AutoEnrollmentRuleResponse>>> getByTrigger(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable AutoEnrollmentTrigger trigger
+    ) {
+        List<AutoEnrollmentRuleResponse> response = autoEnrollmentRuleService.getByTrigger(principal.tenantId(), trigger);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{ruleId}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<AutoEnrollmentRuleResponse>> getById(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long ruleId
+    ) {
+        AutoEnrollmentRuleResponse response = autoEnrollmentRuleService.getById(principal.tenantId(), ruleId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<AutoEnrollmentRuleResponse>> create(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody CreateAutoEnrollmentRuleRequest request
+    ) {
+        AutoEnrollmentRuleResponse response = autoEnrollmentRuleService.create(principal.tenantId(), request);
+        return ResponseEntity.status(201).body(ApiResponse.success(response));
+    }
+
+    @PutMapping("/{ruleId}")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<AutoEnrollmentRuleResponse>> update(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long ruleId,
+            @Valid @RequestBody UpdateAutoEnrollmentRuleRequest request
+    ) {
+        AutoEnrollmentRuleResponse response = autoEnrollmentRuleService.update(principal.tenantId(), ruleId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/{ruleId}")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long ruleId
+    ) {
+        autoEnrollmentRuleService.delete(principal.tenantId(), ruleId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{ruleId}/activate")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<AutoEnrollmentRuleResponse>> activate(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long ruleId
+    ) {
+        AutoEnrollmentRuleResponse response = autoEnrollmentRuleService.activate(principal.tenantId(), ruleId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/{ruleId}/deactivate")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<AutoEnrollmentRuleResponse>> deactivate(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long ruleId
+    ) {
+        AutoEnrollmentRuleResponse response = autoEnrollmentRuleService.deactivate(principal.tenantId(), ruleId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/enrollment/dto/request/CreateAutoEnrollmentRuleRequest.java
+++ b/src/main/java/com/mzc/lp/domain/enrollment/dto/request/CreateAutoEnrollmentRuleRequest.java
@@ -1,0 +1,25 @@
+package com.mzc.lp.domain.enrollment.dto.request;
+
+import com.mzc.lp.domain.enrollment.constant.AutoEnrollmentTrigger;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateAutoEnrollmentRuleRequest(
+        @NotBlank(message = "규칙 이름은 필수입니다")
+        @Size(max = 200, message = "규칙 이름은 200자 이하여야 합니다")
+        String name,
+
+        @Size(max = 500, message = "설명은 500자 이하여야 합니다")
+        String description,
+
+        @NotNull(message = "트리거 타입은 필수입니다")
+        AutoEnrollmentTrigger trigger,
+
+        Long departmentId,
+
+        @NotNull(message = "과정 회차 ID는 필수입니다")
+        Long courseTimeId,
+
+        Integer sortOrder
+) {}

--- a/src/main/java/com/mzc/lp/domain/enrollment/dto/request/UpdateAutoEnrollmentRuleRequest.java
+++ b/src/main/java/com/mzc/lp/domain/enrollment/dto/request/UpdateAutoEnrollmentRuleRequest.java
@@ -1,0 +1,20 @@
+package com.mzc.lp.domain.enrollment.dto.request;
+
+import com.mzc.lp.domain.enrollment.constant.AutoEnrollmentTrigger;
+import jakarta.validation.constraints.Size;
+
+public record UpdateAutoEnrollmentRuleRequest(
+        @Size(max = 200, message = "규칙 이름은 200자 이하여야 합니다")
+        String name,
+
+        @Size(max = 500, message = "설명은 500자 이하여야 합니다")
+        String description,
+
+        AutoEnrollmentTrigger trigger,
+
+        Long departmentId,
+
+        Long courseTimeId,
+
+        Integer sortOrder
+) {}

--- a/src/main/java/com/mzc/lp/domain/enrollment/dto/response/AutoEnrollmentRuleResponse.java
+++ b/src/main/java/com/mzc/lp/domain/enrollment/dto/response/AutoEnrollmentRuleResponse.java
@@ -1,0 +1,44 @@
+package com.mzc.lp.domain.enrollment.dto.response;
+
+import com.mzc.lp.domain.enrollment.constant.AutoEnrollmentTrigger;
+import com.mzc.lp.domain.enrollment.entity.AutoEnrollmentRule;
+
+import java.time.Instant;
+
+public record AutoEnrollmentRuleResponse(
+        Long id,
+        String name,
+        String description,
+        AutoEnrollmentTrigger trigger,
+        Long departmentId,
+        String departmentName,
+        Long courseTimeId,
+        String courseTimeTitle,
+        Boolean isActive,
+        Integer sortOrder,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static AutoEnrollmentRuleResponse from(AutoEnrollmentRule rule) {
+        return from(rule, null, null);
+    }
+
+    public static AutoEnrollmentRuleResponse from(AutoEnrollmentRule rule,
+                                                   String departmentName,
+                                                   String courseTimeTitle) {
+        return new AutoEnrollmentRuleResponse(
+                rule.getId(),
+                rule.getName(),
+                rule.getDescription(),
+                rule.getTrigger(),
+                rule.getDepartmentId(),
+                departmentName,
+                rule.getCourseTimeId(),
+                courseTimeTitle,
+                rule.getIsActive(),
+                rule.getSortOrder(),
+                rule.getCreatedAt(),
+                rule.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/enrollment/entity/AutoEnrollmentRule.java
+++ b/src/main/java/com/mzc/lp/domain/enrollment/entity/AutoEnrollmentRule.java
@@ -1,0 +1,80 @@
+package com.mzc.lp.domain.enrollment.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import com.mzc.lp.domain.enrollment.constant.AutoEnrollmentTrigger;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "auto_enrollment_rules")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AutoEnrollmentRule extends TenantEntity {
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    @Column(length = 500)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private AutoEnrollmentTrigger trigger;
+
+    @Column(name = "department_id")
+    private Long departmentId;
+
+    @Column(name = "course_time_id", nullable = false)
+    private Long courseTimeId;
+
+    @Column(name = "is_active")
+    private Boolean isActive = true;
+
+    @Column(name = "sort_order")
+    private Integer sortOrder = 0;
+
+    // 정적 팩토리 메서드
+    public static AutoEnrollmentRule create(String name, AutoEnrollmentTrigger trigger, Long courseTimeId) {
+        AutoEnrollmentRule rule = new AutoEnrollmentRule();
+        rule.name = name;
+        rule.trigger = trigger;
+        rule.courseTimeId = courseTimeId;
+        return rule;
+    }
+
+    public static AutoEnrollmentRule createForDepartment(String name, Long departmentId, Long courseTimeId) {
+        AutoEnrollmentRule rule = create(name, AutoEnrollmentTrigger.DEPARTMENT_ASSIGN, courseTimeId);
+        rule.departmentId = departmentId;
+        return rule;
+    }
+
+    // 비즈니스 메서드
+    public void update(String name, String description, AutoEnrollmentTrigger trigger,
+                       Long departmentId, Long courseTimeId) {
+        if (name != null && !name.isBlank()) {
+            this.name = name;
+        }
+        this.description = description;
+        if (trigger != null) {
+            this.trigger = trigger;
+        }
+        this.departmentId = departmentId;
+        if (courseTimeId != null) {
+            this.courseTimeId = courseTimeId;
+        }
+    }
+
+    public void setSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder != null ? sortOrder : 0;
+    }
+
+    public void activate() {
+        this.isActive = true;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/enrollment/exception/AutoEnrollmentRuleNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/enrollment/exception/AutoEnrollmentRuleNotFoundException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.enrollment.exception;
+
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.common.constant.ErrorCode;
+
+public class AutoEnrollmentRuleNotFoundException extends BusinessException {
+
+    public AutoEnrollmentRuleNotFoundException() {
+        super(ErrorCode.AUTO_ENROLLMENT_RULE_NOT_FOUND);
+    }
+
+    public AutoEnrollmentRuleNotFoundException(Long ruleId) {
+        super(ErrorCode.AUTO_ENROLLMENT_RULE_NOT_FOUND, "자동 수강신청 규칙을 찾을 수 없습니다. ID: " + ruleId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/enrollment/repository/AutoEnrollmentRuleRepository.java
+++ b/src/main/java/com/mzc/lp/domain/enrollment/repository/AutoEnrollmentRuleRepository.java
@@ -1,0 +1,25 @@
+package com.mzc.lp.domain.enrollment.repository;
+
+import com.mzc.lp.domain.enrollment.constant.AutoEnrollmentTrigger;
+import com.mzc.lp.domain.enrollment.entity.AutoEnrollmentRule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AutoEnrollmentRuleRepository extends JpaRepository<AutoEnrollmentRule, Long> {
+
+    List<AutoEnrollmentRule> findByTenantIdOrderBySortOrderAsc(Long tenantId);
+
+    List<AutoEnrollmentRule> findByTenantIdAndIsActiveTrueOrderBySortOrderAsc(Long tenantId);
+
+    List<AutoEnrollmentRule> findByTenantIdAndTriggerOrderBySortOrderAsc(Long tenantId, AutoEnrollmentTrigger trigger);
+
+    List<AutoEnrollmentRule> findByTenantIdAndTriggerAndIsActiveTrueOrderBySortOrderAsc(
+            Long tenantId, AutoEnrollmentTrigger trigger);
+
+    List<AutoEnrollmentRule> findByTenantIdAndDepartmentIdAndIsActiveTrueOrderBySortOrderAsc(
+            Long tenantId, Long departmentId);
+
+    Optional<AutoEnrollmentRule> findByIdAndTenantId(Long id, Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/enrollment/service/AutoEnrollmentRuleService.java
+++ b/src/main/java/com/mzc/lp/domain/enrollment/service/AutoEnrollmentRuleService.java
@@ -1,0 +1,29 @@
+package com.mzc.lp.domain.enrollment.service;
+
+import com.mzc.lp.domain.enrollment.constant.AutoEnrollmentTrigger;
+import com.mzc.lp.domain.enrollment.dto.request.CreateAutoEnrollmentRuleRequest;
+import com.mzc.lp.domain.enrollment.dto.request.UpdateAutoEnrollmentRuleRequest;
+import com.mzc.lp.domain.enrollment.dto.response.AutoEnrollmentRuleResponse;
+
+import java.util.List;
+
+public interface AutoEnrollmentRuleService {
+
+    AutoEnrollmentRuleResponse create(Long tenantId, CreateAutoEnrollmentRuleRequest request);
+
+    AutoEnrollmentRuleResponse update(Long tenantId, Long ruleId, UpdateAutoEnrollmentRuleRequest request);
+
+    void delete(Long tenantId, Long ruleId);
+
+    AutoEnrollmentRuleResponse getById(Long tenantId, Long ruleId);
+
+    List<AutoEnrollmentRuleResponse> getAll(Long tenantId);
+
+    List<AutoEnrollmentRuleResponse> getActiveRules(Long tenantId);
+
+    List<AutoEnrollmentRuleResponse> getByTrigger(Long tenantId, AutoEnrollmentTrigger trigger);
+
+    AutoEnrollmentRuleResponse activate(Long tenantId, Long ruleId);
+
+    AutoEnrollmentRuleResponse deactivate(Long tenantId, Long ruleId);
+}

--- a/src/main/java/com/mzc/lp/domain/enrollment/service/AutoEnrollmentRuleServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/enrollment/service/AutoEnrollmentRuleServiceImpl.java
@@ -1,0 +1,152 @@
+package com.mzc.lp.domain.enrollment.service;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.domain.enrollment.constant.AutoEnrollmentTrigger;
+import com.mzc.lp.domain.enrollment.dto.request.CreateAutoEnrollmentRuleRequest;
+import com.mzc.lp.domain.enrollment.dto.request.UpdateAutoEnrollmentRuleRequest;
+import com.mzc.lp.domain.enrollment.dto.response.AutoEnrollmentRuleResponse;
+import com.mzc.lp.domain.enrollment.entity.AutoEnrollmentRule;
+import com.mzc.lp.domain.enrollment.exception.AutoEnrollmentRuleNotFoundException;
+import com.mzc.lp.domain.enrollment.repository.AutoEnrollmentRuleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AutoEnrollmentRuleServiceImpl implements AutoEnrollmentRuleService {
+
+    private final AutoEnrollmentRuleRepository ruleRepository;
+
+    @Override
+    @Transactional
+    public AutoEnrollmentRuleResponse create(Long tenantId, CreateAutoEnrollmentRuleRequest request) {
+        log.info("Creating auto enrollment rule: tenantId={}, name={}, trigger={}",
+                tenantId, request.name(), request.trigger());
+
+        TenantContext.setTenantId(tenantId);
+
+        try {
+            AutoEnrollmentRule rule;
+            if (request.trigger() == AutoEnrollmentTrigger.DEPARTMENT_ASSIGN && request.departmentId() != null) {
+                rule = AutoEnrollmentRule.createForDepartment(
+                        request.name(),
+                        request.departmentId(),
+                        request.courseTimeId()
+                );
+            } else {
+                rule = AutoEnrollmentRule.create(
+                        request.name(),
+                        request.trigger(),
+                        request.courseTimeId()
+                );
+            }
+
+            rule.update(null, request.description(), null, request.departmentId(), null);
+
+            if (request.sortOrder() != null) {
+                rule.setSortOrder(request.sortOrder());
+            }
+
+            AutoEnrollmentRule saved = ruleRepository.save(rule);
+            return AutoEnrollmentRuleResponse.from(saved);
+        } finally {
+            TenantContext.clear();
+        }
+    }
+
+    @Override
+    @Transactional
+    public AutoEnrollmentRuleResponse update(Long tenantId, Long ruleId, UpdateAutoEnrollmentRuleRequest request) {
+        log.info("Updating auto enrollment rule: tenantId={}, ruleId={}", tenantId, ruleId);
+
+        AutoEnrollmentRule rule = ruleRepository.findByIdAndTenantId(ruleId, tenantId)
+                .orElseThrow(() -> new AutoEnrollmentRuleNotFoundException(ruleId));
+
+        rule.update(
+                request.name(),
+                request.description(),
+                request.trigger(),
+                request.departmentId(),
+                request.courseTimeId()
+        );
+
+        if (request.sortOrder() != null) {
+            rule.setSortOrder(request.sortOrder());
+        }
+
+        return AutoEnrollmentRuleResponse.from(rule);
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long tenantId, Long ruleId) {
+        log.info("Deleting auto enrollment rule: tenantId={}, ruleId={}", tenantId, ruleId);
+
+        AutoEnrollmentRule rule = ruleRepository.findByIdAndTenantId(ruleId, tenantId)
+                .orElseThrow(() -> new AutoEnrollmentRuleNotFoundException(ruleId));
+
+        ruleRepository.delete(rule);
+    }
+
+    @Override
+    public AutoEnrollmentRuleResponse getById(Long tenantId, Long ruleId) {
+        AutoEnrollmentRule rule = ruleRepository.findByIdAndTenantId(ruleId, tenantId)
+                .orElseThrow(() -> new AutoEnrollmentRuleNotFoundException(ruleId));
+
+        return AutoEnrollmentRuleResponse.from(rule);
+    }
+
+    @Override
+    public List<AutoEnrollmentRuleResponse> getAll(Long tenantId) {
+        return ruleRepository.findByTenantIdOrderBySortOrderAsc(tenantId)
+                .stream()
+                .map(AutoEnrollmentRuleResponse::from)
+                .toList();
+    }
+
+    @Override
+    public List<AutoEnrollmentRuleResponse> getActiveRules(Long tenantId) {
+        return ruleRepository.findByTenantIdAndIsActiveTrueOrderBySortOrderAsc(tenantId)
+                .stream()
+                .map(AutoEnrollmentRuleResponse::from)
+                .toList();
+    }
+
+    @Override
+    public List<AutoEnrollmentRuleResponse> getByTrigger(Long tenantId, AutoEnrollmentTrigger trigger) {
+        return ruleRepository.findByTenantIdAndTriggerOrderBySortOrderAsc(tenantId, trigger)
+                .stream()
+                .map(AutoEnrollmentRuleResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public AutoEnrollmentRuleResponse activate(Long tenantId, Long ruleId) {
+        log.info("Activating auto enrollment rule: tenantId={}, ruleId={}", tenantId, ruleId);
+
+        AutoEnrollmentRule rule = ruleRepository.findByIdAndTenantId(ruleId, tenantId)
+                .orElseThrow(() -> new AutoEnrollmentRuleNotFoundException(ruleId));
+
+        rule.activate();
+        return AutoEnrollmentRuleResponse.from(rule);
+    }
+
+    @Override
+    @Transactional
+    public AutoEnrollmentRuleResponse deactivate(Long tenantId, Long ruleId) {
+        log.info("Deactivating auto enrollment rule: tenantId={}, ruleId={}", tenantId, ruleId);
+
+        AutoEnrollmentRule rule = ruleRepository.findByIdAndTenantId(ruleId, tenantId)
+                .orElseThrow(() -> new AutoEnrollmentRuleNotFoundException(ruleId));
+
+        rule.deactivate();
+        return AutoEnrollmentRuleResponse.from(rule);
+    }
+}


### PR DESCRIPTION
## Summary

자동 수강신청 규칙 관리 API 구현 (Tenant Admin 기능)

## Related Issue

- Closes #288

## Changes

- `AutoEnrollmentTrigger` enum 추가 (USER_JOIN, DEPARTMENT_ASSIGN, ROLE_CHANGE)
- `AutoEnrollmentRule` 엔티티 및 Repository 구현
- 자동 수강신청 규칙 CRUD API 구현
- 규칙 활성화/비활성화 기능 구현
- `AUTO_ENROLLMENT_RULE_NOT_FOUND` 에러 코드 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/auto-enrollment-rules` | 전체 규칙 조회 |
| GET | `/api/auto-enrollment-rules/active` | 활성 규칙 조회 |
| GET | `/api/auto-enrollment-rules/trigger/{trigger}` | 트리거별 조회 |
| GET | `/api/auto-enrollment-rules/{ruleId}` | 단건 조회 |
| POST | `/api/auto-enrollment-rules` | 규칙 생성 |
| PUT | `/api/auto-enrollment-rules/{ruleId}` | 규칙 수정 |
| DELETE | `/api/auto-enrollment-rules/{ruleId}` | 규칙 삭제 |
| POST | `/api/auto-enrollment-rules/{ruleId}/activate` | 활성화 |
| POST | `/api/auto-enrollment-rules/{ruleId}/deactivate` | 비활성화 |

## Additional Notes

- 트리거 타입: 사용자 가입 시(USER_JOIN), 부서 배정 시(DEPARTMENT_ASSIGN), 역할 변경 시(ROLE_CHANGE)
- TENANT_ADMIN 권한 필요 (조회는 OPERATOR도 가능)
