### PR TITLE
feat: 수료증 발급 및 재발급 API 구현

### DIFF
--- a/src/main/java/com/mzc/lp/domain/certificate/controller/CertificateController.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/controller/CertificateController.java
@@ -2,15 +2,18 @@ package com.mzc.lp.domain.certificate.controller;
 
 import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.certificate.dto.request.ReissueCertificateRequest;
 import com.mzc.lp.domain.certificate.dto.response.CertificateDetailResponse;
 import com.mzc.lp.domain.certificate.dto.response.CertificateResponse;
 import com.mzc.lp.domain.certificate.dto.response.CertificateVerifyResponse;
 import com.mzc.lp.domain.certificate.service.CertificateService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -25,6 +28,39 @@ import java.nio.charset.StandardCharsets;
 public class CertificateController {
 
     private final CertificateService certificateService;
+
+    /**
+     * 수료증 발급
+     * POST /api/enrollments/{enrollmentId}/certificate
+     */
+    @PostMapping("/api/enrollments/{enrollmentId}/certificate")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<CertificateDetailResponse>> issueCertificate(
+            @PathVariable Long enrollmentId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CertificateDetailResponse response = certificateService.issueCertificateByUser(
+                enrollmentId, principal.id());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
+    }
+
+    /**
+     * 수료증 재발급
+     * POST /api/certificates/{id}/reissue
+     */
+    @PostMapping("/api/certificates/{id}/reissue")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<CertificateDetailResponse>> reissueCertificate(
+            @PathVariable Long id,
+            @Valid @RequestBody ReissueCertificateRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CertificateDetailResponse response = certificateService.reissueCertificate(
+                id, request.reason(), principal.id());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
+    }
 
     /**
      * 내 수료증 목록 조회

--- a/src/main/java/com/mzc/lp/domain/certificate/dto/request/ReissueCertificateRequest.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/dto/request/ReissueCertificateRequest.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.certificate.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ReissueCertificateRequest(
+        @NotBlank(message = "재발급 사유는 필수입니다")
+        @Size(max = 500, message = "재발급 사유는 500자를 초과할 수 없습니다")
+        String reason
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/dto/response/CertificateDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/dto/response/CertificateDetailResponse.java
@@ -17,9 +17,13 @@ public record CertificateDetailResponse(
         String programTitle,
         Instant completedAt,
         Instant issuedAt,
+        Instant expiresAt,
         CertificateStatus status,
         Instant revokedAt,
-        String revokedReason
+        String revokedReason,
+        int reissueCount,
+        Long originalCertificateId,
+        String reissueReason
 ) {
     public static CertificateDetailResponse from(Certificate certificate) {
         return new CertificateDetailResponse(
@@ -34,9 +38,13 @@ public record CertificateDetailResponse(
                 certificate.getProgramTitle(),
                 certificate.getCompletedAt(),
                 certificate.getIssuedAt(),
+                certificate.getExpiresAt(),
                 certificate.getStatus(),
                 certificate.getRevokedAt(),
-                certificate.getRevokedReason()
+                certificate.getRevokedReason(),
+                certificate.getReissueCount(),
+                certificate.getOriginalCertificateId(),
+                certificate.getReissueReason()
         );
     }
 }

--- a/src/main/java/com/mzc/lp/domain/certificate/repository/CertificateRepository.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/repository/CertificateRepository.java
@@ -1,9 +1,12 @@
 package com.mzc.lp.domain.certificate.repository;
 
+import com.mzc.lp.domain.certificate.constant.CertificateStatus;
 import com.mzc.lp.domain.certificate.entity.Certificate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -18,6 +21,26 @@ public interface CertificateRepository extends JpaRepository<Certificate, Long> 
     Page<Certificate> findByUserIdAndTenantIdOrderByIssuedAtDesc(Long userId, Long tenantId, Pageable pageable);
 
     boolean existsByEnrollmentIdAndTenantId(Long enrollmentId, Long tenantId);
+
+    /**
+     * 해당 수강에 대해 유효한(발급됨) 수료증이 존재하는지 확인
+     */
+    @Query("SELECT COUNT(c) > 0 FROM Certificate c WHERE c.enrollmentId = :enrollmentId AND c.tenantId = :tenantId AND c.status = :status")
+    boolean existsByEnrollmentIdAndTenantIdAndStatus(
+            @Param("enrollmentId") Long enrollmentId,
+            @Param("tenantId") Long tenantId,
+            @Param("status") CertificateStatus status
+    );
+
+    /**
+     * 해당 수강에 대한 유효한 수료증 조회
+     */
+    @Query("SELECT c FROM Certificate c WHERE c.enrollmentId = :enrollmentId AND c.tenantId = :tenantId AND c.status = :status")
+    Optional<Certificate> findByEnrollmentIdAndTenantIdAndStatus(
+            @Param("enrollmentId") Long enrollmentId,
+            @Param("tenantId") Long tenantId,
+            @Param("status") CertificateStatus status
+    );
 
     Long countByTenantIdAndCertificateNumberStartingWith(Long tenantId, String prefix);
 }

--- a/src/main/java/com/mzc/lp/domain/certificate/service/CertificateService.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/service/CertificateService.java
@@ -9,9 +9,21 @@ import org.springframework.data.domain.Pageable;
 public interface CertificateService {
 
     /**
-     * 수료 시 수료증 자동 발급
+     * 수료증 발급 (내부/이벤트 호출용)
      */
     CertificateDetailResponse issueCertificate(Long enrollmentId);
+
+    /**
+     * 수료증 발급 (사용자 API 요청)
+     */
+    CertificateDetailResponse issueCertificateByUser(Long enrollmentId, Long userId);
+
+    /**
+     * 수료증 재발급
+     * - 기존 수료증 자동 무효화
+     * - 새로운 수료증 번호 발급
+     */
+    CertificateDetailResponse reissueCertificate(Long certificateId, String reason, Long userId);
 
     /**
      * 내 수료증 목록 조회

--- a/src/test/java/com/mzc/lp/domain/certificate/service/CertificateServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/certificate/service/CertificateServiceTest.java
@@ -125,7 +125,8 @@ class CertificateServiceTest extends TenantTestSupport {
             User user = mock(User.class);
             given(user.getName()).willReturn("테스트 사용자");
 
-            given(certificateRepository.existsByEnrollmentIdAndTenantId(enrollmentId, TENANT_ID))
+            given(certificateRepository.existsByEnrollmentIdAndTenantIdAndStatus(
+                    enrollmentId, TENANT_ID, CertificateStatus.ISSUED))
                     .willReturn(false);
             given(enrollmentRepository.findByIdAndTenantId(enrollmentId, TENANT_ID))
                     .willReturn(Optional.of(enrollment));
@@ -166,7 +167,8 @@ class CertificateServiceTest extends TenantTestSupport {
             // given
             Long enrollmentId = 1L;
 
-            given(certificateRepository.existsByEnrollmentIdAndTenantId(enrollmentId, TENANT_ID))
+            given(certificateRepository.existsByEnrollmentIdAndTenantIdAndStatus(
+                    enrollmentId, TENANT_ID, CertificateStatus.ISSUED))
                     .willReturn(true);
 
             // when & then


### PR DESCRIPTION
## Summary

수료증 발급 및 재발급 API 구현

## Related Issue

- Closes #115

## Changes

- Certificate Entity에 reissueCount, originalCertificateId, reissueReason 필드 추가
- enrollment unique constraint 제거 (재발급 지원)
- CertificateRepository에 상태 기반 조회 메서드 추가
- CertificateService에 issueCertificateByUser, reissueCertificate 메서드 추가
- POST /api/enrollments/{enrollmentId}/certificate - 수료증 발급 API
- POST /api/certificates/{id}/reissue - 수료증 재발급 API
- 재발급 시 기존 수료증 자동 무효화
- 수강 완료 상태 검증, 중복 발급 방지
- CertificateDetailResponse에 reissueCount, expiresAt 등 필드 추가
- CertificateServiceTest 테스트 코드 수정

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

API 엔드포인트:
| Method | Endpoint | 설명 |
|--------|----------|------|
| POST | `/api/enrollments/{enrollmentId}/certificate` | 수료증 발급 |
| POST | `/api/certificates/{id}/reissue` | 수료증 재발급 |