### PR TITLE
fix: 브랜딩 API에서 tenantId 없을 때 기본값 반환

### DIFF
--- a/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
@@ -63,7 +63,10 @@ public class TenantSettingsController {
     @Operation(summary = "현재 테넌트 브랜딩 조회", description = "로그인한 사용자의 테넌트 브랜딩 정보를 조회합니다")
     @GetMapping("/branding")
     public ResponseEntity<ApiResponse<PublicBrandingResponse>> getBranding() {
-        Long tenantId = TenantContext.getCurrentTenantId();
+        Long tenantId = TenantContext.getCurrentTenantIdOrNull();
+        if (tenantId == null) {
+            return ResponseEntity.ok(ApiResponse.success(PublicBrandingResponse.defaultBranding()));
+        }
         PublicBrandingResponse response = tenantSettingsService.getBrandingByTenantId(tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }


### PR DESCRIPTION
## Summary

로그인하지 않은 상태에서 `/api/tenant/settings/branding` API 호출 시 500 에러 발생하는 문제 수정

## Related Issue

- N/A

## Changes

- `TenantSettingsController.getBranding()`에서 `getCurrentTenantId()` → `getCurrentTenantIdOrNull()` 변경
- tenantId가 null인 경우 `PublicBrandingResponse.defaultBranding()` 반환

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 기존: `TenantContext.getCurrentTenantId()` 호출 시 tenantId가 없으면 `TenantNotFoundException` 발생 → 500 에러
- 수정: `getCurrentTenantIdOrNull()` 사용하여 null 체크 후 기본 브랜딩 반환
