### PR TITLE
feat: 관리자 수료증 관리 기능 구현

### DIFF
--- a/src/main/java/com/mzc/lp/domain/certificate/controller/CertificateController.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/controller/CertificateController.java
@@ -3,9 +3,11 @@ package com.mzc.lp.domain.certificate.controller;
 import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.common.security.UserPrincipal;
 import com.mzc.lp.domain.certificate.dto.request.ReissueCertificateRequest;
+import com.mzc.lp.domain.certificate.dto.request.RevokeCertificateRequest;
 import com.mzc.lp.domain.certificate.dto.response.CertificateDetailResponse;
 import com.mzc.lp.domain.certificate.dto.response.CertificateResponse;
 import com.mzc.lp.domain.certificate.dto.response.CertificateVerifyResponse;
+import com.mzc.lp.domain.certificate.dto.response.CourseTimeCertificatesResponse;
 import com.mzc.lp.domain.certificate.service.CertificateService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -147,11 +149,25 @@ public class CertificateController {
      */
     @DeleteMapping("/api/certificates/{id}")
     @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
-    public ResponseEntity<Void> revokeCertificate(
+    public ResponseEntity<ApiResponse<CertificateDetailResponse>> revokeCertificate(
             @PathVariable Long id,
-            @RequestParam String reason
+            @Valid @RequestBody RevokeCertificateRequest request
     ) {
-        certificateService.revokeCertificate(id, reason);
-        return ResponseEntity.noContent().build();
+        CertificateDetailResponse response = certificateService.revokeCertificate(id, request.reason());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 차수별 수료증 현황 조회 (관리자)
+     * GET /api/times/{timeId}/certificates
+     */
+    @GetMapping("/api/times/{timeId}/certificates")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseTimeCertificatesResponse>> getCertificatesByCourseTime(
+            @PathVariable Long timeId,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        CourseTimeCertificatesResponse response = certificateService.getCertificatesByCourseTime(timeId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/certificate/dto/request/RevokeCertificateRequest.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/dto/request/RevokeCertificateRequest.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.certificate.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RevokeCertificateRequest(
+        @NotBlank(message = "폐기 사유는 필수입니다")
+        @Size(max = 500, message = "폐기 사유는 500자를 초과할 수 없습니다")
+        String reason
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/dto/response/CourseTimeCertificateSummary.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/dto/response/CourseTimeCertificateSummary.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.certificate.dto.response;
+
+public record CourseTimeCertificateSummary(
+        long total,
+        long issued,
+        long pending
+) {
+    public static CourseTimeCertificateSummary of(long total, long issued) {
+        return new CourseTimeCertificateSummary(total, issued, total - issued);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/dto/response/CourseTimeCertificatesResponse.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/dto/response/CourseTimeCertificatesResponse.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.certificate.dto.response;
+
+import org.springframework.data.domain.Page;
+
+public record CourseTimeCertificatesResponse(
+        CourseTimeCertificateSummary summary,
+        Page<CertificateResponse> certificates
+) {
+    public static CourseTimeCertificatesResponse of(
+            CourseTimeCertificateSummary summary,
+            Page<CertificateResponse> certificates
+    ) {
+        return new CourseTimeCertificatesResponse(summary, certificates);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/certificate/repository/CertificateRepository.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/repository/CertificateRepository.java
@@ -43,4 +43,16 @@ public interface CertificateRepository extends JpaRepository<Certificate, Long> 
     );
 
     Long countByTenantIdAndCertificateNumberStartingWith(Long tenantId, String prefix);
+
+    /**
+     * 차수별 수료증 목록 조회 (페이징)
+     */
+    Page<Certificate> findByCourseTimeIdAndTenantIdOrderByIssuedAtDesc(
+            Long courseTimeId, Long tenantId, Pageable pageable);
+
+    /**
+     * 차수별 발급된 수료증 카운트
+     */
+    long countByCourseTimeIdAndTenantIdAndStatus(
+            Long courseTimeId, Long tenantId, CertificateStatus status);
 }

--- a/src/main/java/com/mzc/lp/domain/certificate/service/CertificateService.java
+++ b/src/main/java/com/mzc/lp/domain/certificate/service/CertificateService.java
@@ -3,6 +3,7 @@ package com.mzc.lp.domain.certificate.service;
 import com.mzc.lp.domain.certificate.dto.response.CertificateDetailResponse;
 import com.mzc.lp.domain.certificate.dto.response.CertificateResponse;
 import com.mzc.lp.domain.certificate.dto.response.CertificateVerifyResponse;
+import com.mzc.lp.domain.certificate.dto.response.CourseTimeCertificatesResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -53,5 +54,12 @@ public interface CertificateService {
     /**
      * 수료증 폐기 (관리자)
      */
-    void revokeCertificate(Long certificateId, String reason);
+    CertificateDetailResponse revokeCertificate(Long certificateId, String reason);
+
+    /**
+     * 차수별 수료증 현황 조회 (관리자)
+     * - summary: 전체 수강 인원, 발급 수, 미발급 수
+     * - certificates: 발급된 수료증 목록 (페이징)
+     */
+    CourseTimeCertificatesResponse getCertificatesByCourseTime(Long courseTimeId, Pageable pageable);
 }


### PR DESCRIPTION
## Summary

관리자용 수료증 관리 기능(폐기, 차수별 현황 조회) 구현

## Related Issue

- Closes #118

## Changes

- 수료증 폐기 API 수정 (`DELETE /api/certificates/{id}`)
  - `@RequestParam` → `@RequestBody` 변경
  - 반환값: `204 No Content` → `200 OK` (폐기된 수료증 상세)
  - `RevokeCertificateRequest` DTO 추가
- 차수별 수료증 현황 조회 API 추가 (`GET /api/times/{timeId}/certificates`)
  - 요약 정보: 전체 수강 인원, 발급 수, 미발급 수
  - 수료증 목록 페이징 지원
  - `CourseTimeCertificateSummary`, `CourseTimeCertificatesResponse` DTO 추가
  - `CertificateRepository` 쿼리 메서드 추가
- 테스트 코드 추가 및 수정

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

## Additional Notes

### API 변경 사항

**수료증 폐기 (관리자)**
DELETE /api/certificates/{id} Authorization: Bearer {token} Content-Type: application/json Request Body: { "reason": "폐기 사유" } Response: 200 OK { "success": true, "data": { /* CertificateDetailResponse */ } }


**차수별 수료증 현황 조회 (관리자)**
GET /api/times/{timeId}/certificates?page=0&size=20 Authorization: Bearer {token} Response: 200 OK { "success": true, "data": { "summary": { "total": 10, "issued": 5, "pending": 5 }, "certificates": { /* Page<CertificateResponse> */ } } }