### PR TITLE
feat: CertificateTemplate 엔티티 및 관리 기능 구현

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -138,6 +138,8 @@ public enum ErrorCode {
     CERTIFICATE_NOT_FOUND(HttpStatus.NOT_FOUND, "CERT001", "Certificate not found"),
     CERTIFICATE_ALREADY_ISSUED(HttpStatus.CONFLICT, "CERT002", "Certificate already issued for this enrollment"),
     CERTIFICATE_REVOKED(HttpStatus.BAD_REQUEST, "CERT003", "Certificate has been revoked"),
+    CERTIFICATE_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, "CERT004", "Certificate template not found"),
+    CERTIFICATE_TEMPLATE_CODE_DUPLICATE(HttpStatus.CONFLICT, "CERT005", "Certificate template code already exists"),
 
     // Department (DEPT)
     DEPARTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "DEPT001", "Department not found"),

--- a/src/main/java/com/mzc/lp/domain/certificate/constant/CertificateStatus.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/constant/CertificateStatus.java
@@ -4,6 +4,8 @@ package com.mzc.lp.domain.certificate.constant;
  * 수료증 상태
  */
 public enum CertificateStatus {
-    ISSUED,     // 발급됨 (유효)
+    ISSUED,     // 발급됨 (초기 상태, VALID와 동일)
+    VALID,      // 유효함
+    EXPIRED,    // 만료됨 (유효 기간 초과)
     REVOKED     // 폐기됨 (무효)
 }

--- a/src/main/java/com/mzc/lp/domain/certificate/controller/CertificateTemplateController.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/controller/CertificateTemplateController.java
@@ -1,0 +1,138 @@
+package com.mzc.lp.domain.certificate.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.certificate.dto.request.CertificateTemplateCreateRequest;
+import com.mzc.lp.domain.certificate.dto.request.CertificateTemplateUpdateRequest;
+import com.mzc.lp.domain.certificate.dto.response.CertificateTemplateResponse;
+import com.mzc.lp.domain.certificate.service.CertificateTemplateService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/certificate-templates")
+@RequiredArgsConstructor
+public class CertificateTemplateController {
+
+    private final CertificateTemplateService certificateTemplateService;
+
+    /**
+     * 템플릿 생성
+     * POST /api/certificate-templates
+     */
+    @PostMapping
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CertificateTemplateResponse>> createTemplate(
+            @Valid @RequestBody CertificateTemplateCreateRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CertificateTemplateResponse response = certificateTemplateService.createTemplate(request, principal.id());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
+    }
+
+    /**
+     * 템플릿 목록 조회
+     * GET /api/certificate-templates
+     */
+    @GetMapping
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<Page<CertificateTemplateResponse>>> getTemplates(
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<CertificateTemplateResponse> response = certificateTemplateService.getTemplates(pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 활성 템플릿 목록 조회
+     * GET /api/certificate-templates/active
+     */
+    @GetMapping("/active")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<CertificateTemplateResponse>>> getActiveTemplates() {
+        List<CertificateTemplateResponse> response = certificateTemplateService.getActiveTemplates();
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 템플릿 상세 조회
+     * GET /api/certificate-templates/{id}
+     */
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CertificateTemplateResponse>> getTemplate(
+            @PathVariable Long id
+    ) {
+        CertificateTemplateResponse response = certificateTemplateService.getTemplate(id);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 템플릿 수정
+     * PUT /api/certificate-templates/{id}
+     */
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CertificateTemplateResponse>> updateTemplate(
+            @PathVariable Long id,
+            @Valid @RequestBody CertificateTemplateUpdateRequest request
+    ) {
+        CertificateTemplateResponse response = certificateTemplateService.updateTemplate(id, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 기본 템플릿으로 설정
+     * POST /api/certificate-templates/{id}/set-default
+     */
+    @PostMapping("/{id}/set-default")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> setAsDefault(@PathVariable Long id) {
+        certificateTemplateService.setAsDefault(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 템플릿 활성화
+     * POST /api/certificate-templates/{id}/activate
+     */
+    @PostMapping("/{id}/activate")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> activateTemplate(@PathVariable Long id) {
+        certificateTemplateService.activateTemplate(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 템플릿 비활성화
+     * POST /api/certificate-templates/{id}/deactivate
+     */
+    @PostMapping("/{id}/deactivate")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> deactivateTemplate(@PathVariable Long id) {
+        certificateTemplateService.deactivateTemplate(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 템플릿 삭제
+     * DELETE /api/certificate-templates/{id}
+     */
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> deleteTemplate(@PathVariable Long id) {
+        certificateTemplateService.deleteTemplate(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/dto/request/CertificateTemplateCreateRequest.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/dto/request/CertificateTemplateCreateRequest.java
@@ -1,0 +1,29 @@
+package com.mzc.lp.domain.certificate.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CertificateTemplateCreateRequest(
+        @NotBlank(message = "템플릿 코드는 필수입니다")
+        @Size(max = 50, message = "템플릿 코드는 50자를 초과할 수 없습니다")
+        String templateCode,
+
+        @NotBlank(message = "템플릿 제목은 필수입니다")
+        @Size(max = 200, message = "템플릿 제목은 200자를 초과할 수 없습니다")
+        String title,
+
+        String description,
+
+        @Size(max = 500, message = "배경 이미지 URL은 500자를 초과할 수 없습니다")
+        String backgroundImageUrl,
+
+        @Size(max = 500, message = "서명 이미지 URL은 500자를 초과할 수 없습니다")
+        String signatureImageUrl,
+
+        String certificateBodyHtml,
+
+        Integer validityMonths,
+
+        Boolean isDefault
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/dto/request/CertificateTemplateUpdateRequest.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/dto/request/CertificateTemplateUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.mzc.lp.domain.certificate.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CertificateTemplateUpdateRequest(
+        @NotBlank(message = "템플릿 제목은 필수입니다")
+        @Size(max = 200, message = "템플릿 제목은 200자를 초과할 수 없습니다")
+        String title,
+
+        String description,
+
+        @Size(max = 500, message = "배경 이미지 URL은 500자를 초과할 수 없습니다")
+        String backgroundImageUrl,
+
+        @Size(max = 500, message = "서명 이미지 URL은 500자를 초과할 수 없습니다")
+        String signatureImageUrl,
+
+        String certificateBodyHtml,
+
+        Integer validityMonths
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/dto/response/CertificateTemplateResponse.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/dto/response/CertificateTemplateResponse.java
@@ -1,0 +1,37 @@
+package com.mzc.lp.domain.certificate.dto.response;
+
+import com.mzc.lp.domain.certificate.entity.CertificateTemplate;
+
+import java.time.Instant;
+
+public record CertificateTemplateResponse(
+        Long id,
+        String templateCode,
+        String title,
+        String description,
+        String backgroundImageUrl,
+        String signatureImageUrl,
+        String certificateBodyHtml,
+        Integer validityMonths,
+        boolean isDefault,
+        boolean isActive,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static CertificateTemplateResponse from(CertificateTemplate template) {
+        return new CertificateTemplateResponse(
+                template.getId(),
+                template.getTemplateCode(),
+                template.getTitle(),
+                template.getDescription(),
+                template.getBackgroundImageUrl(),
+                template.getSignatureImageUrl(),
+                template.getCertificateBodyHtml(),
+                template.getValidityMonths(),
+                template.isDefault(),
+                template.isActive(),
+                template.getCreatedAt(),
+                template.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/entity/Certificate.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/entity/Certificate.java
@@ -24,7 +24,8 @@ import java.time.Instant;
         indexes = {
                 @Index(name = "idx_certificate_user", columnList = "tenant_id, user_id"),
                 @Index(name = "idx_certificate_status", columnList = "tenant_id, status"),
-                @Index(name = "idx_certificate_issued_at", columnList = "tenant_id, issued_at")
+                @Index(name = "idx_certificate_issued_at", columnList = "tenant_id, issued_at"),
+                @Index(name = "idx_certificate_template", columnList = "tenant_id, template_id")
         }
 )
 @Getter
@@ -36,6 +37,10 @@ public class Certificate extends TenantEntity {
 
     @Column(name = "certificate_number", nullable = false, length = 50)
     private String certificateNumber;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "template_id")
+    private CertificateTemplate template;
 
     @Column(name = "user_id", nullable = false)
     private Long userId;
@@ -63,6 +68,9 @@ public class Certificate extends TenantEntity {
 
     @Column(name = "issued_at", nullable = false)
     private Instant issuedAt;
+
+    @Column(name = "expires_at")
+    private Instant expiresAt;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
@@ -100,17 +108,93 @@ public class Certificate extends TenantEntity {
         return certificate;
     }
 
+    public static Certificate createWithTemplate(
+            String certificateNumber,
+            CertificateTemplate template,
+            Long userId,
+            String userName,
+            Long enrollmentId,
+            Long courseTimeId,
+            String courseTimeTitle,
+            Long programId,
+            String programTitle,
+            Instant completedAt
+    ) {
+        Certificate certificate = new Certificate();
+        certificate.certificateNumber = certificateNumber;
+        certificate.template = template;
+        certificate.userId = userId;
+        certificate.userName = userName;
+        certificate.enrollmentId = enrollmentId;
+        certificate.courseTimeId = courseTimeId;
+        certificate.courseTimeTitle = courseTimeTitle;
+        certificate.programId = programId;
+        certificate.programTitle = programTitle;
+        certificate.completedAt = completedAt;
+        certificate.issuedAt = Instant.now();
+        certificate.status = CertificateStatus.ISSUED;
+
+        // 템플릿에 유효 기간이 설정되어 있으면 만료일 계산
+        if (template != null && template.getValidityMonths() != null) {
+            certificate.expiresAt = certificate.issuedAt
+                    .atZone(java.time.ZoneId.systemDefault())
+                    .plusMonths(template.getValidityMonths())
+                    .toInstant();
+        }
+
+        return certificate;
+    }
+
     public void revoke(String reason) {
         this.status = CertificateStatus.REVOKED;
         this.revokedAt = Instant.now();
         this.revokedReason = reason;
     }
 
+    public void expire() {
+        this.status = CertificateStatus.EXPIRED;
+    }
+
+    public void linkTemplate(CertificateTemplate template) {
+        this.template = template;
+        if (template != null && template.getValidityMonths() != null) {
+            this.expiresAt = this.issuedAt
+                    .atZone(java.time.ZoneId.systemDefault())
+                    .plusMonths(template.getValidityMonths())
+                    .toInstant();
+        }
+    }
+
+    /**
+     * 수료증이 유효한지 확인
+     * - 발급됨 또는 유효 상태
+     * - 만료되지 않음
+     */
     public boolean isValid() {
-        return this.status == CertificateStatus.ISSUED;
+        if (this.status == CertificateStatus.REVOKED || this.status == CertificateStatus.EXPIRED) {
+            return false;
+        }
+        if (this.expiresAt != null && Instant.now().isAfter(this.expiresAt)) {
+            return false;
+        }
+        return this.status == CertificateStatus.ISSUED || this.status == CertificateStatus.VALID;
     }
 
     public boolean isRevoked() {
         return this.status == CertificateStatus.REVOKED;
+    }
+
+    public boolean isExpired() {
+        if (this.status == CertificateStatus.EXPIRED) {
+            return true;
+        }
+        return this.expiresAt != null && Instant.now().isAfter(this.expiresAt);
+    }
+
+    /**
+     * 만료일이 무기한인지 확인
+     */
+    public boolean hasUnlimitedValidity() {
+        return this.expiresAt == null;
     }
 }

--- a/src/main/java/com/mzc/lp/domain/certificate/entity/CertificateTemplate.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/entity/CertificateTemplate.java
@@ -1,0 +1,139 @@
+package com.mzc.lp.domain.certificate.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 수료증 템플릿 엔티티
+ * 수료증의 디자인 및 레이아웃 정보를 관리
+ */
+@Entity
+@Table(name = "certificate_templates",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_certificate_template_code",
+                        columnNames = {"tenant_id", "template_code"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_certificate_template_active", columnList = "tenant_id, is_active"),
+                @Index(name = "idx_certificate_template_default", columnList = "tenant_id, is_default")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CertificateTemplate extends TenantEntity {
+
+    @Version
+    private Long version;
+
+    @Column(name = "template_code", nullable = false, length = 50)
+    private String templateCode;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "background_image_url", length = 500)
+    private String backgroundImageUrl;
+
+    @Column(name = "signature_image_url", length = 500)
+    private String signatureImageUrl;
+
+    @Column(name = "certificate_body_html", columnDefinition = "TEXT")
+    private String certificateBodyHtml;
+
+    /**
+     * 유효 기간 (월 단위)
+     * null이면 무기한 유효
+     */
+    @Column(name = "validity_months")
+    private Integer validityMonths;
+
+    @Column(name = "is_default", nullable = false)
+    private boolean isDefault;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive;
+
+    @Column(name = "created_by")
+    private Long createdBy;
+
+    // ===== 정적 팩토리 메서드 =====
+    public static CertificateTemplate create(
+            String templateCode,
+            String title,
+            String description,
+            Long createdBy
+    ) {
+        CertificateTemplate template = new CertificateTemplate();
+        template.templateCode = templateCode;
+        template.title = title;
+        template.description = description;
+        template.createdBy = createdBy;
+        template.isDefault = false;
+        template.isActive = true;
+        return template;
+    }
+
+    public static CertificateTemplate createDefault(
+            String templateCode,
+            String title,
+            String certificateBodyHtml,
+            Long createdBy
+    ) {
+        CertificateTemplate template = new CertificateTemplate();
+        template.templateCode = templateCode;
+        template.title = title;
+        template.certificateBodyHtml = certificateBodyHtml;
+        template.createdBy = createdBy;
+        template.isDefault = true;
+        template.isActive = true;
+        return template;
+    }
+
+    // ===== 비즈니스 메서드 =====
+    public void update(
+            String title,
+            String description,
+            String backgroundImageUrl,
+            String signatureImageUrl,
+            String certificateBodyHtml,
+            Integer validityMonths
+    ) {
+        this.title = title;
+        this.description = description;
+        this.backgroundImageUrl = backgroundImageUrl;
+        this.signatureImageUrl = signatureImageUrl;
+        this.certificateBodyHtml = certificateBodyHtml;
+        this.validityMonths = validityMonths;
+    }
+
+    public void setAsDefault() {
+        this.isDefault = true;
+    }
+
+    public void unsetDefault() {
+        this.isDefault = false;
+    }
+
+    public void activate() {
+        this.isActive = true;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    /**
+     * 유효 기간이 무기한인지 확인
+     */
+    public boolean hasUnlimitedValidity() {
+        return this.validityMonths == null;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/exception/CertificateTemplateCodeDuplicateException.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/exception/CertificateTemplateCodeDuplicateException.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.certificate.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class CertificateTemplateCodeDuplicateException extends BusinessException {
+
+    public CertificateTemplateCodeDuplicateException(String templateCode) {
+        super(ErrorCode.CERTIFICATE_TEMPLATE_CODE_DUPLICATE, "Template code already exists: " + templateCode);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/exception/CertificateTemplateNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/exception/CertificateTemplateNotFoundException.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.domain.certificate.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class CertificateTemplateNotFoundException extends BusinessException {
+
+    public CertificateTemplateNotFoundException() {
+        super(ErrorCode.CERTIFICATE_TEMPLATE_NOT_FOUND);
+    }
+
+    public CertificateTemplateNotFoundException(Long templateId) {
+        super(ErrorCode.CERTIFICATE_TEMPLATE_NOT_FOUND, "Certificate template not found with id: " + templateId);
+    }
+
+    public CertificateTemplateNotFoundException(String templateCode) {
+        super(ErrorCode.CERTIFICATE_TEMPLATE_NOT_FOUND, "Certificate template not found with code: " + templateCode);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/repository/CertificateTemplateRepository.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/repository/CertificateTemplateRepository.java
@@ -1,0 +1,35 @@
+package com.mzc.lp.domain.certificate.repository;
+
+import com.mzc.lp.domain.certificate.entity.CertificateTemplate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CertificateTemplateRepository extends JpaRepository<CertificateTemplate, Long> {
+
+    Optional<CertificateTemplate> findByIdAndTenantId(Long id, Long tenantId);
+
+    Optional<CertificateTemplate> findByTemplateCodeAndTenantId(String templateCode, Long tenantId);
+
+    Page<CertificateTemplate> findByTenantIdOrderByCreatedAtDesc(Long tenantId, Pageable pageable);
+
+    Page<CertificateTemplate> findByTenantIdAndIsActiveOrderByCreatedAtDesc(Long tenantId, boolean isActive, Pageable pageable);
+
+    List<CertificateTemplate> findByTenantIdAndIsActiveTrue(Long tenantId);
+
+    Optional<CertificateTemplate> findByTenantIdAndIsDefaultTrue(Long tenantId);
+
+    boolean existsByTemplateCodeAndTenantId(String templateCode, Long tenantId);
+
+    @Query("SELECT t FROM CertificateTemplate t WHERE t.tenantId = :tenantId AND t.isDefault = true AND t.isActive = true")
+    Optional<CertificateTemplate> findDefaultActiveTemplate(@Param("tenantId") Long tenantId);
+
+    long countByTenantId(Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/service/CertificateTemplateService.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/service/CertificateTemplateService.java
@@ -1,0 +1,57 @@
+package com.mzc.lp.domain.certificate.service;
+
+import com.mzc.lp.domain.certificate.dto.request.CertificateTemplateCreateRequest;
+import com.mzc.lp.domain.certificate.dto.request.CertificateTemplateUpdateRequest;
+import com.mzc.lp.domain.certificate.dto.response.CertificateTemplateResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface CertificateTemplateService {
+
+    /**
+     * 템플릿 생성
+     */
+    CertificateTemplateResponse createTemplate(CertificateTemplateCreateRequest request, Long createdBy);
+
+    /**
+     * 템플릿 목록 조회
+     */
+    Page<CertificateTemplateResponse> getTemplates(Pageable pageable);
+
+    /**
+     * 활성 템플릿 목록 조회
+     */
+    List<CertificateTemplateResponse> getActiveTemplates();
+
+    /**
+     * 템플릿 상세 조회
+     */
+    CertificateTemplateResponse getTemplate(Long templateId);
+
+    /**
+     * 템플릿 수정
+     */
+    CertificateTemplateResponse updateTemplate(Long templateId, CertificateTemplateUpdateRequest request);
+
+    /**
+     * 기본 템플릿으로 설정
+     */
+    void setAsDefault(Long templateId);
+
+    /**
+     * 템플릿 활성화
+     */
+    void activateTemplate(Long templateId);
+
+    /**
+     * 템플릿 비활성화
+     */
+    void deactivateTemplate(Long templateId);
+
+    /**
+     * 템플릿 삭제
+     */
+    void deleteTemplate(Long templateId);
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/service/CertificateTemplateServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/service/CertificateTemplateServiceImpl.java
@@ -1,0 +1,174 @@
+package com.mzc.lp.domain.certificate.service;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.domain.certificate.dto.request.CertificateTemplateCreateRequest;
+import com.mzc.lp.domain.certificate.dto.request.CertificateTemplateUpdateRequest;
+import com.mzc.lp.domain.certificate.dto.response.CertificateTemplateResponse;
+import com.mzc.lp.domain.certificate.entity.CertificateTemplate;
+import com.mzc.lp.domain.certificate.exception.CertificateTemplateCodeDuplicateException;
+import com.mzc.lp.domain.certificate.exception.CertificateTemplateNotFoundException;
+import com.mzc.lp.domain.certificate.repository.CertificateTemplateRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CertificateTemplateServiceImpl implements CertificateTemplateService {
+
+    private final CertificateTemplateRepository certificateTemplateRepository;
+
+    @Override
+    @Transactional
+    public CertificateTemplateResponse createTemplate(CertificateTemplateCreateRequest request, Long createdBy) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        log.info("Creating certificate template: code={}, tenantId={}", request.templateCode(), tenantId);
+
+        // 템플릿 코드 중복 체크
+        if (certificateTemplateRepository.existsByTemplateCodeAndTenantId(request.templateCode(), tenantId)) {
+            throw new CertificateTemplateCodeDuplicateException(request.templateCode());
+        }
+
+        CertificateTemplate template = CertificateTemplate.create(
+                request.templateCode(),
+                request.title(),
+                request.description(),
+                createdBy
+        );
+
+        // 추가 필드 설정
+        template.update(
+                request.title(),
+                request.description(),
+                request.backgroundImageUrl(),
+                request.signatureImageUrl(),
+                request.certificateBodyHtml(),
+                request.validityMonths()
+        );
+
+        // 기본 템플릿으로 설정 요청 시
+        if (Boolean.TRUE.equals(request.isDefault())) {
+            // 기존 기본 템플릿 해제
+            certificateTemplateRepository.findByTenantIdAndIsDefaultTrue(tenantId)
+                    .ifPresent(CertificateTemplate::unsetDefault);
+            template.setAsDefault();
+        }
+
+        CertificateTemplate saved = certificateTemplateRepository.save(template);
+        log.info("Certificate template created: id={}, code={}", saved.getId(), saved.getTemplateCode());
+
+        return CertificateTemplateResponse.from(saved);
+    }
+
+    @Override
+    public Page<CertificateTemplateResponse> getTemplates(Pageable pageable) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        return certificateTemplateRepository.findByTenantIdOrderByCreatedAtDesc(tenantId, pageable)
+                .map(CertificateTemplateResponse::from);
+    }
+
+    @Override
+    public List<CertificateTemplateResponse> getActiveTemplates() {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        return certificateTemplateRepository.findByTenantIdAndIsActiveTrue(tenantId).stream()
+                .map(CertificateTemplateResponse::from)
+                .toList();
+    }
+
+    @Override
+    public CertificateTemplateResponse getTemplate(Long templateId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        CertificateTemplate template = certificateTemplateRepository.findByIdAndTenantId(templateId, tenantId)
+                .orElseThrow(() -> new CertificateTemplateNotFoundException(templateId));
+        return CertificateTemplateResponse.from(template);
+    }
+
+    @Override
+    @Transactional
+    public CertificateTemplateResponse updateTemplate(Long templateId, CertificateTemplateUpdateRequest request) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        log.info("Updating certificate template: id={}, tenantId={}", templateId, tenantId);
+
+        CertificateTemplate template = certificateTemplateRepository.findByIdAndTenantId(templateId, tenantId)
+                .orElseThrow(() -> new CertificateTemplateNotFoundException(templateId));
+
+        template.update(
+                request.title(),
+                request.description(),
+                request.backgroundImageUrl(),
+                request.signatureImageUrl(),
+                request.certificateBodyHtml(),
+                request.validityMonths()
+        );
+
+        log.info("Certificate template updated: id={}", templateId);
+        return CertificateTemplateResponse.from(template);
+    }
+
+    @Override
+    @Transactional
+    public void setAsDefault(Long templateId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        log.info("Setting template as default: id={}, tenantId={}", templateId, tenantId);
+
+        CertificateTemplate template = certificateTemplateRepository.findByIdAndTenantId(templateId, tenantId)
+                .orElseThrow(() -> new CertificateTemplateNotFoundException(templateId));
+
+        // 기존 기본 템플릿 해제
+        certificateTemplateRepository.findByTenantIdAndIsDefaultTrue(tenantId)
+                .ifPresent(existing -> {
+                    if (!existing.getId().equals(templateId)) {
+                        existing.unsetDefault();
+                    }
+                });
+
+        template.setAsDefault();
+        log.info("Template set as default: id={}", templateId);
+    }
+
+    @Override
+    @Transactional
+    public void activateTemplate(Long templateId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        log.info("Activating template: id={}, tenantId={}", templateId, tenantId);
+
+        CertificateTemplate template = certificateTemplateRepository.findByIdAndTenantId(templateId, tenantId)
+                .orElseThrow(() -> new CertificateTemplateNotFoundException(templateId));
+
+        template.activate();
+        log.info("Template activated: id={}", templateId);
+    }
+
+    @Override
+    @Transactional
+    public void deactivateTemplate(Long templateId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        log.info("Deactivating template: id={}, tenantId={}", templateId, tenantId);
+
+        CertificateTemplate template = certificateTemplateRepository.findByIdAndTenantId(templateId, tenantId)
+                .orElseThrow(() -> new CertificateTemplateNotFoundException(templateId));
+
+        template.deactivate();
+        log.info("Template deactivated: id={}", templateId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteTemplate(Long templateId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        log.info("Deleting template: id={}, tenantId={}", templateId, tenantId);
+
+        CertificateTemplate template = certificateTemplateRepository.findByIdAndTenantId(templateId, tenantId)
+                .orElseThrow(() -> new CertificateTemplateNotFoundException(templateId));
+
+        certificateTemplateRepository.delete(template);
+        log.info("Template deleted: id={}", templateId);
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/certificate/service/CertificateTemplateServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/certificate/service/CertificateTemplateServiceTest.java
@@ -1,0 +1,437 @@
+package com.mzc.lp.domain.certificate.service;
+
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.certificate.dto.request.CertificateTemplateCreateRequest;
+import com.mzc.lp.domain.certificate.dto.request.CertificateTemplateUpdateRequest;
+import com.mzc.lp.domain.certificate.dto.response.CertificateTemplateResponse;
+import com.mzc.lp.domain.certificate.entity.CertificateTemplate;
+import com.mzc.lp.domain.certificate.exception.CertificateTemplateCodeDuplicateException;
+import com.mzc.lp.domain.certificate.exception.CertificateTemplateNotFoundException;
+import com.mzc.lp.domain.certificate.repository.CertificateTemplateRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CertificateTemplateServiceTest extends TenantTestSupport {
+
+    @InjectMocks
+    private CertificateTemplateServiceImpl certificateTemplateService;
+
+    @Mock
+    private CertificateTemplateRepository certificateTemplateRepository;
+
+    private static final Long TENANT_ID = 1L;
+
+    private CertificateTemplate createTestTemplate(String templateCode, String title) {
+        CertificateTemplate template = CertificateTemplate.create(
+                templateCode,
+                title,
+                "테스트 설명",
+                1L
+        );
+
+        // tenantId, id 설정
+        try {
+            var tenantIdField = com.mzc.lp.common.entity.TenantEntity.class.getDeclaredField("tenantId");
+            tenantIdField.setAccessible(true);
+            tenantIdField.set(template, TENANT_ID);
+
+            var idField = com.mzc.lp.common.entity.BaseEntity.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(template, 1L);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        return template;
+    }
+
+    // ==================== 템플릿 생성 테스트 ====================
+
+    @Nested
+    @DisplayName("createTemplate - 템플릿 생성")
+    class CreateTemplate {
+
+        @Test
+        @DisplayName("성공 - 템플릿 생성")
+        void createTemplate_success() {
+            // given
+            CertificateTemplateCreateRequest request = new CertificateTemplateCreateRequest(
+                    "TEMPLATE-001",
+                    "기본 수료증 템플릿",
+                    "기본 템플릿 설명",
+                    "https://example.com/bg.png",
+                    "https://example.com/sign.png",
+                    "<html>Certificate Body</html>",
+                    12,
+                    false
+            );
+
+            given(certificateTemplateRepository.existsByTemplateCodeAndTenantId("TEMPLATE-001", TENANT_ID))
+                    .willReturn(false);
+            given(certificateTemplateRepository.save(any(CertificateTemplate.class)))
+                    .willAnswer(invocation -> {
+                        CertificateTemplate template = invocation.getArgument(0);
+                        try {
+                            var idField = com.mzc.lp.common.entity.BaseEntity.class.getDeclaredField("id");
+                            idField.setAccessible(true);
+                            idField.set(template, 1L);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                        return template;
+                    });
+
+            // when
+            CertificateTemplateResponse response = certificateTemplateService.createTemplate(request, 1L);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.templateCode()).isEqualTo("TEMPLATE-001");
+            assertThat(response.title()).isEqualTo("기본 수료증 템플릿");
+            assertThat(response.validityMonths()).isEqualTo(12);
+
+            verify(certificateTemplateRepository).save(any(CertificateTemplate.class));
+        }
+
+        @Test
+        @DisplayName("실패 - 중복 템플릿 코드")
+        void createTemplate_fail_duplicateCode() {
+            // given
+            CertificateTemplateCreateRequest request = new CertificateTemplateCreateRequest(
+                    "TEMPLATE-001",
+                    "기본 수료증 템플릿",
+                    null, null, null, null, null, false
+            );
+
+            given(certificateTemplateRepository.existsByTemplateCodeAndTenantId("TEMPLATE-001", TENANT_ID))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> certificateTemplateService.createTemplate(request, 1L))
+                    .isInstanceOf(CertificateTemplateCodeDuplicateException.class);
+
+            verify(certificateTemplateRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("성공 - 기본 템플릿으로 생성")
+        void createTemplate_success_asDefault() {
+            // given
+            CertificateTemplateCreateRequest request = new CertificateTemplateCreateRequest(
+                    "TEMPLATE-DEFAULT",
+                    "기본 템플릿",
+                    null, null, null, null, null,
+                    true
+            );
+
+            CertificateTemplate existingDefault = createTestTemplate("TEMPLATE-OLD", "이전 기본 템플릿");
+
+            given(certificateTemplateRepository.existsByTemplateCodeAndTenantId("TEMPLATE-DEFAULT", TENANT_ID))
+                    .willReturn(false);
+            given(certificateTemplateRepository.findByTenantIdAndIsDefaultTrue(TENANT_ID))
+                    .willReturn(Optional.of(existingDefault));
+            given(certificateTemplateRepository.save(any(CertificateTemplate.class)))
+                    .willAnswer(invocation -> {
+                        CertificateTemplate template = invocation.getArgument(0);
+                        try {
+                            var idField = com.mzc.lp.common.entity.BaseEntity.class.getDeclaredField("id");
+                            idField.setAccessible(true);
+                            idField.set(template, 2L);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                        return template;
+                    });
+
+            // when
+            CertificateTemplateResponse response = certificateTemplateService.createTemplate(request, 1L);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.isDefault()).isTrue();
+            assertThat(existingDefault.isDefault()).isFalse(); // 기존 기본 템플릿 해제 확인
+        }
+    }
+
+    // ==================== 템플릿 목록 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("getTemplates - 템플릿 목록 조회")
+    class GetTemplates {
+
+        @Test
+        @DisplayName("성공 - 템플릿 목록 조회")
+        void getTemplates_success() {
+            // given
+            Pageable pageable = PageRequest.of(0, 20);
+            List<CertificateTemplate> templates = List.of(
+                    createTestTemplate("TEMPLATE-001", "템플릿 1"),
+                    createTestTemplate("TEMPLATE-002", "템플릿 2")
+            );
+            Page<CertificateTemplate> page = new PageImpl<>(templates, pageable, templates.size());
+
+            given(certificateTemplateRepository.findByTenantIdOrderByCreatedAtDesc(TENANT_ID, pageable))
+                    .willReturn(page);
+
+            // when
+            Page<CertificateTemplateResponse> response = certificateTemplateService.getTemplates(pageable);
+
+            // then
+            assertThat(response.getContent()).hasSize(2);
+        }
+    }
+
+    // ==================== 활성 템플릿 목록 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("getActiveTemplates - 활성 템플릿 목록 조회")
+    class GetActiveTemplates {
+
+        @Test
+        @DisplayName("성공 - 활성 템플릿 목록 조회")
+        void getActiveTemplates_success() {
+            // given
+            List<CertificateTemplate> templates = List.of(
+                    createTestTemplate("TEMPLATE-001", "활성 템플릿 1"),
+                    createTestTemplate("TEMPLATE-002", "활성 템플릿 2")
+            );
+
+            given(certificateTemplateRepository.findByTenantIdAndIsActiveTrue(TENANT_ID))
+                    .willReturn(templates);
+
+            // when
+            List<CertificateTemplateResponse> response = certificateTemplateService.getActiveTemplates();
+
+            // then
+            assertThat(response).hasSize(2);
+        }
+    }
+
+    // ==================== 템플릿 상세 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("getTemplate - 템플릿 상세 조회")
+    class GetTemplate {
+
+        @Test
+        @DisplayName("성공 - 템플릿 상세 조회")
+        void getTemplate_success() {
+            // given
+            Long templateId = 1L;
+            CertificateTemplate template = createTestTemplate("TEMPLATE-001", "테스트 템플릿");
+
+            given(certificateTemplateRepository.findByIdAndTenantId(templateId, TENANT_ID))
+                    .willReturn(Optional.of(template));
+
+            // when
+            CertificateTemplateResponse response = certificateTemplateService.getTemplate(templateId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.templateCode()).isEqualTo("TEMPLATE-001");
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 템플릿")
+        void getTemplate_fail_notFound() {
+            // given
+            Long templateId = 999L;
+
+            given(certificateTemplateRepository.findByIdAndTenantId(templateId, TENANT_ID))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> certificateTemplateService.getTemplate(templateId))
+                    .isInstanceOf(CertificateTemplateNotFoundException.class);
+        }
+    }
+
+    // ==================== 템플릿 수정 테스트 ====================
+
+    @Nested
+    @DisplayName("updateTemplate - 템플릿 수정")
+    class UpdateTemplate {
+
+        @Test
+        @DisplayName("성공 - 템플릿 수정")
+        void updateTemplate_success() {
+            // given
+            Long templateId = 1L;
+            CertificateTemplate template = createTestTemplate("TEMPLATE-001", "원래 제목");
+            CertificateTemplateUpdateRequest request = new CertificateTemplateUpdateRequest(
+                    "수정된 제목",
+                    "수정된 설명",
+                    "https://example.com/new-bg.png",
+                    "https://example.com/new-sign.png",
+                    "<html>Updated Body</html>",
+                    24
+            );
+
+            given(certificateTemplateRepository.findByIdAndTenantId(templateId, TENANT_ID))
+                    .willReturn(Optional.of(template));
+
+            // when
+            CertificateTemplateResponse response = certificateTemplateService.updateTemplate(templateId, request);
+
+            // then
+            assertThat(response.title()).isEqualTo("수정된 제목");
+            assertThat(response.validityMonths()).isEqualTo(24);
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 템플릿 수정")
+        void updateTemplate_fail_notFound() {
+            // given
+            Long templateId = 999L;
+            CertificateTemplateUpdateRequest request = new CertificateTemplateUpdateRequest(
+                    "수정된 제목", null, null, null, null, null
+            );
+
+            given(certificateTemplateRepository.findByIdAndTenantId(templateId, TENANT_ID))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> certificateTemplateService.updateTemplate(templateId, request))
+                    .isInstanceOf(CertificateTemplateNotFoundException.class);
+        }
+    }
+
+    // ==================== 기본 템플릿 설정 테스트 ====================
+
+    @Nested
+    @DisplayName("setAsDefault - 기본 템플릿 설정")
+    class SetAsDefault {
+
+        @Test
+        @DisplayName("성공 - 기본 템플릿 설정")
+        void setAsDefault_success() {
+            // given
+            Long templateId = 2L;
+            CertificateTemplate newDefault = createTestTemplate("TEMPLATE-NEW", "새 기본 템플릿");
+            CertificateTemplate oldDefault = createTestTemplate("TEMPLATE-OLD", "이전 기본 템플릿");
+            oldDefault.setAsDefault();
+
+            // newDefault의 id를 2로 설정
+            try {
+                var idField = com.mzc.lp.common.entity.BaseEntity.class.getDeclaredField("id");
+                idField.setAccessible(true);
+                idField.set(newDefault, 2L);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            given(certificateTemplateRepository.findByIdAndTenantId(templateId, TENANT_ID))
+                    .willReturn(Optional.of(newDefault));
+            given(certificateTemplateRepository.findByTenantIdAndIsDefaultTrue(TENANT_ID))
+                    .willReturn(Optional.of(oldDefault));
+
+            // when
+            certificateTemplateService.setAsDefault(templateId);
+
+            // then
+            assertThat(newDefault.isDefault()).isTrue();
+            assertThat(oldDefault.isDefault()).isFalse();
+        }
+    }
+
+    // ==================== 템플릿 활성화/비활성화 테스트 ====================
+
+    @Nested
+    @DisplayName("activateTemplate / deactivateTemplate")
+    class ActivateDeactivate {
+
+        @Test
+        @DisplayName("성공 - 템플릿 활성화")
+        void activateTemplate_success() {
+            // given
+            Long templateId = 1L;
+            CertificateTemplate template = createTestTemplate("TEMPLATE-001", "테스트");
+            template.deactivate();
+
+            given(certificateTemplateRepository.findByIdAndTenantId(templateId, TENANT_ID))
+                    .willReturn(Optional.of(template));
+
+            // when
+            certificateTemplateService.activateTemplate(templateId);
+
+            // then
+            assertThat(template.isActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공 - 템플릿 비활성화")
+        void deactivateTemplate_success() {
+            // given
+            Long templateId = 1L;
+            CertificateTemplate template = createTestTemplate("TEMPLATE-001", "테스트");
+
+            given(certificateTemplateRepository.findByIdAndTenantId(templateId, TENANT_ID))
+                    .willReturn(Optional.of(template));
+
+            // when
+            certificateTemplateService.deactivateTemplate(templateId);
+
+            // then
+            assertThat(template.isActive()).isFalse();
+        }
+    }
+
+    // ==================== 템플릿 삭제 테스트 ====================
+
+    @Nested
+    @DisplayName("deleteTemplate - 템플릿 삭제")
+    class DeleteTemplate {
+
+        @Test
+        @DisplayName("성공 - 템플릿 삭제")
+        void deleteTemplate_success() {
+            // given
+            Long templateId = 1L;
+            CertificateTemplate template = createTestTemplate("TEMPLATE-001", "테스트");
+
+            given(certificateTemplateRepository.findByIdAndTenantId(templateId, TENANT_ID))
+                    .willReturn(Optional.of(template));
+
+            // when
+            certificateTemplateService.deleteTemplate(templateId);
+
+            // then
+            verify(certificateTemplateRepository).delete(template);
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 템플릿 삭제")
+        void deleteTemplate_fail_notFound() {
+            // given
+            Long templateId = 999L;
+
+            given(certificateTemplateRepository.findByIdAndTenantId(templateId, TENANT_ID))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> certificateTemplateService.deleteTemplate(templateId))
+                    .isInstanceOf(CertificateTemplateNotFoundException.class);
+
+            verify(certificateTemplateRepository, never()).delete(any());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

수료증 템플릿(CertificateTemplate) 엔티티 및 관리 기능 구현

## Related Issue

- Closes #114

## Changes

- CertificateTemplate 엔티티 추가 (templateCode, title, backgroundImageUrl, signatureImageUrl, certificateBodyHtml, validityMonths, isDefault, isActive)
- Certificate 엔티티에 template 연관관계 및 expiresAt 필드 추가
- CertificateStatus enum에 VALID, EXPIRED 상태 추가
- CertificateTemplateRepository 구현
- CertificateTemplateService/Impl 구현 (CRUD, 기본 템플릿 설정, 활성화/비활성화)
- CertificateTemplateController 구현 (관리자 API)
- CertificateTemplateServiceTest 테스트 코드 작성

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

API 엔드포인트:
| Method | Endpoint | 설명 |
|--------|----------|------|
| POST | `/api/certificate-templates` | 템플릿 생성 |
| GET | `/api/certificate-templates` | 목록 조회 |
| GET | `/api/certificate-templates/active` | 활성 목록 |
| GET | `/api/certificate-templates/{id}` | 상세 조회 |
| PUT | `/api/certificate-templates/{id}` | 수정 |
| POST | `/api/certificate-templates/{id}/set-default` | 기본 설정 |
| POST | `/api/certificate-templates/{id}/activate` | 활성화 |
| POST | `/api/certificate-templates/{id}/deactivate` | 비활성화 |
| DELETE | `/api/certificate-templates/{id}` | 삭제 |