### PR TITLE
feat(certificate): 수료증 진위 확인 Public API 구현

### DIFF
--- a/src/main/java/com/mzc/lp/domain/certificate/controller/CertificateController.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/controller/CertificateController.java
@@ -130,11 +130,10 @@ public class CertificateController {
     }
 
     /**
-     * 수료증 진위 확인
+     * 수료증 진위 확인 (Public API - 인증 불필요)
      * GET /api/certificates/verify/{certificateNumber}
      */
     @GetMapping("/api/certificates/verify/{certificateNumber}")
-    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<CertificateVerifyResponse>> verifyCertificate(
             @PathVariable String certificateNumber
     ) {

--- a/src/main/java/com/mzc/lp/domain/certificate/dto/response/CertificateVerifyResponse.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/dto/response/CertificateVerifyResponse.java
@@ -25,7 +25,7 @@ public record CertificateVerifyResponse(
         return new CertificateVerifyResponse(
                 isValid,
                 certificate.getCertificateNumber(),
-                certificate.getUserName(),
+                maskName(certificate.getUserName()),
                 certificate.getProgramTitle(),
                 certificate.getCourseTimeTitle(),
                 certificate.getCompletedAt(),
@@ -33,6 +33,31 @@ public record CertificateVerifyResponse(
                 certificate.getStatus(),
                 message
         );
+    }
+
+    /**
+     * 이름 마스킹 (Public API용)
+     * - 1자: * (예: 홍 → *)
+     * - 2자: X* (예: 홍길 → 홍*)
+     * - 3자: X*X (예: 홍길동 → 홍*동)
+     * - 4자 이상: 첫글자 + ** + 마지막글자 (예: 홍길동수 → 홍**수)
+     */
+    private static String maskName(String name) {
+        if (name == null || name.isBlank()) {
+            return name;
+        }
+
+        int length = name.length();
+        if (length == 1) {
+            return "*";
+        } else if (length == 2) {
+            return name.charAt(0) + "*";
+        } else if (length == 3) {
+            return name.charAt(0) + "*" + name.charAt(2);
+        } else {
+            // 4자 이상: 첫글자와 마지막글자만 표시, 중간은 **
+            return name.charAt(0) + "*".repeat(length - 2) + name.charAt(length - 1);
+        }
     }
 
     public static CertificateVerifyResponse notFound(String certificateNumber) {


### PR DESCRIPTION
## Summary

수료증 진위 확인 API를 Public API로 변경하고 개인정보 보호를 위한 이름 마스킹 기능 추가

## Related Issue

- Closes #117 

## Changes

- CertificateController에서 `@PreAuthorize` 제거하여 인증 없이 접근 가능
- CertificateVerifyResponse에 `maskName()` 메서드 추가
  - 1자: `*` (홍 → *)
  - 2자: `X*` (홍길 → 홍*)
  - 3자: `X*X` (홍길동 → 홍*동)
  - 4자+: `X**X` (남궁민수 → 남**수)
- 이름 마스킹 테스트 케이스 추가 (2/3/4글자)

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

## Additional Notes
