### PR TITLE
feat: 수강별 수료증 조회 API 추가

### DIFF
--- a/src/main/java/com/mzc/lp/domain/certificate/controller/CertificateController.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/controller/CertificateController.java
@@ -46,6 +46,21 @@ public class CertificateController {
     }
 
     /**
+     * 수강별 수료증 조회
+     * GET /api/enrollments/{enrollmentId}/certificate
+     */
+    @GetMapping("/api/enrollments/{enrollmentId}/certificate")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<CertificateDetailResponse>> getCertificateByEnrollment(
+            @PathVariable Long enrollmentId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CertificateDetailResponse response = certificateService.getCertificateByEnrollment(
+                enrollmentId, principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
      * 수료증 재발급
      * POST /api/certificates/{id}/reissue
      */

--- a/src/main/java/com/mzc/lp/domain/certificate/exception/CertificateNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/exception/CertificateNotFoundException.java
@@ -16,4 +16,12 @@ public class CertificateNotFoundException extends BusinessException {
     public CertificateNotFoundException(String certificateNumber) {
         super(ErrorCode.CERTIFICATE_NOT_FOUND, "Certificate not found with number: " + certificateNumber);
     }
+
+    public static CertificateNotFoundException withMessage(String message) {
+        return new CertificateNotFoundException(ErrorCode.CERTIFICATE_NOT_FOUND, message);
+    }
+
+    private CertificateNotFoundException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
 }

--- a/src/main/java/com/mzc/lp/domain/certificate/service/CertificateService.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/service/CertificateService.java
@@ -36,6 +36,11 @@ public interface CertificateService {
     CertificateDetailResponse getCertificate(Long certificateId, Long userId);
 
     /**
+     * 수강별 수료증 조회
+     */
+    CertificateDetailResponse getCertificateByEnrollment(Long enrollmentId, Long userId);
+
+    /**
      * 수료증 PDF 다운로드
      */
     byte[] downloadCertificatePdf(Long certificateId, Long userId);


### PR DESCRIPTION
## Summary

수강별 수료증 조회 API 추가 (GET /api/enrollments/{enrollmentId}/certificate)

## Related Issue

- Closes #116

## Changes

- GET /api/enrollments/{enrollmentId}/certificate 엔드포인트 추가
- 본인 수강 확인 후 ISSUED 상태의 유효한 수료증 반환
- CertificateNotFoundException.withMessage() 정적 팩토리 메서드 추가
- 테스트 케이스 3개 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

## Additional Notes