### PR TITLE
feat(program): delete snapshot when program is deleted

### DIFF
--- a/src/main/java/com/mzc/lp/domain/program/repository/ProgramRepository.java
+++ b/src/main/java/com/mzc/lp/domain/program/repository/ProgramRepository.java
@@ -41,6 +41,11 @@ public interface ProgramRepository extends JpaRepository<Program, Long> {
 
     boolean existsByIdAndTenantId(Long id, Long tenantId);
 
+    /**
+     * 특정 스냅샷을 참조하는 프로그램 수 조회
+     */
+    long countBySnapshotId(Long snapshotId);
+
     // ===== 통계 집계 쿼리 =====
 
     /**


### PR DESCRIPTION
## Summary
- 프로그램 삭제 시 연결된 스냅샷도 함께 삭제
- 다른 프로그램에서 참조하지 않는 경우에만 삭제

## Changes
- `ProgramServiceImpl.deleteProgram()` 수정
- `deleteSnapshotIfNotReferenced()` private 메서드 추가

## Logic
```
프로그램 삭제 요청
    ↓
DRAFT 상태 확인
    ↓ (DRAFT인 경우)
스냅샷 참조 카운트 확인 (countBySnapshotId)
    ↓
refCount <= 1 → 스냅샷 삭제
refCount > 1  → 스냅샷 유지 (다른 프로그램이 참조)
    ↓
프로그램 삭제
```

## Test plan
- [ ] 스냅샷이 있는 DRAFT 프로그램 삭제 → 스냅샷도 삭제됨
- [ ] 스냅샷이 없는 DRAFT 프로그램 삭제 → 정상 삭제
- [ ] DRAFT가 아닌 프로그램 삭제 시도 → CLOSED로 변경, 스냅샷 유지

## Dependencies
- #308 (countBySnapshotId 메서드 추가)

Closes #307