### PR TITLE
feat: 코스(차수) 단위 커뮤니티 기능 구현

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -130,6 +130,7 @@ public enum ErrorCode {
     COMMUNITY_ALREADY_LIKED(HttpStatus.CONFLICT, "CMT003", "Already liked"),
     COMMUNITY_NOT_POST_AUTHOR(HttpStatus.FORBIDDEN, "CMT004", "Not authorized to modify this post"),
     COMMUNITY_NOT_COMMENT_AUTHOR(HttpStatus.FORBIDDEN, "CMT005", "Not authorized to modify this comment"),
+    COMMUNITY_NOT_ENROLLED(HttpStatus.FORBIDDEN, "CMT006", "Not enrolled in this course"),
 
     // Notification (NF)
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NF001", "Notification not found"),

--- a/src/main/java/com/mzc/lp/domain/community/controller/CourseCommunityController.java
+++ b/src/main/java/com/mzc/lp/domain/community/controller/CourseCommunityController.java
@@ -1,0 +1,157 @@
+package com.mzc.lp.domain.community.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.community.dto.request.CreateCoursePostRequest;
+import com.mzc.lp.domain.community.dto.request.UpdatePostRequest;
+import com.mzc.lp.domain.community.dto.response.CategoryResponse;
+import com.mzc.lp.domain.community.dto.response.PostDetailResponse;
+import com.mzc.lp.domain.community.dto.response.PostListResponse;
+import com.mzc.lp.domain.community.dto.response.PostResponse;
+import com.mzc.lp.domain.community.service.CourseCommunityService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 코스(차수) 단위 커뮤니티 API
+ */
+@RestController
+@RequestMapping("/api/times/{timeId}/community")
+@RequiredArgsConstructor
+@Validated
+public class CourseCommunityController {
+
+    private final CourseCommunityService courseCommunityService;
+
+    /**
+     * 코스 커뮤니티 게시글 목록 조회
+     * GET /api/times/{timeId}/community/posts
+     */
+    @GetMapping("/posts")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<PostListResponse>> getPosts(
+            @PathVariable Long timeId,
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String type,
+            @RequestParam(required = false, defaultValue = "latest") String sortBy,
+            @RequestParam(required = false, defaultValue = "0") int page,
+            @RequestParam(required = false, defaultValue = "20") int pageSize,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        PostListResponse response = courseCommunityService.getPosts(
+                timeId, search, category, type, sortBy, page, pageSize, principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 코스 커뮤니티 게시글 상세 조회
+     * GET /api/times/{timeId}/community/posts/{postId}
+     */
+    @GetMapping("/posts/{postId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<PostDetailResponse>> getPost(
+            @PathVariable Long timeId,
+            @PathVariable Long postId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        PostDetailResponse response = courseCommunityService.getPost(timeId, postId, principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 코스 커뮤니티 게시글 작성
+     * POST /api/times/{timeId}/community/posts
+     */
+    @PostMapping("/posts")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<PostResponse>> createPost(
+            @PathVariable Long timeId,
+            @Valid @RequestBody CreateCoursePostRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        PostResponse response = courseCommunityService.createPost(timeId, principal.id(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 코스 커뮤니티 게시글 수정
+     * PATCH /api/times/{timeId}/community/posts/{postId}
+     */
+    @PatchMapping("/posts/{postId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<PostResponse>> updatePost(
+            @PathVariable Long timeId,
+            @PathVariable Long postId,
+            @Valid @RequestBody UpdatePostRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        PostResponse response = courseCommunityService.updatePost(timeId, principal.id(), postId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 코스 커뮤니티 게시글 삭제
+     * DELETE /api/times/{timeId}/community/posts/{postId}
+     */
+    @DeleteMapping("/posts/{postId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> deletePost(
+            @PathVariable Long timeId,
+            @PathVariable Long postId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        courseCommunityService.deletePost(timeId, principal.id(), postId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 코스 커뮤니티 게시글 좋아요
+     * POST /api/times/{timeId}/community/posts/{postId}/like
+     */
+    @PostMapping("/posts/{postId}/like")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> likePost(
+            @PathVariable Long timeId,
+            @PathVariable Long postId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        courseCommunityService.likePost(timeId, principal.id(), postId);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 코스 커뮤니티 게시글 좋아요 취소
+     * DELETE /api/times/{timeId}/community/posts/{postId}/like
+     */
+    @DeleteMapping("/posts/{postId}/like")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> unlikePost(
+            @PathVariable Long timeId,
+            @PathVariable Long postId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        courseCommunityService.unlikePost(timeId, principal.id(), postId);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 코스 커뮤니티 카테고리 목록 조회
+     * GET /api/times/{timeId}/community/categories
+     */
+    @GetMapping("/categories")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<CategoryResponse>> getCategories(
+            @PathVariable Long timeId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CategoryResponse response = courseCommunityService.getCategories(timeId, principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/community/dto/request/CreateCoursePostRequest.java
+++ b/src/main/java/com/mzc/lp/domain/community/dto/request/CreateCoursePostRequest.java
@@ -1,0 +1,36 @@
+package com.mzc.lp.domain.community.dto.request;
+
+import com.mzc.lp.domain.community.constant.PostType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+/**
+ * 코스 커뮤니티 게시글 생성 요청 DTO
+ */
+public record CreateCoursePostRequest(
+        @NotNull(message = "게시글 타입은 필수입니다")
+        PostType type,
+
+        @NotBlank(message = "제목은 필수입니다")
+        @Size(max = 255, message = "제목은 255자 이내여야 합니다")
+        String title,
+
+        @NotBlank(message = "내용은 필수입니다")
+        String content,
+
+        @NotBlank(message = "카테고리는 필수입니다")
+        @Size(max = 50, message = "카테고리는 50자 이내여야 합니다")
+        String category,
+
+        List<String> tags
+) {
+    public String tagsAsString() {
+        if (tags == null || tags.isEmpty()) {
+            return null;
+        }
+        return String.join(",", tags);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/community/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/community/dto/response/PostDetailResponse.java
@@ -22,6 +22,7 @@ public record PostDetailResponse(
         Boolean isLiked,
         Boolean isPinned,
         Boolean isSolved,
+        Long courseTimeId,
         Instant createdAt,
         Instant updatedAt,
         RelatedCourseResponse relatedCourse
@@ -52,6 +53,7 @@ public record PostDetailResponse(
                 isLiked,
                 post.getIsPinned(),
                 post.getIsSolved(),
+                post.getCourseTimeId(),
                 post.getCreatedAt(),
                 post.getUpdatedAt(),
                 null  // relatedCourse는 추후 구현

--- a/src/main/java/com/mzc/lp/domain/community/dto/response/PostResponse.java
+++ b/src/main/java/com/mzc/lp/domain/community/dto/response/PostResponse.java
@@ -22,6 +22,7 @@ public record PostResponse(
         Boolean isLiked,
         Boolean isPinned,
         Boolean isSolved,
+        Long courseTimeId,
         Instant createdAt,
         Instant updatedAt
 ) {
@@ -51,6 +52,7 @@ public record PostResponse(
                 isLiked,
                 post.getIsPinned(),
                 post.getIsSolved(),
+                post.getCourseTimeId(),
                 post.getCreatedAt(),
                 post.getUpdatedAt()
         );

--- a/src/main/java/com/mzc/lp/domain/community/entity/CommunityPost.java
+++ b/src/main/java/com/mzc/lp/domain/community/entity/CommunityPost.java
@@ -13,7 +13,8 @@ import lombok.NoArgsConstructor;
                 @Index(name = "idx_community_post_category", columnList = "category"),
                 @Index(name = "idx_community_post_type", columnList = "type"),
                 @Index(name = "idx_community_post_author", columnList = "author_id"),
-                @Index(name = "idx_community_post_created", columnList = "created_at")
+                @Index(name = "idx_community_post_created", columnList = "created_at"),
+                @Index(name = "idx_community_post_course_time", columnList = "course_time_id")
         })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -47,6 +48,12 @@ public class CommunityPost extends TenantEntity {
     @Column(length = 500)
     private String tags;
 
+    /**
+     * 코스 커뮤니티용 차수 ID (null이면 전체 커뮤니티)
+     */
+    @Column(name = "course_time_id")
+    private Long courseTimeId;
+
     public static CommunityPost create(PostType type, String category, String title, String content, Long authorId, String tags) {
         CommunityPost post = new CommunityPost();
         post.type = type;
@@ -58,6 +65,16 @@ public class CommunityPost extends TenantEntity {
         post.viewCount = 0;
         post.isPinned = false;
         post.isSolved = false;
+        return post;
+    }
+
+    /**
+     * 코스 커뮤니티 게시글 생성
+     */
+    public static CommunityPost createForCourse(PostType type, String category, String title, String content,
+                                                 Long authorId, String tags, Long courseTimeId) {
+        CommunityPost post = create(type, category, title, content, authorId, tags);
+        post.courseTimeId = courseTimeId;
         return post;
     }
 

--- a/src/main/java/com/mzc/lp/domain/community/exception/NotEnrolledException.java
+++ b/src/main/java/com/mzc/lp/domain/community/exception/NotEnrolledException.java
@@ -1,0 +1,18 @@
+package com.mzc.lp.domain.community.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+/**
+ * 코스 커뮤니티 접근 시 수강 등록되지 않은 경우 발생하는 예외
+ */
+public class NotEnrolledException extends BusinessException {
+
+    public NotEnrolledException() {
+        super(ErrorCode.COMMUNITY_NOT_ENROLLED);
+    }
+
+    public NotEnrolledException(Long courseTimeId) {
+        super(ErrorCode.COMMUNITY_NOT_ENROLLED, "Not enrolled in course time: " + courseTimeId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/community/repository/CommunityPostRepository.java
+++ b/src/main/java/com/mzc/lp/domain/community/repository/CommunityPostRepository.java
@@ -55,4 +55,53 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
     long countByCategory(String category);
 
     long countByType(PostType type);
+
+    // ==================== 코스 커뮤니티 관련 메서드 ====================
+
+    /**
+     * 코스 커뮤니티 게시글 목록 조회 (최신순)
+     */
+    @Query("SELECT p FROM CommunityPost p WHERE p.courseTimeId = :courseTimeId " +
+            "AND (:keyword IS NULL OR p.title LIKE %:keyword% OR p.content LIKE %:keyword%) " +
+            "AND (:category IS NULL OR p.category = :category) " +
+            "AND (:type IS NULL OR p.type = :type) " +
+            "ORDER BY p.isPinned DESC, p.createdAt DESC")
+    Page<CommunityPost> findByCourseTimeIdWithFilters(
+            @Param("courseTimeId") Long courseTimeId,
+            @Param("keyword") String keyword,
+            @Param("category") String category,
+            @Param("type") PostType type,
+            Pageable pageable
+    );
+
+    /**
+     * 코스 커뮤니티 게시글 목록 조회 (인기순)
+     */
+    @Query("SELECT p FROM CommunityPost p WHERE p.courseTimeId = :courseTimeId " +
+            "AND (:keyword IS NULL OR p.title LIKE %:keyword% OR p.content LIKE %:keyword%) " +
+            "AND (:category IS NULL OR p.category = :category) " +
+            "AND (:type IS NULL OR p.type = :type) " +
+            "ORDER BY p.isPinned DESC, p.viewCount DESC")
+    Page<CommunityPost> findByCourseTimeIdWithFiltersOrderByPopular(
+            @Param("courseTimeId") Long courseTimeId,
+            @Param("keyword") String keyword,
+            @Param("category") String category,
+            @Param("type") PostType type,
+            Pageable pageable
+    );
+
+    /**
+     * 코스 커뮤니티 게시글 조회
+     */
+    Optional<CommunityPost> findByIdAndCourseTimeId(Long id, Long courseTimeId);
+
+    /**
+     * 코스 커뮤니티 전체 게시글 수
+     */
+    long countByCourseTimeId(Long courseTimeId);
+
+    /**
+     * 코스 커뮤니티 카테고리별 게시글 수
+     */
+    long countByCourseTimeIdAndCategory(Long courseTimeId, String category);
 }

--- a/src/main/java/com/mzc/lp/domain/community/service/CourseCommunityService.java
+++ b/src/main/java/com/mzc/lp/domain/community/service/CourseCommunityService.java
@@ -1,0 +1,306 @@
+package com.mzc.lp.domain.community.service;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.domain.community.constant.PostType;
+import com.mzc.lp.domain.community.dto.request.CreateCoursePostRequest;
+import com.mzc.lp.domain.community.dto.request.UpdatePostRequest;
+import com.mzc.lp.domain.community.dto.response.*;
+import com.mzc.lp.domain.community.entity.CommunityPost;
+import com.mzc.lp.domain.community.entity.CommunityPostLike;
+import com.mzc.lp.domain.community.exception.AlreadyLikedException;
+import com.mzc.lp.domain.community.exception.NotEnrolledException;
+import com.mzc.lp.domain.community.exception.NotPostAuthorException;
+import com.mzc.lp.domain.community.exception.PostNotFoundException;
+import com.mzc.lp.domain.community.repository.CommunityCommentRepository;
+import com.mzc.lp.domain.community.repository.CommunityPostLikeRepository;
+import com.mzc.lp.domain.community.repository.CommunityPostRepository;
+import com.mzc.lp.domain.notification.constant.NotificationType;
+import com.mzc.lp.domain.notification.service.NotificationService;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 코스(차수) 단위 커뮤니티 서비스
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class CourseCommunityService {
+
+    private final CommunityPostRepository postRepository;
+    private final CommunityPostLikeRepository postLikeRepository;
+    private final CommunityCommentRepository commentRepository;
+    private final EnrollmentRepository enrollmentRepository;
+    private final UserRepository userRepository;
+    private final NotificationService notificationService;
+
+    /**
+     * 수강 여부 검증
+     */
+    private void validateEnrollment(Long courseTimeId, Long userId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        boolean isEnrolled = enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(
+                userId, courseTimeId, tenantId);
+        if (!isEnrolled) {
+            throw new NotEnrolledException(courseTimeId);
+        }
+    }
+
+    /**
+     * 코스 커뮤니티 게시글 목록 조회
+     */
+    public PostListResponse getPosts(Long courseTimeId, String keyword, String category,
+                                     String type, String sortBy, int page, int pageSize, Long userId) {
+        // 수강 검증
+        validateEnrollment(courseTimeId, userId);
+
+        PostType postType = null;
+        if (type != null && !type.equalsIgnoreCase("all")) {
+            try {
+                postType = PostType.valueOf(type.toUpperCase());
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+
+        String categoryFilter = (category != null && !category.equalsIgnoreCase("all")) ? category : null;
+        String keywordFilter = (keyword != null && !keyword.isBlank()) ? keyword : null;
+
+        Pageable pageable = PageRequest.of(page, pageSize);
+
+        Page<CommunityPost> postPage;
+        if ("popular".equalsIgnoreCase(sortBy)) {
+            postPage = postRepository.findByCourseTimeIdWithFiltersOrderByPopular(
+                    courseTimeId, keywordFilter, categoryFilter, postType, pageable);
+        } else {
+            postPage = postRepository.findByCourseTimeIdWithFilters(
+                    courseTimeId, keywordFilter, categoryFilter, postType, pageable);
+        }
+
+        List<CommunityPost> posts = postPage.getContent();
+
+        if (posts.isEmpty()) {
+            return PostListResponse.of(List.of(), 0, page, pageSize, 0);
+        }
+
+        // 작성자 벌크 조회
+        Set<Long> authorIds = posts.stream().map(CommunityPost::getAuthorId).collect(Collectors.toSet());
+        Map<Long, User> authorMap = userRepository.findAllById(authorIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        // 좋아요 여부 벌크 조회
+        List<Long> postIds = posts.stream().map(CommunityPost::getId).toList();
+        Set<Long> likedPostIds = new HashSet<>(postLikeRepository.findLikedPostIdsByUserIdAndPostIdIn(userId, postIds));
+
+        // 응답 변환
+        List<PostResponse> postResponses = posts.stream()
+                .map(post -> {
+                    User author = authorMap.get(post.getAuthorId());
+                    long likeCount = postLikeRepository.countByPostId(post.getId());
+                    long commentCount = commentRepository.countByPostId(post.getId());
+                    boolean isLiked = likedPostIds.contains(post.getId());
+                    return PostResponse.from(post, author, likeCount, commentCount, isLiked);
+                })
+                .toList();
+
+        return PostListResponse.of(
+                postResponses,
+                postPage.getTotalElements(),
+                page,
+                pageSize,
+                postPage.getTotalPages()
+        );
+    }
+
+    /**
+     * 코스 커뮤니티 게시글 상세 조회
+     */
+    @Transactional
+    public PostDetailResponse getPost(Long courseTimeId, Long postId, Long userId) {
+        // 수강 검증
+        validateEnrollment(courseTimeId, userId);
+
+        CommunityPost post = postRepository.findByIdAndCourseTimeId(postId, courseTimeId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        // 조회수 증가
+        postRepository.incrementViewCount(postId);
+        post.incrementViewCount();
+
+        User author = userRepository.findById(post.getAuthorId()).orElse(null);
+        long likeCount = postLikeRepository.countByPostId(postId);
+        long commentCount = commentRepository.countByPostId(postId);
+        boolean isLiked = postLikeRepository.existsByPostIdAndUserId(postId, userId);
+
+        return PostDetailResponse.from(post, author, likeCount, commentCount, isLiked);
+    }
+
+    /**
+     * 코스 커뮤니티 게시글 작성
+     */
+    @Transactional
+    public PostResponse createPost(Long courseTimeId, Long userId, CreateCoursePostRequest request) {
+        // 수강 검증
+        validateEnrollment(courseTimeId, userId);
+
+        CommunityPost post = CommunityPost.createForCourse(
+                request.type(),
+                request.category(),
+                request.title(),
+                request.content(),
+                userId,
+                request.tagsAsString(),
+                courseTimeId
+        );
+
+        CommunityPost savedPost = postRepository.save(post);
+
+        User author = userRepository.findById(userId).orElse(null);
+        return PostResponse.from(savedPost, author, 0, 0, false);
+    }
+
+    /**
+     * 코스 커뮤니티 게시글 수정
+     */
+    @Transactional
+    public PostResponse updatePost(Long courseTimeId, Long userId, Long postId, UpdatePostRequest request) {
+        // 수강 검증
+        validateEnrollment(courseTimeId, userId);
+
+        CommunityPost post = postRepository.findByIdAndCourseTimeId(postId, courseTimeId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        if (!post.getAuthorId().equals(userId)) {
+            throw new NotPostAuthorException(postId);
+        }
+
+        post.update(request.title(), request.content(), request.category(), request.tagsAsString());
+
+        User author = userRepository.findById(post.getAuthorId()).orElse(null);
+        long likeCount = postLikeRepository.countByPostId(postId);
+        long commentCount = commentRepository.countByPostId(postId);
+        boolean isLiked = postLikeRepository.existsByPostIdAndUserId(postId, userId);
+
+        return PostResponse.from(post, author, likeCount, commentCount, isLiked);
+    }
+
+    /**
+     * 코스 커뮤니티 게시글 삭제
+     */
+    @Transactional
+    public void deletePost(Long courseTimeId, Long userId, Long postId) {
+        // 수강 검증
+        validateEnrollment(courseTimeId, userId);
+
+        CommunityPost post = postRepository.findByIdAndCourseTimeId(postId, courseTimeId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        if (!post.getAuthorId().equals(userId)) {
+            throw new NotPostAuthorException(postId);
+        }
+
+        // 관련 좋아요 삭제
+        postLikeRepository.deleteByPostId(postId);
+        // 관련 댓글 삭제
+        commentRepository.deleteByPostId(postId);
+        // 게시글 삭제
+        postRepository.delete(post);
+    }
+
+    /**
+     * 코스 커뮤니티 게시글 좋아요
+     */
+    @Transactional
+    public void likePost(Long courseTimeId, Long userId, Long postId) {
+        // 수강 검증
+        validateEnrollment(courseTimeId, userId);
+
+        CommunityPost post = postRepository.findByIdAndCourseTimeId(postId, courseTimeId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        if (postLikeRepository.existsByPostIdAndUserId(postId, userId)) {
+            throw new AlreadyLikedException("Already liked post: " + postId);
+        }
+
+        try {
+            CommunityPostLike like = CommunityPostLike.create(postId, userId);
+            postLikeRepository.save(like);
+            postLikeRepository.flush();
+
+            // 알림 생성: 게시글 작성자에게 (본인 제외)
+            if (!post.getAuthorId().equals(userId)) {
+                User actor = userRepository.findById(userId).orElse(null);
+                String actorName = actor != null ? actor.getName() : "알 수 없음";
+
+                notificationService.createNotification(
+                        post.getAuthorId(),
+                        NotificationType.LIKE,
+                        "게시글에 좋아요를 받았습니다",
+                        actorName + "님이 \"" + truncate(post.getTitle(), 20) + "\" 게시글을 좋아합니다.",
+                        "/tu/b2c/times/" + courseTimeId + "/community/" + postId,
+                        postId,
+                        "COURSE_POST_LIKE",
+                        userId,
+                        actorName
+                );
+            }
+        } catch (DataIntegrityViolationException e) {
+            log.debug("Concurrent like attempt detected for post {} by user {}", postId, userId);
+            throw new AlreadyLikedException("Already liked post: " + postId);
+        }
+    }
+
+    private String truncate(String text, int maxLength) {
+        if (text == null) return "";
+        return text.length() > maxLength ? text.substring(0, maxLength) + "..." : text;
+    }
+
+    /**
+     * 코스 커뮤니티 게시글 좋아요 취소
+     */
+    @Transactional
+    public void unlikePost(Long courseTimeId, Long userId, Long postId) {
+        // 수강 검증
+        validateEnrollment(courseTimeId, userId);
+
+        if (!postRepository.existsById(postId)) {
+            throw new PostNotFoundException(postId);
+        }
+
+        postLikeRepository.deleteByPostIdAndUserId(postId, userId);
+    }
+
+    /**
+     * 코스 커뮤니티 카테고리 목록 조회
+     */
+    public CategoryResponse getCategories(Long courseTimeId, Long userId) {
+        // 수강 검증
+        validateEnrollment(courseTimeId, userId);
+
+        List<CategoryResponse.CategoryItem> categories = List.of(
+                CategoryResponse.CategoryItem.of("all", "전체", null,
+                        postRepository.countByCourseTimeId(courseTimeId), "grid"),
+                CategoryResponse.CategoryItem.of("question", "Q&A", null,
+                        postRepository.countByCourseTimeIdAndCategory(courseTimeId, "question"), "help-circle"),
+                CategoryResponse.CategoryItem.of("tip", "학습 팁", null,
+                        postRepository.countByCourseTimeIdAndCategory(courseTimeId, "tip"), "lightbulb"),
+                CategoryResponse.CategoryItem.of("discussion", "스터디/토론", null,
+                        postRepository.countByCourseTimeIdAndCategory(courseTimeId, "discussion"), "users")
+        );
+
+        return CategoryResponse.of(categories);
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/community/service/CourseCommunityServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/community/service/CourseCommunityServiceTest.java
@@ -1,0 +1,421 @@
+package com.mzc.lp.domain.community.service;
+
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.community.constant.PostType;
+import com.mzc.lp.domain.community.dto.request.CreateCoursePostRequest;
+import com.mzc.lp.domain.community.dto.request.UpdatePostRequest;
+import com.mzc.lp.domain.community.dto.response.CategoryResponse;
+import com.mzc.lp.domain.community.dto.response.PostDetailResponse;
+import com.mzc.lp.domain.community.dto.response.PostListResponse;
+import com.mzc.lp.domain.community.dto.response.PostResponse;
+import com.mzc.lp.domain.community.entity.CommunityPost;
+import com.mzc.lp.domain.community.exception.NotEnrolledException;
+import com.mzc.lp.domain.community.exception.NotPostAuthorException;
+import com.mzc.lp.domain.community.exception.PostNotFoundException;
+import com.mzc.lp.domain.community.repository.CommunityCommentRepository;
+import com.mzc.lp.domain.community.repository.CommunityPostLikeRepository;
+import com.mzc.lp.domain.community.repository.CommunityPostRepository;
+import com.mzc.lp.domain.notification.service.NotificationService;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CourseCommunityService 테스트")
+class CourseCommunityServiceTest extends TenantTestSupport {
+
+    protected static final Long TENANT_ID = DEFAULT_TENANT_ID;
+
+    @InjectMocks
+    private CourseCommunityService courseCommunityService;
+
+    @Mock
+    private CommunityPostRepository postRepository;
+
+    @Mock
+    private CommunityPostLikeRepository postLikeRepository;
+
+    @Mock
+    private CommunityCommentRepository commentRepository;
+
+    @Mock
+    private EnrollmentRepository enrollmentRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private NotificationService notificationService;
+
+    private CommunityPost createTestPost(Long id, Long courseTimeId, Long authorId) {
+        CommunityPost post = CommunityPost.createForCourse(
+                PostType.QUESTION,
+                "question",
+                "테스트 제목",
+                "테스트 내용",
+                authorId,
+                "tag1,tag2",
+                courseTimeId
+        );
+        // Reflection을 사용하여 id 설정 (테스트용)
+        // CommunityPost -> TenantEntity -> BaseTimeEntity -> BaseEntity (id 필드 위치)
+        try {
+            var idField = CommunityPost.class.getSuperclass().getSuperclass().getSuperclass().getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(post, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return post;
+    }
+
+    private User createTestUser(Long id, String name) {
+        User user = User.create(
+                "test" + id + "@test.com",
+                name,
+                "encodedPassword123"
+        );
+        // Reflection을 사용하여 id 설정 (테스트용)
+        // User -> TenantEntity -> BaseTimeEntity -> BaseEntity (id 필드 위치)
+        try {
+            var idField = User.class.getSuperclass().getSuperclass().getSuperclass().getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(user, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return user;
+    }
+
+    // ==================== 게시글 목록 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("getPosts - 코스 커뮤니티 게시글 목록 조회")
+    class GetPosts {
+
+        @Test
+        @DisplayName("성공 - 수강생이 게시글 목록 조회")
+        void getPosts_success() {
+            // given
+            Long courseTimeId = 1L;
+            Long userId = 100L;
+            int page = 0, pageSize = 20;
+
+            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, TENANT_ID))
+                    .willReturn(true);
+
+            List<CommunityPost> posts = List.of(
+                    createTestPost(1L, courseTimeId, userId),
+                    createTestPost(2L, courseTimeId, 101L)
+            );
+            Page<CommunityPost> postPage = new PageImpl<>(posts, PageRequest.of(page, pageSize), posts.size());
+
+            given(postRepository.findByCourseTimeIdWithFilters(
+                    eq(courseTimeId), isNull(), isNull(), isNull(), any(Pageable.class)))
+                    .willReturn(postPage);
+
+            given(userRepository.findAllById(anySet()))
+                    .willReturn(List.of(createTestUser(userId, "테스트유저"), createTestUser(101L, "유저2")));
+
+            given(postLikeRepository.findLikedPostIdsByUserIdAndPostIdIn(eq(userId), anyList()))
+                    .willReturn(List.of());
+
+            given(postLikeRepository.countByPostId(anyLong())).willReturn(0L);
+            given(commentRepository.countByPostId(anyLong())).willReturn(0L);
+
+            // when
+            PostListResponse response = courseCommunityService.getPosts(
+                    courseTimeId, null, null, null, "latest", page, pageSize, userId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.posts()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("실패 - 수강생이 아닌 경우")
+        void getPosts_fail_notEnrolled() {
+            // given
+            Long courseTimeId = 1L;
+            Long userId = 100L;
+
+            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, TENANT_ID))
+                    .willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> courseCommunityService.getPosts(
+                    courseTimeId, null, null, null, "latest", 0, 20, userId))
+                    .isInstanceOf(NotEnrolledException.class);
+        }
+    }
+
+    // ==================== 게시글 작성 테스트 ====================
+
+    @Nested
+    @DisplayName("createPost - 코스 커뮤니티 게시글 작성")
+    class CreatePost {
+
+        @Test
+        @DisplayName("성공 - 수강생이 게시글 작성")
+        void createPost_success() {
+            // given
+            Long courseTimeId = 1L;
+            Long userId = 100L;
+
+            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, TENANT_ID))
+                    .willReturn(true);
+
+            CreateCoursePostRequest request = new CreateCoursePostRequest(
+                    PostType.QUESTION,
+                    "테스트 제목",
+                    "테스트 내용",
+                    "question",
+                    List.of("tag1", "tag2")
+            );
+
+            CommunityPost savedPost = createTestPost(1L, courseTimeId, userId);
+            given(postRepository.save(any(CommunityPost.class))).willReturn(savedPost);
+            given(userRepository.findById(userId)).willReturn(Optional.of(createTestUser(userId, "테스트유저")));
+
+            // when
+            PostResponse response = courseCommunityService.createPost(courseTimeId, userId, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.courseTimeId()).isEqualTo(courseTimeId);
+            verify(postRepository).save(any(CommunityPost.class));
+        }
+
+        @Test
+        @DisplayName("실패 - 수강생이 아닌 경우")
+        void createPost_fail_notEnrolled() {
+            // given
+            Long courseTimeId = 1L;
+            Long userId = 100L;
+
+            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, TENANT_ID))
+                    .willReturn(false);
+
+            CreateCoursePostRequest request = new CreateCoursePostRequest(
+                    PostType.QUESTION,
+                    "테스트 제목",
+                    "테스트 내용",
+                    "question",
+                    null
+            );
+
+            // when & then
+            assertThatThrownBy(() -> courseCommunityService.createPost(courseTimeId, userId, request))
+                    .isInstanceOf(NotEnrolledException.class);
+        }
+    }
+
+    // ==================== 게시글 상세 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("getPost - 코스 커뮤니티 게시글 상세 조회")
+    class GetPost {
+
+        @Test
+        @DisplayName("성공 - 수강생이 게시글 상세 조회")
+        void getPost_success() {
+            // given
+            Long courseTimeId = 1L;
+            Long postId = 1L;
+            Long userId = 100L;
+
+            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, TENANT_ID))
+                    .willReturn(true);
+
+            CommunityPost post = createTestPost(postId, courseTimeId, userId);
+            given(postRepository.findByIdAndCourseTimeId(postId, courseTimeId))
+                    .willReturn(Optional.of(post));
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(createTestUser(userId, "테스트유저")));
+            given(postLikeRepository.countByPostId(postId)).willReturn(5L);
+            given(commentRepository.countByPostId(postId)).willReturn(3L);
+            given(postLikeRepository.existsByPostIdAndUserId(postId, userId)).willReturn(true);
+
+            // when
+            PostDetailResponse response = courseCommunityService.getPost(courseTimeId, postId, userId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.id()).isEqualTo(postId);
+            assertThat(response.courseTimeId()).isEqualTo(courseTimeId);
+            assertThat(response.likeCount()).isEqualTo(5L);
+            assertThat(response.commentCount()).isEqualTo(3L);
+            assertThat(response.isLiked()).isTrue();
+            verify(postRepository).incrementViewCount(postId);
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 게시글")
+        void getPost_fail_notFound() {
+            // given
+            Long courseTimeId = 1L;
+            Long postId = 999L;
+            Long userId = 100L;
+
+            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, TENANT_ID))
+                    .willReturn(true);
+            given(postRepository.findByIdAndCourseTimeId(postId, courseTimeId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> courseCommunityService.getPost(courseTimeId, postId, userId))
+                    .isInstanceOf(PostNotFoundException.class);
+        }
+    }
+
+    // ==================== 게시글 수정 테스트 ====================
+
+    @Nested
+    @DisplayName("updatePost - 코스 커뮤니티 게시글 수정")
+    class UpdatePost {
+
+        @Test
+        @DisplayName("성공 - 작성자가 게시글 수정")
+        void updatePost_success() {
+            // given
+            Long courseTimeId = 1L;
+            Long postId = 1L;
+            Long userId = 100L;
+
+            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, TENANT_ID))
+                    .willReturn(true);
+
+            CommunityPost post = createTestPost(postId, courseTimeId, userId);
+            given(postRepository.findByIdAndCourseTimeId(postId, courseTimeId))
+                    .willReturn(Optional.of(post));
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(createTestUser(userId, "테스트유저")));
+            given(postLikeRepository.countByPostId(postId)).willReturn(0L);
+            given(commentRepository.countByPostId(postId)).willReturn(0L);
+            given(postLikeRepository.existsByPostIdAndUserId(postId, userId)).willReturn(false);
+
+            UpdatePostRequest request = new UpdatePostRequest(
+                    "수정된 제목",
+                    "수정된 내용",
+                    "question",
+                    List.of("newtag")
+            );
+
+            // when
+            PostResponse response = courseCommunityService.updatePost(courseTimeId, userId, postId, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.title()).isEqualTo("수정된 제목");
+        }
+
+        @Test
+        @DisplayName("실패 - 작성자가 아닌 경우")
+        void updatePost_fail_notAuthor() {
+            // given
+            Long courseTimeId = 1L;
+            Long postId = 1L;
+            Long userId = 100L;
+            Long anotherUserId = 200L;
+
+            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(anotherUserId, courseTimeId, TENANT_ID))
+                    .willReturn(true);
+
+            CommunityPost post = createTestPost(postId, courseTimeId, userId);
+            given(postRepository.findByIdAndCourseTimeId(postId, courseTimeId))
+                    .willReturn(Optional.of(post));
+
+            UpdatePostRequest request = new UpdatePostRequest(
+                    "수정된 제목",
+                    "수정된 내용",
+                    "question",
+                    null
+            );
+
+            // when & then
+            assertThatThrownBy(() -> courseCommunityService.updatePost(courseTimeId, anotherUserId, postId, request))
+                    .isInstanceOf(NotPostAuthorException.class);
+        }
+    }
+
+    // ==================== 게시글 삭제 테스트 ====================
+
+    @Nested
+    @DisplayName("deletePost - 코스 커뮤니티 게시글 삭제")
+    class DeletePost {
+
+        @Test
+        @DisplayName("성공 - 작성자가 게시글 삭제")
+        void deletePost_success() {
+            // given
+            Long courseTimeId = 1L;
+            Long postId = 1L;
+            Long userId = 100L;
+
+            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, TENANT_ID))
+                    .willReturn(true);
+
+            CommunityPost post = createTestPost(postId, courseTimeId, userId);
+            given(postRepository.findByIdAndCourseTimeId(postId, courseTimeId))
+                    .willReturn(Optional.of(post));
+
+            // when
+            courseCommunityService.deletePost(courseTimeId, userId, postId);
+
+            // then
+            verify(postLikeRepository).deleteByPostId(postId);
+            verify(commentRepository).deleteByPostId(postId);
+            verify(postRepository).delete(post);
+        }
+    }
+
+    // ==================== 카테고리 조회 테스트 ====================
+
+    @Nested
+    @DisplayName("getCategories - 코스 커뮤니티 카테고리 조회")
+    class GetCategories {
+
+        @Test
+        @DisplayName("성공 - 카테고리 목록 조회")
+        void getCategories_success() {
+            // given
+            Long courseTimeId = 1L;
+            Long userId = 100L;
+
+            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, TENANT_ID))
+                    .willReturn(true);
+
+            given(postRepository.countByCourseTimeId(courseTimeId)).willReturn(10L);
+            given(postRepository.countByCourseTimeIdAndCategory(courseTimeId, "question")).willReturn(5L);
+            given(postRepository.countByCourseTimeIdAndCategory(courseTimeId, "tip")).willReturn(3L);
+            given(postRepository.countByCourseTimeIdAndCategory(courseTimeId, "discussion")).willReturn(2L);
+
+            // when
+            CategoryResponse response = courseCommunityService.getCategories(courseTimeId, userId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.categories()).hasSize(4);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

코스 수강생 간 소통을 위한 코스 커뮤니티 기능 추가

## Related Issue

- Closes #313

## Changes

- CommunityPost 엔티티에 courseTimeId 필드 추가
- 코스 커뮤니티 전용 API 엔드포인트 구현
  - GET/POST /api/times/{timeId}/community/posts
  - GET/PATCH/DELETE /api/times/{timeId}/community/posts/{postId}
  - POST/DELETE /api/times/{timeId}/community/posts/{postId}/like
  - GET /api/times/{timeId}/community/categories
- 수강 등록 여부 검증 로직 추가 (NotEnrolledException)
- PostResponse, PostDetailResponse에 courseTimeId 필드 추가
- 코스 커뮤니티 서비스 테스트 케이스 10개 작성

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 수강생만 해당 코스 커뮤니티에 접근 가능 (403 반환)
- 기존 전체 커뮤니티와 분리된 코스별 커뮤니티 운영