### PR TITLE
feat: 임직원-LMS 계정 자동 매칭 및 연동 API 구현

### DIFF
--- a/src/main/java/com/mzc/lp/domain/employee/controller/EmployeeController.java
+++ b/src/main/java/com/mzc/lp/domain/employee/controller/EmployeeController.java
@@ -5,7 +5,10 @@ import com.mzc.lp.common.security.UserPrincipal;
 import com.mzc.lp.domain.employee.constant.EmployeeStatus;
 import com.mzc.lp.domain.employee.dto.request.ChangeEmployeeStatusRequest;
 import com.mzc.lp.domain.employee.dto.request.CreateEmployeeRequest;
+import com.mzc.lp.domain.employee.dto.request.CreateLmsAccountRequest;
 import com.mzc.lp.domain.employee.dto.request.UpdateEmployeeRequest;
+import com.mzc.lp.domain.employee.dto.response.CreateLmsAccountResponse;
+import com.mzc.lp.domain.employee.dto.response.EmployeeLmsAccountResponse;
 import com.mzc.lp.domain.employee.dto.response.EmployeeResponse;
 import com.mzc.lp.domain.employee.service.EmployeeService;
 import jakarta.validation.Valid;
@@ -126,5 +129,49 @@ public class EmployeeController {
     ) {
         employeeService.delete(principal.tenantId(), employeeId);
         return ResponseEntity.noContent().build();
+    }
+
+    // ========== LMS 계정 연동 API ==========
+
+    /**
+     * 임직원의 LMS 계정 조회
+     */
+    @GetMapping("/{employeeId}/lms-account")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<EmployeeLmsAccountResponse>> getLmsAccount(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long employeeId
+    ) {
+        EmployeeLmsAccountResponse response = employeeService.getLmsAccount(
+                principal.tenantId(), employeeId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 임직원의 LMS 계정 생성
+     */
+    @PostMapping("/{employeeId}/lms-account")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CreateLmsAccountResponse>> createLmsAccount(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long employeeId,
+            @Valid @RequestBody CreateLmsAccountRequest request
+    ) {
+        CreateLmsAccountResponse response = employeeService.createLmsAccount(
+                principal.tenantId(), employeeId, request);
+        return ResponseEntity.status(201).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 임직원의 LMS 계정 존재 여부 확인
+     */
+    @GetMapping("/{employeeId}/has-lms-account")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<Boolean>> hasLmsAccount(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long employeeId
+    ) {
+        boolean hasAccount = employeeService.hasLmsAccount(principal.tenantId(), employeeId);
+        return ResponseEntity.ok(ApiResponse.success(hasAccount));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/employee/dto/request/CreateLmsAccountRequest.java
+++ b/src/main/java/com/mzc/lp/domain/employee/dto/request/CreateLmsAccountRequest.java
@@ -1,0 +1,22 @@
+package com.mzc.lp.domain.employee.dto.request;
+
+import com.mzc.lp.domain.user.constant.TenantRole;
+
+public record CreateLmsAccountRequest(
+        String password,
+        Boolean generatePassword,
+        Boolean sendWelcomeEmail,
+        TenantRole role
+) {
+    public CreateLmsAccountRequest {
+        if (generatePassword == null) {
+            generatePassword = true;
+        }
+        if (sendWelcomeEmail == null) {
+            sendWelcomeEmail = false;
+        }
+        if (role == null) {
+            role = TenantRole.USER;
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/employee/dto/response/CreateLmsAccountResponse.java
+++ b/src/main/java/com/mzc/lp/domain/employee/dto/response/CreateLmsAccountResponse.java
@@ -1,0 +1,38 @@
+package com.mzc.lp.domain.employee.dto.response;
+
+import com.mzc.lp.domain.employee.entity.Employee;
+import com.mzc.lp.domain.user.entity.User;
+
+import java.time.Instant;
+
+public record CreateLmsAccountResponse(
+        Long userId,
+        String email,
+        String name,
+        Long employeeId,
+        String employeeNumber,
+        String department,
+        String position,
+        String jobTitle,
+        String temporaryPassword,
+        Instant createdAt
+) {
+    public static CreateLmsAccountResponse from(User user, Employee employee, String temporaryPassword) {
+        String departmentName = employee.getDepartment() != null
+                ? employee.getDepartment().getName()
+                : null;
+
+        return new CreateLmsAccountResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                employee.getId(),
+                employee.getEmployeeNumber(),
+                departmentName,
+                employee.getPosition(),
+                employee.getJobTitle(),
+                temporaryPassword,
+                user.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/employee/dto/response/EmployeeLmsAccountResponse.java
+++ b/src/main/java/com/mzc/lp/domain/employee/dto/response/EmployeeLmsAccountResponse.java
@@ -1,0 +1,55 @@
+package com.mzc.lp.domain.employee.dto.response;
+
+import com.mzc.lp.domain.employee.entity.Employee;
+
+import java.time.Instant;
+
+public record EmployeeLmsAccountResponse(
+        boolean hasAccount,
+        Long userId,
+        String email,
+        String name,
+        Long employeeId,
+        String employeeNumber,
+        String employeeName,
+        String department,
+        String position,
+        String jobTitle,
+        Instant syncedAt
+) {
+    public static EmployeeLmsAccountResponse withAccount(Employee employee) {
+        String departmentName = employee.getDepartment() != null
+                ? employee.getDepartment().getName()
+                : null;
+
+        return new EmployeeLmsAccountResponse(
+                true,
+                employee.getUser().getId(),
+                employee.getUser().getEmail(),
+                employee.getUser().getName(),
+                employee.getId(),
+                employee.getEmployeeNumber(),
+                employee.getUser().getName(),
+                departmentName,
+                employee.getPosition(),
+                employee.getJobTitle(),
+                employee.getUpdatedAt()
+        );
+    }
+
+    public static EmployeeLmsAccountResponse withoutAccount(Long employeeId, String employeeNumber, String employeeName) {
+        return new EmployeeLmsAccountResponse(
+                false,
+                null,
+                null,
+                null,
+                employeeId,
+                employeeNumber,
+                employeeName,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/employee/repository/EmployeeRepository.java
+++ b/src/main/java/com/mzc/lp/domain/employee/repository/EmployeeRepository.java
@@ -43,6 +43,21 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
     boolean existsByTenantIdAndUserId(Long tenantId, Long userId);
     boolean existsByDepartmentId(Long departmentId);
 
+    // 이메일 기반 임직원 조회 (LMS 계정 자동 연동용)
+    @Query("SELECT e FROM Employee e JOIN FETCH e.user u LEFT JOIN FETCH e.department d " +
+           "WHERE e.tenantId = :tenantId AND u.email IN :emails")
+    List<Employee> findByTenantIdAndUserEmailIn(@Param("tenantId") Long tenantId,
+                                                  @Param("emails") List<String> emails);
+
+    // 이메일로 단건 조회
+    @Query("SELECT e FROM Employee e JOIN e.user u WHERE e.tenantId = :tenantId AND u.email = :email")
+    Optional<Employee> findByTenantIdAndUserEmail(@Param("tenantId") Long tenantId,
+                                                   @Param("email") String email);
+
+    // User 엔티티가 없는 임직원 조회 (LMS 계정 미생성 상태)
+    @Query("SELECT e FROM Employee e WHERE e.tenantId = :tenantId AND e.user IS NULL")
+    List<Employee> findByTenantIdAndUserIsNull(@Param("tenantId") Long tenantId);
+
     // 검색 쿼리
     @Query("SELECT e FROM Employee e JOIN e.user u WHERE e.tenantId = :tenantId " +
            "AND (LOWER(e.employeeNumber) LIKE LOWER(CONCAT('%', :keyword, '%')) " +

--- a/src/main/java/com/mzc/lp/domain/employee/service/EmployeeService.java
+++ b/src/main/java/com/mzc/lp/domain/employee/service/EmployeeService.java
@@ -3,7 +3,10 @@ package com.mzc.lp.domain.employee.service;
 import com.mzc.lp.domain.employee.constant.EmployeeStatus;
 import com.mzc.lp.domain.employee.dto.request.ChangeEmployeeStatusRequest;
 import com.mzc.lp.domain.employee.dto.request.CreateEmployeeRequest;
+import com.mzc.lp.domain.employee.dto.request.CreateLmsAccountRequest;
 import com.mzc.lp.domain.employee.dto.request.UpdateEmployeeRequest;
+import com.mzc.lp.domain.employee.dto.response.CreateLmsAccountResponse;
+import com.mzc.lp.domain.employee.dto.response.EmployeeLmsAccountResponse;
 import com.mzc.lp.domain.employee.dto.response.EmployeeResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -29,4 +32,11 @@ public interface EmployeeService {
     List<EmployeeResponse> getByDepartment(Long tenantId, Long departmentId);
 
     Page<EmployeeResponse> search(Long tenantId, Long departmentId, EmployeeStatus status, String keyword, Pageable pageable);
+
+    // LMS 계정 연동 API
+    EmployeeLmsAccountResponse getLmsAccount(Long tenantId, Long employeeId);
+
+    CreateLmsAccountResponse createLmsAccount(Long tenantId, Long employeeId, CreateLmsAccountRequest request);
+
+    boolean hasLmsAccount(Long tenantId, Long employeeId);
 }

--- a/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
+++ b/src/main/java/com/mzc/lp/domain/user/controller/UserController.java
@@ -211,9 +211,12 @@ public class UserController {
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestParam("file") MultipartFile file,
             @RequestParam(value = "defaultPassword", required = false) String defaultPassword,
-            @RequestParam(value = "role", required = false) TenantRole role
+            @RequestParam(value = "role", required = false) TenantRole role,
+            @RequestParam(value = "autoLinkEmployees", required = false) Boolean autoLinkEmployees,
+            @RequestParam(value = "sendWelcomeEmail", required = false) Boolean sendWelcomeEmail
     ) {
-        FileBulkCreateUsersRequest request = new FileBulkCreateUsersRequest(defaultPassword, role);
+        FileBulkCreateUsersRequest request = new FileBulkCreateUsersRequest(
+                defaultPassword, role, autoLinkEmployees, sendWelcomeEmail);
         BulkCreateUsersResponse response = userService.fileBulkCreateUsers(principal.tenantId(), file, request);
         return ResponseEntity.status(201).body(ApiResponse.success(response));
     }

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/FileBulkCreateUsersRequest.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/FileBulkCreateUsersRequest.java
@@ -4,11 +4,19 @@ import com.mzc.lp.domain.user.constant.TenantRole;
 
 public record FileBulkCreateUsersRequest(
         String defaultPassword,
-        TenantRole role
+        TenantRole role,
+        Boolean autoLinkEmployees,
+        Boolean sendWelcomeEmail
 ) {
     public FileBulkCreateUsersRequest {
         if (role == null) {
             role = TenantRole.USER;
+        }
+        if (autoLinkEmployees == null) {
+            autoLinkEmployees = true;
+        }
+        if (sendWelcomeEmail == null) {
+            sendWelcomeEmail = false;
         }
     }
 }

--- a/src/main/java/com/mzc/lp/domain/user/dto/response/BulkCreateUsersResponse.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/response/BulkCreateUsersResponse.java
@@ -6,18 +6,37 @@ public record BulkCreateUsersResponse(
         int totalRequested,
         int successCount,
         int failedCount,
+        int autoLinkedCount,
         List<CreatedUserInfo> createdUsers,
-        List<FailedUserInfo> failedUsers
+        List<FailedUserInfo> failedUsers,
+        List<AutoLinkedUserInfo> autoLinkedUsers
 ) {
     public record CreatedUserInfo(
             Long id,
             String email,
-            String name
-    ) {}
+            String name,
+            boolean employeeLinked,
+            Long employeeId
+    ) {
+        public CreatedUserInfo(Long id, String email, String name) {
+            this(id, email, name, false, null);
+        }
+    }
 
     public record FailedUserInfo(
             String email,
             String reason
+    ) {}
+
+    public record AutoLinkedUserInfo(
+            Long userId,
+            String email,
+            Long employeeId,
+            String employeeNumber,
+            String employeeName,
+            String department,
+            String position,
+            String jobTitle
     ) {}
 
     public static BulkCreateUsersResponse of(
@@ -29,8 +48,27 @@ public record BulkCreateUsersResponse(
                 totalRequested,
                 createdUsers.size(),
                 failedUsers.size(),
+                0,
                 createdUsers,
-                failedUsers
+                failedUsers,
+                List.of()
+        );
+    }
+
+    public static BulkCreateUsersResponse of(
+            int totalRequested,
+            List<CreatedUserInfo> createdUsers,
+            List<FailedUserInfo> failedUsers,
+            List<AutoLinkedUserInfo> autoLinkedUsers
+    ) {
+        return new BulkCreateUsersResponse(
+                totalRequested,
+                createdUsers.size(),
+                failedUsers.size(),
+                autoLinkedUsers.size(),
+                createdUsers,
+                failedUsers,
+                autoLinkedUsers
         );
     }
 }

--- a/src/main/java/com/mzc/lp/domain/user/dto/response/UserListResponse.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/response/UserListResponse.java
@@ -5,11 +5,14 @@ import com.mzc.lp.domain.user.entity.User;
 import java.time.Instant;
 
 public record UserListResponse(
-        Long userId,
+        Long id,
         String email,
         String name,
-        String role,
+        String profileImageUrl,
+        String systemRole,
         String status,
+        String organizationName,
+        Instant lastLoginAt,
         Instant createdAt
 ) {
     public static UserListResponse from(User user) {
@@ -17,8 +20,11 @@ public record UserListResponse(
                 user.getId(),
                 user.getEmail(),
                 user.getName(),
+                user.getProfileImageUrl(),
                 user.getRole().name(),
                 user.getStatus().name(),
+                null,
+                null,
                 user.getCreatedAt()
         );
     }


### PR DESCRIPTION
## Summary
- 단체 사용자 생성(CSV/Excel) 시 이메일 기반 임직원 자동 연동 기능 추가
- 임직원 LMS 계정 조회/생성/확인 API 엔드포인트 구현
- 보안 요구사항을 충족하는 12자리 랜덤 비밀번호 생성 기능 추가

## Changes
### 단체 계정 생성 시 임직원 자동 연동
- `FileBulkCreateUsersRequest`: `autoLinkEmployees`, `sendWelcomeEmail` 플래그 추가
- `BulkCreateUsersResponse`: `autoLinkedCount`, `autoLinkedUsers`, `AutoLinkedUserInfo` 추가
- `UserServiceImpl`: 이메일 기반 임직원 매칭 로직 구현
- `EmployeeRepository`: 이메일 기반 조회 쿼리 추가

### 임직원 LMS 계정 API
- `GET /api/employees/{id}/lms-account` - LMS 계정 정보 조회
- `POST /api/employees/{id}/lms-account` - LMS 계정 생성
- `GET /api/employees/{id}/has-lms-account` - 계정 존재 여부 확인

### 새로운 DTO
- `CreateLmsAccountRequest`: 비밀번호, 자동생성 여부, 역할 설정
- `CreateLmsAccountResponse`: 생성된 계정 정보 및 임시 비밀번호
- `EmployeeLmsAccountResponse`: LMS 계정 연동 상태 정보

## Test plan
- [ ] CSV 파일 업로드 시 `autoLinkEmployees=true`로 임직원 자동 연동 확인
- [ ] 연동된 임직원 정보가 응답의 `autoLinkedUsers`에 포함되는지 확인
- [ ] `GET /api/employees/{id}/lms-account` API 정상 동작 확인
- [ ] `POST /api/employees/{id}/lms-account` API로 계정 생성 확인
- [ ] 생성된 임시 비밀번호가 보안 요구사항 충족하는지 확인

Closes #282