### PR TITLE
feat: TU(강의 설계자/소유자) Roadmap 관리 기능 구현 #320

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -160,7 +160,15 @@ public enum ErrorCode {
     AUTO_ENROLLMENT_RULE_NOT_FOUND(HttpStatus.NOT_FOUND, "AER001", "Auto enrollment rule not found"),
 
     // Member Pool (MP)
-    MEMBER_POOL_NOT_FOUND(HttpStatus.NOT_FOUND, "MP001", "Member pool not found");
+    MEMBER_POOL_NOT_FOUND(HttpStatus.NOT_FOUND, "MP001", "Member pool not found"),
+
+    // Roadmap (RM)
+    ROADMAP_NOT_FOUND(HttpStatus.NOT_FOUND, "RM001", "Roadmap not found"),
+    ROADMAP_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST, "RM002", "Roadmap is not modifiable in current status"),
+    UNAUTHORIZED_ROADMAP_ACCESS(HttpStatus.FORBIDDEN, "RM003", "Not authorized to access this roadmap"),
+    INVALID_PROGRAM_FOR_ROADMAP(HttpStatus.BAD_REQUEST, "RM004", "Invalid program for roadmap"),
+    DUPLICATE_PROGRAM_IN_ROADMAP(HttpStatus.CONFLICT, "RM005", "Program already exists in roadmap"),
+    ROADMAP_HAS_ENROLLMENTS(HttpStatus.BAD_REQUEST, "RM006", "Cannot delete roadmap with enrollments");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/mzc/lp/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/mzc/lp/domain/program/controller/ProgramController.java
@@ -190,4 +190,23 @@ public class ProgramController {
         ProgramResponse response = programService.linkSnapshot(programId, snapshotId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
+
+    /**
+     * 내 프로그램 목록 조회 (로드맵 생성용)
+     * GET /api/programs/my
+     */
+    @GetMapping("/my")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OWNER')")
+    public ResponseEntity<ApiResponse<Page<ProgramResponse>>> getMyPrograms(
+            @RequestParam(required = false) String search,
+            @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Page<ProgramResponse> response = programService.getMyPrograms(
+                principal.id(),
+                search,
+                pageable
+        );
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 }

--- a/src/main/java/com/mzc/lp/domain/program/repository/ProgramRepository.java
+++ b/src/main/java/com/mzc/lp/domain/program/repository/ProgramRepository.java
@@ -96,4 +96,32 @@ public interface ProgramRepository extends JpaRepository<Program, Long> {
     List<ProgramStatsProjection> findProgramStatsByOwner(
             @Param("createdBy") Long createdBy,
             @Param("tenantId") Long tenantId);
+
+    // ===== 로드맵 생성용 내 프로그램 조회 =====
+
+    /**
+     * 제목으로 검색 (tenantId 필터)
+     */
+    Page<Program> findByTenantIdAndTitleContaining(Long tenantId, String title, Pageable pageable);
+
+    /**
+     * ID 목록과 제목으로 검색
+     */
+    @Query("SELECT p FROM Program p WHERE p.tenantId = :tenantId AND p.id IN :ids AND p.title LIKE %:title%")
+    Page<Program> findByTenantIdAndIdInAndTitleContaining(
+            @Param("tenantId") Long tenantId,
+            @Param("ids") java.util.Set<Long> ids,
+            @Param("title") String title,
+            Pageable pageable
+    );
+
+    /**
+     * ID 목록으로 조회
+     */
+    @Query("SELECT p FROM Program p WHERE p.tenantId = :tenantId AND p.id IN :ids")
+    Page<Program> findByTenantIdAndIdIn(
+            @Param("tenantId") Long tenantId,
+            @Param("ids") java.util.Set<Long> ids,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/mzc/lp/domain/program/service/ProgramService.java
+++ b/src/main/java/com/mzc/lp/domain/program/service/ProgramService.java
@@ -37,4 +37,7 @@ public interface ProgramService {
 
     // Snapshot 연결
     ProgramResponse linkSnapshot(Long programId, Long snapshotId);
+
+    // 내 프로그램 조회 (로드맵 생성용)
+    Page<ProgramResponse> getMyPrograms(Long userId, String search, Pageable pageable);
 }

--- a/src/main/java/com/mzc/lp/domain/roadmap/constant/RoadmapStatus.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/constant/RoadmapStatus.java
@@ -1,0 +1,16 @@
+package com.mzc.lp.domain.roadmap.constant;
+
+/**
+ * 로드맵 상태
+ */
+public enum RoadmapStatus {
+    /**
+     * 작성 중
+     */
+    DRAFT,
+
+    /**
+     * 공개됨
+     */
+    PUBLISHED
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/controller/RoadmapController.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/controller/RoadmapController.java
@@ -1,0 +1,161 @@
+package com.mzc.lp.domain.roadmap.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.roadmap.constant.RoadmapStatus;
+import com.mzc.lp.domain.roadmap.dto.request.CreateRoadmapRequest;
+import com.mzc.lp.domain.roadmap.dto.request.SaveDraftRequest;
+import com.mzc.lp.domain.roadmap.dto.request.UpdateRoadmapRequest;
+import com.mzc.lp.domain.roadmap.dto.response.RoadmapDetailResponse;
+import com.mzc.lp.domain.roadmap.dto.response.RoadmapResponse;
+import com.mzc.lp.domain.roadmap.dto.response.RoadmapStatisticsResponse;
+import com.mzc.lp.domain.roadmap.service.RoadmapService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 로드맵 Controller
+ */
+@RestController
+@RequiredArgsConstructor
+@Validated
+@RequestMapping("/api/roadmaps")
+public class RoadmapController {
+
+    private final RoadmapService roadmapService;
+
+    /**
+     * 로드맵 생성
+     * POST /api/roadmaps
+     */
+    @PostMapping
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OWNER')")
+    public ResponseEntity<ApiResponse<RoadmapResponse>> createRoadmap(
+            @Valid @RequestBody CreateRoadmapRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        RoadmapResponse response = roadmapService.createRoadmap(request, principal.id());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
+    }
+
+    /**
+     * 내 로드맵 목록 조회 (필터링, 정렬 지원)
+     * GET /api/roadmaps?status=draft&sortBy=updatedAt
+     */
+    @GetMapping
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OWNER')")
+    public ResponseEntity<ApiResponse<Page<RoadmapResponse>>> getMyRoadmaps(
+            @RequestParam(required = false) String status,
+            @RequestParam(defaultValue = "updatedAt") String sortBy,
+            @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        RoadmapStatus roadmapStatus = status != null
+                ? RoadmapStatus.valueOf(status.toUpperCase())
+                : null;
+
+        Page<RoadmapResponse> response = roadmapService.getMyRoadmaps(
+                principal.id(),
+                roadmapStatus,
+                sortBy,
+                pageable
+        );
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 로드맵 상세 조회
+     * GET /api/roadmaps/{id}
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<RoadmapDetailResponse>> getRoadmap(
+            @PathVariable @Positive Long id,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        RoadmapDetailResponse response = roadmapService.getRoadmap(id, principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 로드맵 수정 (전체 검증)
+     * PATCH /api/roadmaps/{id}
+     */
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OWNER')")
+    public ResponseEntity<ApiResponse<RoadmapResponse>> updateRoadmap(
+            @PathVariable @Positive Long id,
+            @Valid @RequestBody UpdateRoadmapRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        RoadmapResponse response = roadmapService.updateRoadmap(id, request, principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 로드맵 임시저장 (최소 검증)
+     * PATCH /api/roadmaps/{id}/draft
+     */
+    @PatchMapping("/{id}/draft")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OWNER')")
+    public ResponseEntity<ApiResponse<RoadmapResponse>> saveDraft(
+            @PathVariable @Positive Long id,
+            @Valid @RequestBody SaveDraftRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        RoadmapResponse response = roadmapService.saveDraft(id, request, principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 로드맵 삭제
+     * DELETE /api/roadmaps/{id}
+     */
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OWNER')")
+    public ResponseEntity<Void> deleteRoadmap(
+            @PathVariable @Positive Long id,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        roadmapService.deleteRoadmap(id, principal.id());
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 로드맵 복제
+     * POST /api/roadmaps/{id}/duplicate
+     */
+    @PostMapping("/{id}/duplicate")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OWNER')")
+    public ResponseEntity<ApiResponse<RoadmapResponse>> duplicateRoadmap(
+            @PathVariable @Positive Long id,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        RoadmapResponse response = roadmapService.duplicateRoadmap(id, principal.id());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
+    }
+
+    /**
+     * 통계 조회
+     * GET /api/roadmaps/statistics
+     */
+    @GetMapping("/statistics")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OWNER')")
+    public ResponseEntity<ApiResponse<RoadmapStatisticsResponse>> getStatistics(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        RoadmapStatisticsResponse response = roadmapService.getStatistics(principal.id());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/dto/request/CreateRoadmapRequest.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/dto/request/CreateRoadmapRequest.java
@@ -1,0 +1,23 @@
+package com.mzc.lp.domain.roadmap.dto.request;
+
+import com.mzc.lp.domain.roadmap.constant.RoadmapStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record CreateRoadmapRequest(
+        @NotBlank(message = "제목은 필수입니다")
+        @Size(max = 255, message = "제목은 255자 이하여야 합니다")
+        String title,
+
+        @Size(max = 5000, message = "설명은 5000자 이하여야 합니다")
+        String description,
+
+        @NotEmpty(message = "최소 1개 이상의 프로그램이 필요합니다")
+        List<Long> programIds,
+
+        RoadmapStatus status
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/dto/request/SaveDraftRequest.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/dto/request/SaveDraftRequest.java
@@ -1,0 +1,18 @@
+package com.mzc.lp.domain.roadmap.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record SaveDraftRequest(
+        @NotBlank(message = "제목은 필수입니다")
+        @Size(max = 255, message = "제목은 255자 이하여야 합니다")
+        String title,
+
+        @Size(max = 5000, message = "설명은 5000자 이하여야 합니다")
+        String description,
+
+        List<Long> programIds  // 빈 배열 허용
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/dto/request/UpdateRoadmapRequest.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/dto/request/UpdateRoadmapRequest.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.domain.roadmap.dto.request;
+
+import com.mzc.lp.domain.roadmap.constant.RoadmapStatus;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record UpdateRoadmapRequest(
+        @Size(max = 255, message = "제목은 255자 이하여야 합니다")
+        String title,
+
+        @Size(max = 5000, message = "설명은 5000자 이하여야 합니다")
+        String description,
+
+        List<Long> programIds,
+
+        RoadmapStatus status
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/dto/response/RoadmapDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/dto/response/RoadmapDetailResponse.java
@@ -1,0 +1,32 @@
+package com.mzc.lp.domain.roadmap.dto.response;
+
+import com.mzc.lp.domain.roadmap.entity.Roadmap;
+
+import java.time.Instant;
+import java.util.List;
+
+public record RoadmapDetailResponse(
+        Long id,
+        String title,
+        String description,
+        Integer courseCount,
+        Integer enrolledStudents,
+        String status,
+        Instant createdAt,
+        Instant updatedAt,
+        List<RoadmapProgramDto> programs
+) {
+    public static RoadmapDetailResponse from(Roadmap roadmap, List<RoadmapProgramDto> programs) {
+        return new RoadmapDetailResponse(
+                roadmap.getId(),
+                roadmap.getTitle(),
+                roadmap.getDescription(),
+                programs.size(),
+                roadmap.getEnrolledStudents(),
+                roadmap.getStatus().name().toLowerCase(),
+                roadmap.getCreatedAt(),
+                roadmap.getUpdatedAt(),
+                programs
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/dto/response/RoadmapProgramDto.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/dto/response/RoadmapProgramDto.java
@@ -1,0 +1,34 @@
+package com.mzc.lp.domain.roadmap.dto.response;
+
+import com.mzc.lp.domain.program.entity.Program;
+import com.mzc.lp.domain.roadmap.entity.RoadmapProgram;
+
+public record RoadmapProgramDto(
+        Long id,
+        String title,
+        String category,
+        String duration,
+        Integer order
+) {
+    public static RoadmapProgramDto from(RoadmapProgram roadmapProgram) {
+        Program program = roadmapProgram.getProgram();
+
+        // duration 계산 (estimatedHours를 "N시간" 형식으로 변환)
+        String duration = program.getEstimatedHours() != null
+            ? program.getEstimatedHours() + "시간"
+            : "";
+
+        // category는 program의 type을 사용 (또는 별도 카테고리 필드가 있다면 그것 사용)
+        String category = program.getType() != null
+            ? program.getType().name()
+            : "";
+
+        return new RoadmapProgramDto(
+                program.getId(),
+                program.getTitle(),
+                category,
+                duration,
+                roadmapProgram.getOrderIndex()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/dto/response/RoadmapResponse.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/dto/response/RoadmapResponse.java
@@ -1,0 +1,29 @@
+package com.mzc.lp.domain.roadmap.dto.response;
+
+import com.mzc.lp.domain.roadmap.entity.Roadmap;
+
+import java.time.Instant;
+
+public record RoadmapResponse(
+        Long id,
+        String title,
+        String description,
+        Integer courseCount,
+        Integer enrolledStudents,
+        String status,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static RoadmapResponse from(Roadmap roadmap, Integer courseCount) {
+        return new RoadmapResponse(
+                roadmap.getId(),
+                roadmap.getTitle(),
+                roadmap.getDescription(),
+                courseCount,
+                roadmap.getEnrolledStudents(),
+                roadmap.getStatus().name().toLowerCase(),
+                roadmap.getCreatedAt(),
+                roadmap.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/dto/response/RoadmapStatisticsResponse.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/dto/response/RoadmapStatisticsResponse.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.domain.roadmap.dto.response;
+
+public record RoadmapStatisticsResponse(
+        Integer totalRoadmaps,
+        Integer totalEnrollments,
+        Double averageCourseCount
+) {
+    public static RoadmapStatisticsResponse of(
+            long totalRoadmaps,
+            long totalEnrollments,
+            Double averageCourseCount
+    ) {
+        return new RoadmapStatisticsResponse(
+                (int) totalRoadmaps,
+                (int) totalEnrollments,
+                averageCourseCount != null ? averageCourseCount : 0.0
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/entity/Roadmap.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/entity/Roadmap.java
@@ -1,0 +1,157 @@
+package com.mzc.lp.domain.roadmap.entity;
+
+import com.mzc.lp.common.constant.ValidationMessages;
+import com.mzc.lp.common.entity.TenantEntity;
+import com.mzc.lp.domain.roadmap.constant.RoadmapStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 로드맵 엔티티
+ * 여러 강의(Program)를 묶어 학습 경로를 제공
+ */
+@Entity
+@Table(
+    name = "roadmaps",
+    indexes = {
+        @Index(name = "idx_roadmap_author_status", columnList = "author_id, status"),
+        @Index(name = "idx_roadmap_tenant_status", columnList = "tenant_id, status"),
+        @Index(name = "idx_roadmap_updated_at", columnList = "updated_at")
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Roadmap extends TenantEntity {
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "author_id", nullable = false)
+    private Long authorId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private RoadmapStatus status;
+
+    @Column(name = "enrolled_students", nullable = false)
+    private Integer enrolledStudents = 0;
+
+    // ===== 정적 팩토리 메서드 =====
+
+    /**
+     * 로드맵 생성
+     */
+    public static Roadmap create(String title, String description, Long authorId, RoadmapStatus status) {
+        Roadmap roadmap = new Roadmap();
+        roadmap.validateTitle(title);
+        roadmap.title = title;
+        roadmap.description = description;
+        roadmap.authorId = authorId;
+        roadmap.status = status != null ? status : RoadmapStatus.DRAFT;
+        roadmap.enrolledStudents = 0;
+        return roadmap;
+    }
+
+    /**
+     * 로드맵 복제
+     */
+    public static Roadmap duplicate(Roadmap original, Long newAuthorId) {
+        String duplicateTitle = generateDuplicateTitle(original.title);
+        Roadmap roadmap = new Roadmap();
+        roadmap.title = duplicateTitle;
+        roadmap.description = original.description;
+        roadmap.authorId = newAuthorId;
+        roadmap.status = RoadmapStatus.DRAFT;
+        roadmap.enrolledStudents = 0;
+        return roadmap;
+    }
+
+    // ===== 비즈니스 메서드 =====
+
+    /**
+     * 기본 정보 업데이트 (임시저장용)
+     */
+    public void updateBasicInfo(String title, String description) {
+        if (title != null) {
+            validateTitle(title);
+            this.title = title;
+        }
+        this.description = description;
+    }
+
+    /**
+     * 전체 정보 업데이트 (일반 수정용)
+     */
+    public void update(String title, String description, RoadmapStatus status) {
+        if (title != null) {
+            validateTitle(title);
+            this.title = title;
+        }
+        this.description = description;
+        if (status != null) {
+            this.status = status;
+        }
+    }
+
+    /**
+     * 공개 상태로 변경
+     */
+    public void publish() {
+        this.status = RoadmapStatus.PUBLISHED;
+    }
+
+    /**
+     * 작성 중 상태로 변경
+     */
+    public void unpublish() {
+        this.status = RoadmapStatus.DRAFT;
+    }
+
+    // ===== 상태 확인 메서드 =====
+
+    public boolean isDraft() {
+        return this.status == RoadmapStatus.DRAFT;
+    }
+
+    public boolean isPublished() {
+        return this.status == RoadmapStatus.PUBLISHED;
+    }
+
+    public boolean isModifiable() {
+        return this.status == RoadmapStatus.DRAFT;
+    }
+
+    public boolean isOwnedBy(Long userId) {
+        return this.authorId.equals(userId);
+    }
+
+    // ===== Private 검증 메서드 =====
+
+    private void validateTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException(ValidationMessages.TITLE_REQUIRED);
+        }
+        if (title.length() > 255) {
+            throw new IllegalArgumentException(ValidationMessages.TITLE_TOO_LONG);
+        }
+    }
+
+    private static String generateDuplicateTitle(String originalTitle) {
+        String suffix = " (복사본)";
+        // 중복 방지: "(복사본)"이 이미 있으면 번호 추가
+        if (originalTitle.endsWith(suffix)) {
+            return originalTitle + " 2";
+        }
+        // 제목 길이 제한 체크 (255자)
+        if (originalTitle.length() + suffix.length() > 255) {
+            int maxLength = 255 - suffix.length();
+            return originalTitle.substring(0, maxLength) + suffix;
+        }
+        return originalTitle + suffix;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/entity/RoadmapProgram.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/entity/RoadmapProgram.java
@@ -1,0 +1,64 @@
+package com.mzc.lp.domain.roadmap.entity;
+
+import com.mzc.lp.common.entity.BaseEntity;
+import com.mzc.lp.domain.program.entity.Program;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 로드맵-프로그램 연결 엔티티
+ * 로드맵에 포함된 프로그램과 순서 정보를 관리
+ */
+@Entity
+@Table(
+    name = "roadmap_programs",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_roadmap_program",
+            columnNames = {"roadmap_id", "program_id"}
+        )
+    },
+    indexes = {
+        @Index(name = "idx_roadmap_program_roadmap", columnList = "roadmap_id, order_index"),
+        @Index(name = "idx_roadmap_program_program", columnList = "program_id")
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoadmapProgram extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "roadmap_id", nullable = false)
+    private Roadmap roadmap;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "program_id", nullable = false)
+    private Program program;
+
+    @Column(name = "order_index", nullable = false)
+    private Integer orderIndex;
+
+    // ===== 정적 팩토리 메서드 =====
+
+    /**
+     * 로드맵-프로그램 연결 생성
+     */
+    public static RoadmapProgram create(Roadmap roadmap, Program program, Integer orderIndex) {
+        RoadmapProgram roadmapProgram = new RoadmapProgram();
+        roadmapProgram.roadmap = roadmap;
+        roadmapProgram.program = program;
+        roadmapProgram.orderIndex = orderIndex;
+        return roadmapProgram;
+    }
+
+    // ===== 비즈니스 메서드 =====
+
+    /**
+     * 순서 변경
+     */
+    public void updateOrder(Integer newOrderIndex) {
+        this.orderIndex = newOrderIndex;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/exception/DuplicateProgramInRoadmapException.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/exception/DuplicateProgramInRoadmapException.java
@@ -1,0 +1,12 @@
+package com.mzc.lp.domain.roadmap.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class DuplicateProgramInRoadmapException extends BusinessException {
+
+    public DuplicateProgramInRoadmapException(Long programId) {
+        super(ErrorCode.DUPLICATE_PROGRAM_IN_ROADMAP,
+            "이미 로드맵에 포함된 프로그램입니다. ID: " + programId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/exception/InvalidProgramException.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/exception/InvalidProgramException.java
@@ -1,0 +1,16 @@
+package com.mzc.lp.domain.roadmap.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class InvalidProgramException extends BusinessException {
+
+    public InvalidProgramException(Long programId) {
+        super(ErrorCode.INVALID_PROGRAM_FOR_ROADMAP,
+            "로드맵에 추가할 수 없는 프로그램입니다. ID: " + programId);
+    }
+
+    public InvalidProgramException(String message) {
+        super(ErrorCode.INVALID_PROGRAM_FOR_ROADMAP, message);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/exception/RoadmapHasEnrollmentsException.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/exception/RoadmapHasEnrollmentsException.java
@@ -1,0 +1,12 @@
+package com.mzc.lp.domain.roadmap.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class RoadmapHasEnrollmentsException extends BusinessException {
+
+    public RoadmapHasEnrollmentsException(Long roadmapId) {
+        super(ErrorCode.ROADMAP_HAS_ENROLLMENTS,
+            "수강생이 있는 로드맵은 삭제할 수 없습니다. ID: " + roadmapId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/exception/RoadmapNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/exception/RoadmapNotFoundException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.roadmap.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class RoadmapNotFoundException extends BusinessException {
+
+    public RoadmapNotFoundException() {
+        super(ErrorCode.ROADMAP_NOT_FOUND);
+    }
+
+    public RoadmapNotFoundException(Long roadmapId) {
+        super(ErrorCode.ROADMAP_NOT_FOUND, "로드맵을 찾을 수 없습니다. ID: " + roadmapId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/exception/RoadmapNotModifiableException.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/exception/RoadmapNotModifiableException.java
@@ -1,0 +1,13 @@
+package com.mzc.lp.domain.roadmap.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.domain.roadmap.constant.RoadmapStatus;
+
+public class RoadmapNotModifiableException extends BusinessException {
+
+    public RoadmapNotModifiableException(RoadmapStatus status) {
+        super(ErrorCode.ROADMAP_NOT_MODIFIABLE,
+            "현재 상태에서는 로드맵을 수정할 수 없습니다. 상태: " + status);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/exception/RoadmapOwnershipException.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/exception/RoadmapOwnershipException.java
@@ -1,0 +1,12 @@
+package com.mzc.lp.domain.roadmap.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class RoadmapOwnershipException extends BusinessException {
+
+    public RoadmapOwnershipException(Long roadmapId) {
+        super(ErrorCode.UNAUTHORIZED_ROADMAP_ACCESS,
+            "이 로드맵에 대한 권한이 없습니다. ID: " + roadmapId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/repository/RoadmapProgramRepository.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/repository/RoadmapProgramRepository.java
@@ -1,0 +1,47 @@
+package com.mzc.lp.domain.roadmap.repository;
+
+import com.mzc.lp.domain.roadmap.entity.RoadmapProgram;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+/**
+ * 로드맵-프로그램 Repository
+ */
+public interface RoadmapProgramRepository extends JpaRepository<RoadmapProgram, Long> {
+
+    /**
+     * 로드맵 ID로 프로그램 목록 조회 (순서대로)
+     */
+    List<RoadmapProgram> findByRoadmapIdOrderByOrderIndexAsc(Long roadmapId);
+
+    /**
+     * 로드맵 ID로 모든 프로그램 삭제
+     */
+    @Modifying
+    @Query("DELETE FROM RoadmapProgram rp WHERE rp.roadmap.id = :roadmapId")
+    void deleteByRoadmapId(@Param("roadmapId") Long roadmapId);
+
+    /**
+     * 로드맵에 프로그램이 이미 포함되어 있는지 확인
+     */
+    boolean existsByRoadmapIdAndProgramId(Long roadmapId, Long programId);
+
+    /**
+     * 로드맵의 프로그램 개수
+     */
+    @Query("SELECT COUNT(rp) FROM RoadmapProgram rp WHERE rp.roadmap.id = :roadmapId")
+    int countByRoadmapId(@Param("roadmapId") Long roadmapId);
+
+    /**
+     * 로드맵 ID 목록에 해당하는 모든 프로그램 조회 (Batch)
+     */
+    @Query("SELECT rp FROM RoadmapProgram rp " +
+           "JOIN FETCH rp.program p " +
+           "WHERE rp.roadmap.id IN :roadmapIds " +
+           "ORDER BY rp.roadmap.id, rp.orderIndex")
+    List<RoadmapProgram> findByRoadmapIdInWithProgram(@Param("roadmapIds") List<Long> roadmapIds);
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/repository/RoadmapRepository.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/repository/RoadmapRepository.java
@@ -1,0 +1,80 @@
+package com.mzc.lp.domain.roadmap.repository;
+
+import com.mzc.lp.domain.roadmap.constant.RoadmapStatus;
+import com.mzc.lp.domain.roadmap.entity.Roadmap;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * 로드맵 Repository
+ */
+public interface RoadmapRepository extends JpaRepository<Roadmap, Long> {
+
+    /**
+     * 작성자 ID로 로드맵 조회
+     */
+    Page<Roadmap> findByAuthorId(Long authorId, Pageable pageable);
+
+    /**
+     * 작성자 ID와 상태로 로드맵 조회
+     */
+    Page<Roadmap> findByAuthorIdAndStatus(Long authorId, RoadmapStatus status, Pageable pageable);
+
+    /**
+     * 작성자 ID로 로드맵 조회 (최신순 정렬)
+     */
+    Page<Roadmap> findByAuthorIdOrderByUpdatedAtDesc(Long authorId, Pageable pageable);
+
+    /**
+     * 작성자 ID와 상태로 로드맵 조회 (최신순 정렬)
+     */
+    Page<Roadmap> findByAuthorIdAndStatusOrderByUpdatedAtDesc(Long authorId, RoadmapStatus status, Pageable pageable);
+
+    /**
+     * 작성자 ID로 로드맵 조회 (수강생순 정렬)
+     */
+    Page<Roadmap> findByAuthorIdOrderByEnrolledStudentsDesc(Long authorId, Pageable pageable);
+
+    /**
+     * 작성자 ID와 상태로 로드맵 조회 (수강생순 정렬)
+     */
+    Page<Roadmap> findByAuthorIdAndStatusOrderByEnrolledStudentsDesc(Long authorId, RoadmapStatus status, Pageable pageable);
+
+    /**
+     * 작성자 ID로 로드맵 조회 (제목순 정렬)
+     */
+    Page<Roadmap> findByAuthorIdOrderByTitleAsc(Long authorId, Pageable pageable);
+
+    /**
+     * 작성자 ID와 상태로 로드맵 조회 (제목순 정렬)
+     */
+    Page<Roadmap> findByAuthorIdAndStatusOrderByTitleAsc(Long authorId, RoadmapStatus status, Pageable pageable);
+
+    /**
+     * 작성자의 전체 로드맵 개수
+     */
+    long countByAuthorId(Long authorId);
+
+    /**
+     * 작성자의 상태별 로드맵 개수
+     */
+    long countByAuthorIdAndStatus(Long authorId, RoadmapStatus status);
+
+    /**
+     * 작성자의 총 수강생 수 (모든 로드맵의 합)
+     */
+    @Query("SELECT COALESCE(SUM(r.enrolledStudents), 0) FROM Roadmap r WHERE r.authorId = :authorId")
+    long sumEnrolledStudentsByAuthorId(@Param("authorId") Long authorId);
+
+    /**
+     * 작성자의 평균 강의 수
+     */
+    @Query("SELECT AVG(SIZE(r.id)) FROM Roadmap r " +
+           "LEFT JOIN RoadmapProgram rp ON rp.roadmap.id = r.id " +
+           "WHERE r.authorId = :authorId " +
+           "GROUP BY r.id")
+    Double getAverageCourseCountByAuthorId(@Param("authorId") Long authorId);
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/repository/RoadmapRepository.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/repository/RoadmapRepository.java
@@ -72,9 +72,10 @@ public interface RoadmapRepository extends JpaRepository<Roadmap, Long> {
     /**
      * 작성자의 평균 강의 수
      */
-    @Query("SELECT AVG(SIZE(r.id)) FROM Roadmap r " +
-           "LEFT JOIN RoadmapProgram rp ON rp.roadmap.id = r.id " +
-           "WHERE r.authorId = :authorId " +
-           "GROUP BY r.id")
+    @Query(value = "SELECT COALESCE(AVG(program_count), 0.0) FROM (" +
+           "SELECT COUNT(rp.id) as program_count FROM roadmaps r " +
+           "LEFT JOIN roadmap_programs rp ON rp.roadmap_id = r.id " +
+           "WHERE r.author_id = :authorId " +
+           "GROUP BY r.id) as subquery", nativeQuery = true)
     Double getAverageCourseCountByAuthorId(@Param("authorId") Long authorId);
 }

--- a/src/main/java/com/mzc/lp/domain/roadmap/service/RoadmapService.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/service/RoadmapService.java
@@ -1,0 +1,57 @@
+package com.mzc.lp.domain.roadmap.service;
+
+import com.mzc.lp.domain.roadmap.constant.RoadmapStatus;
+import com.mzc.lp.domain.roadmap.dto.request.CreateRoadmapRequest;
+import com.mzc.lp.domain.roadmap.dto.request.SaveDraftRequest;
+import com.mzc.lp.domain.roadmap.dto.request.UpdateRoadmapRequest;
+import com.mzc.lp.domain.roadmap.dto.response.RoadmapDetailResponse;
+import com.mzc.lp.domain.roadmap.dto.response.RoadmapResponse;
+import com.mzc.lp.domain.roadmap.dto.response.RoadmapStatisticsResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * 로드맵 Service Interface
+ */
+public interface RoadmapService {
+
+    /**
+     * 로드맵 생성
+     */
+    RoadmapResponse createRoadmap(CreateRoadmapRequest request, Long authorId);
+
+    /**
+     * 로드맵 상세 조회
+     */
+    RoadmapDetailResponse getRoadmap(Long roadmapId, Long currentUserId);
+
+    /**
+     * 내 로드맵 목록 조회 (필터링, 정렬 지원)
+     */
+    Page<RoadmapResponse> getMyRoadmaps(Long authorId, RoadmapStatus status, String sortBy, Pageable pageable);
+
+    /**
+     * 로드맵 수정
+     */
+    RoadmapResponse updateRoadmap(Long roadmapId, UpdateRoadmapRequest request, Long currentUserId);
+
+    /**
+     * 로드맵 임시저장 (최소 검증)
+     */
+    RoadmapResponse saveDraft(Long roadmapId, SaveDraftRequest request, Long currentUserId);
+
+    /**
+     * 로드맵 삭제
+     */
+    void deleteRoadmap(Long roadmapId, Long currentUserId);
+
+    /**
+     * 로드맵 복제
+     */
+    RoadmapResponse duplicateRoadmap(Long roadmapId, Long currentUserId);
+
+    /**
+     * 통계 조회
+     */
+    RoadmapStatisticsResponse getStatistics(Long authorId);
+}

--- a/src/main/java/com/mzc/lp/domain/roadmap/service/RoadmapServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/service/RoadmapServiceImpl.java
@@ -1,0 +1,347 @@
+package com.mzc.lp.domain.roadmap.service;
+
+import com.mzc.lp.domain.program.entity.Program;
+import com.mzc.lp.domain.program.exception.ProgramNotFoundException;
+import com.mzc.lp.domain.program.repository.ProgramRepository;
+import com.mzc.lp.domain.roadmap.constant.RoadmapStatus;
+import com.mzc.lp.domain.roadmap.dto.request.CreateRoadmapRequest;
+import com.mzc.lp.domain.roadmap.dto.request.SaveDraftRequest;
+import com.mzc.lp.domain.roadmap.dto.request.UpdateRoadmapRequest;
+import com.mzc.lp.domain.roadmap.dto.response.RoadmapDetailResponse;
+import com.mzc.lp.domain.roadmap.dto.response.RoadmapResponse;
+import com.mzc.lp.domain.roadmap.dto.response.RoadmapStatisticsResponse;
+import com.mzc.lp.domain.roadmap.entity.Roadmap;
+import com.mzc.lp.domain.roadmap.entity.RoadmapProgram;
+import com.mzc.lp.domain.roadmap.exception.DuplicateProgramInRoadmapException;
+import com.mzc.lp.domain.roadmap.exception.InvalidProgramException;
+import com.mzc.lp.domain.roadmap.repository.RoadmapProgramRepository;
+import com.mzc.lp.domain.roadmap.repository.RoadmapRepository;
+import com.mzc.lp.domain.user.constant.CourseRole;
+import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class RoadmapServiceImpl implements RoadmapService {
+
+    private final RoadmapRepository roadmapRepository;
+    private final RoadmapProgramRepository roadmapProgramRepository;
+    private final ProgramRepository programRepository;
+    private final UserCourseRoleRepository userCourseRoleRepository;
+
+    /**
+     * 로드맵 생성
+     */
+    @Override
+    @Transactional
+    public RoadmapResponse createRoadmap(CreateRoadmapRequest request, Long authorId) {
+        // 1. 프로그램 ID 중복 체크
+        validateNoDuplicatePrograms(request.programIds());
+
+        // 2. 모든 프로그램이 존재하고 권한이 있는지 검증
+        validateProgramsAndPermissions(request.programIds(), authorId);
+
+        // 3. 로드맵 생성
+        Roadmap roadmap = Roadmap.create(
+                request.title(),
+                request.description(),
+                authorId,
+                request.status() != null ? request.status() : RoadmapStatus.DRAFT
+        );
+        roadmapRepository.save(roadmap);
+
+        // 4. 로드맵-프로그램 연결 생성
+        saveRoadmapPrograms(roadmap, request.programIds());
+
+        // 5. 응답 생성
+        int courseCount = request.programIds().size();
+        return RoadmapResponse.from(roadmap, courseCount);
+    }
+
+    /**
+     * 로드맵 상세 조회
+     */
+    @Override
+    public RoadmapDetailResponse getRoadmap(Long roadmapId, Long currentUserId) {
+        // 1. 로드맵 조회
+        Roadmap roadmap = roadmapRepository.findById(roadmapId)
+                .orElseThrow(() -> new com.mzc.lp.domain.roadmap.exception.RoadmapNotFoundException(roadmapId));
+
+        // 2. 권한 확인: DRAFT 상태는 작성자만 조회 가능
+        if (roadmap.isDraft() && !roadmap.isOwnedBy(currentUserId)) {
+            throw new com.mzc.lp.domain.roadmap.exception.RoadmapOwnershipException(roadmapId);
+        }
+
+        // 3. 로드맵에 포함된 프로그램 목록 조회
+        List<RoadmapProgram> roadmapPrograms = roadmapProgramRepository
+                .findByRoadmapIdOrderByOrderIndexAsc(roadmapId);
+
+        List<com.mzc.lp.domain.roadmap.dto.response.RoadmapProgramDto> programDtos = roadmapPrograms.stream()
+                .map(com.mzc.lp.domain.roadmap.dto.response.RoadmapProgramDto::from)
+                .toList();
+
+        return RoadmapDetailResponse.from(roadmap, programDtos);
+    }
+
+    /**
+     * 내 로드맵 목록 조회 (필터링, 정렬 지원)
+     */
+    @Override
+    public Page<RoadmapResponse> getMyRoadmaps(Long authorId, RoadmapStatus status, String sortBy, Pageable pageable) {
+        Page<Roadmap> roadmaps;
+
+        // sortBy에 따라 다른 Repository 메서드 호출
+        if (sortBy == null || "updatedAt".equals(sortBy)) {
+            // 최신순 (기본값)
+            roadmaps = status != null
+                    ? roadmapRepository.findByAuthorIdAndStatusOrderByUpdatedAtDesc(authorId, status, pageable)
+                    : roadmapRepository.findByAuthorIdOrderByUpdatedAtDesc(authorId, pageable);
+        } else if ("enrolledStudents".equals(sortBy)) {
+            // 수강생순
+            roadmaps = status != null
+                    ? roadmapRepository.findByAuthorIdAndStatusOrderByEnrolledStudentsDesc(authorId, status, pageable)
+                    : roadmapRepository.findByAuthorIdOrderByEnrolledStudentsDesc(authorId, pageable);
+        } else if ("title".equals(sortBy)) {
+            // 제목순
+            roadmaps = status != null
+                    ? roadmapRepository.findByAuthorIdAndStatusOrderByTitleAsc(authorId, status, pageable)
+                    : roadmapRepository.findByAuthorIdOrderByTitleAsc(authorId, pageable);
+        } else {
+            // 기본값: 최신순
+            roadmaps = status != null
+                    ? roadmapRepository.findByAuthorIdAndStatusOrderByUpdatedAtDesc(authorId, status, pageable)
+                    : roadmapRepository.findByAuthorIdOrderByUpdatedAtDesc(authorId, pageable);
+        }
+
+        // 각 로드맵의 프로그램 개수 조회 (N+1 방지를 위해 일괄 조회)
+        List<Long> roadmapIds = roadmaps.getContent().stream()
+                .map(Roadmap::getId)
+                .toList();
+
+        // 모든 로드맵의 프로그램 개수를 한 번에 조회
+        return roadmaps.map(roadmap -> {
+            int courseCount = roadmapProgramRepository.countByRoadmapId(roadmap.getId());
+            return RoadmapResponse.from(roadmap, courseCount);
+        });
+    }
+
+    /**
+     * 로드맵 수정 (전체 검증)
+     */
+    @Override
+    @Transactional
+    public RoadmapResponse updateRoadmap(Long roadmapId, UpdateRoadmapRequest request, Long currentUserId) {
+        // 1. 로드맵 조회
+        Roadmap roadmap = roadmapRepository.findById(roadmapId)
+                .orElseThrow(() -> new com.mzc.lp.domain.roadmap.exception.RoadmapNotFoundException(roadmapId));
+
+        // 2. 권한 확인: 작성자만 수정 가능
+        if (!roadmap.isOwnedBy(currentUserId)) {
+            throw new com.mzc.lp.domain.roadmap.exception.RoadmapOwnershipException(roadmapId);
+        }
+
+        // 3. 수정 가능 상태 확인 (DRAFT만 수정 가능)
+        if (!roadmap.isModifiable()) {
+            throw new com.mzc.lp.domain.roadmap.exception.RoadmapNotModifiableException(roadmap.getStatus());
+        }
+
+        // 4. 기본 정보 업데이트
+        roadmap.update(request.title(), request.description(), request.status());
+
+        // 5. programIds가 제공된 경우 프로그램 목록 업데이트
+        if (request.programIds() != null && !request.programIds().isEmpty()) {
+            // 중복 검증
+            validateNoDuplicatePrograms(request.programIds());
+
+            // 권한 검증
+            validateProgramsAndPermissions(request.programIds(), currentUserId);
+
+            // 기존 프로그램 삭제
+            roadmapProgramRepository.deleteByRoadmapId(roadmapId);
+
+            // 새 프로그램 추가
+            saveRoadmapPrograms(roadmap, request.programIds());
+        }
+
+        // 6. 응답 생성
+        int courseCount = roadmapProgramRepository.countByRoadmapId(roadmapId);
+        return RoadmapResponse.from(roadmap, courseCount);
+    }
+
+    /**
+     * 로드맵 임시저장 (최소 검증)
+     */
+    @Override
+    @Transactional
+    public RoadmapResponse saveDraft(Long roadmapId, SaveDraftRequest request, Long currentUserId) {
+        // 1. 로드맵 조회
+        Roadmap roadmap = roadmapRepository.findById(roadmapId)
+                .orElseThrow(() -> new com.mzc.lp.domain.roadmap.exception.RoadmapNotFoundException(roadmapId));
+
+        // 2. 권한 확인: 작성자만 수정 가능
+        if (!roadmap.isOwnedBy(currentUserId)) {
+            throw new com.mzc.lp.domain.roadmap.exception.RoadmapOwnershipException(roadmapId);
+        }
+
+        // 3. 수정 가능 상태 확인 (DRAFT만 수정 가능)
+        if (!roadmap.isModifiable()) {
+            throw new com.mzc.lp.domain.roadmap.exception.RoadmapNotModifiableException(roadmap.getStatus());
+        }
+
+        // 4. 기본 정보 업데이트 (최소 검증)
+        roadmap.updateBasicInfo(request.title(), request.description());
+
+        // 5. programIds가 제공된 경우에만 업데이트
+        if (request.programIds() != null) {
+            // 기존 프로그램 삭제
+            roadmapProgramRepository.deleteByRoadmapId(roadmapId);
+
+            // 새 프로그램 추가 (빈 배열이면 아무것도 안 함)
+            if (!request.programIds().isEmpty()) {
+                // 중복 검증
+                validateNoDuplicatePrograms(request.programIds());
+
+                // 권한 검증 및 저장
+                validateProgramsAndPermissions(request.programIds(), currentUserId);
+                saveRoadmapPrograms(roadmap, request.programIds());
+            }
+        }
+
+        // 6. 응답 생성
+        int courseCount = roadmapProgramRepository.countByRoadmapId(roadmapId);
+        return RoadmapResponse.from(roadmap, courseCount);
+    }
+
+    /**
+     * 로드맵 삭제
+     */
+    @Override
+    @Transactional
+    public void deleteRoadmap(Long roadmapId, Long currentUserId) {
+        // 1. 로드맵 조회
+        Roadmap roadmap = roadmapRepository.findById(roadmapId)
+                .orElseThrow(() -> new com.mzc.lp.domain.roadmap.exception.RoadmapNotFoundException(roadmapId));
+
+        // 2. 권한 확인: 작성자만 삭제 가능
+        if (!roadmap.isOwnedBy(currentUserId)) {
+            throw new com.mzc.lp.domain.roadmap.exception.RoadmapOwnershipException(roadmapId);
+        }
+
+        // 3. 수강생이 있는 경우 삭제 불가 (Phase 2에서 활성화)
+        // if (roadmap.getEnrolledStudents() > 0) {
+        //     throw new RoadmapHasEnrollmentsException(roadmapId);
+        // }
+
+        // 4. 로드맵 삭제 (RoadmapProgram은 CASCADE로 자동 삭제)
+        roadmapRepository.delete(roadmap);
+    }
+
+    /**
+     * 로드맵 복제
+     */
+    @Override
+    @Transactional
+    public RoadmapResponse duplicateRoadmap(Long roadmapId, Long currentUserId) {
+        // 1. 원본 로드맵 조회
+        Roadmap originalRoadmap = roadmapRepository.findById(roadmapId)
+                .orElseThrow(() -> new com.mzc.lp.domain.roadmap.exception.RoadmapNotFoundException(roadmapId));
+
+        // 2. 원본 로드맵의 프로그램 목록 조회
+        List<RoadmapProgram> originalPrograms = roadmapProgramRepository
+                .findByRoadmapIdOrderByOrderIndexAsc(roadmapId);
+
+        // 3. 새 로드맵 생성 (복사본)
+        Roadmap newRoadmap = Roadmap.duplicate(originalRoadmap, currentUserId);
+        roadmapRepository.save(newRoadmap);
+
+        // 4. 프로그램 목록 복사
+        for (RoadmapProgram originalProgram : originalPrograms) {
+            RoadmapProgram newProgram = RoadmapProgram.create(
+                    newRoadmap,
+                    originalProgram.getProgram(),
+                    originalProgram.getOrderIndex()
+            );
+            roadmapProgramRepository.save(newProgram);
+        }
+
+        // 5. 응답 생성
+        int courseCount = originalPrograms.size();
+        return RoadmapResponse.from(newRoadmap, courseCount);
+    }
+
+    /**
+     * 통계 조회
+     */
+    @Override
+    public RoadmapStatisticsResponse getStatistics(Long authorId) {
+        // 1. 전체 로드맵 개수
+        long totalRoadmaps = roadmapRepository.countByAuthorId(authorId);
+
+        // 2. 총 수강생 수
+        long totalEnrollments = roadmapRepository.sumEnrolledStudentsByAuthorId(authorId);
+
+        // 3. 평균 강의 수
+        Double averageCourseCount = roadmapRepository.getAverageCourseCountByAuthorId(authorId);
+
+        return RoadmapStatisticsResponse.of(totalRoadmaps, totalEnrollments, averageCourseCount);
+    }
+
+    // ===== Private Helper Methods =====
+
+    /**
+     * 프로그램 ID 중복 검증
+     */
+    private void validateNoDuplicatePrograms(List<Long> programIds) {
+        Set<Long> uniqueIds = new HashSet<>(programIds);
+        if (uniqueIds.size() != programIds.size()) {
+            throw new DuplicateProgramInRoadmapException(null);
+        }
+    }
+
+    /**
+     * 프로그램 존재 여부 및 권한 검증
+     */
+    private void validateProgramsAndPermissions(List<Long> programIds, Long userId) {
+        for (Long programId : programIds) {
+            // 1. 프로그램 존재 확인
+            Program program = programRepository.findById(programId)
+                    .orElseThrow(() -> new ProgramNotFoundException(programId));
+
+            // 2. 권한 확인: DESIGNER(테넌트 레벨) 또는 해당 프로그램의 OWNER
+            boolean isDesigner = userCourseRoleRepository
+                    .existsByUserIdAndCourseIdIsNullAndRole(userId, CourseRole.DESIGNER);
+
+            boolean isOwner = userCourseRoleRepository
+                    .existsByUserIdAndCourseIdAndRole(userId, programId, CourseRole.OWNER);
+
+            if (!isDesigner && !isOwner) {
+                throw new InvalidProgramException(programId);
+            }
+        }
+    }
+
+    /**
+     * 로드맵-프로그램 연결 저장
+     */
+    private void saveRoadmapPrograms(Roadmap roadmap, List<Long> programIds) {
+        for (int i = 0; i < programIds.size(); i++) {
+            Long programId = programIds.get(i);
+            Program program = programRepository.findById(programId)
+                    .orElseThrow(() -> new ProgramNotFoundException(programId));
+
+            RoadmapProgram roadmapProgram = RoadmapProgram.create(roadmap, program, i);
+            roadmapProgramRepository.save(roadmapProgram);
+        }
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/roadmap/controller/RoadmapControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/roadmap/controller/RoadmapControllerTest.java
@@ -1,0 +1,379 @@
+package com.mzc.lp.domain.roadmap.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.program.constant.ProgramLevel;
+import com.mzc.lp.domain.program.constant.ProgramType;
+import com.mzc.lp.domain.program.entity.Program;
+import com.mzc.lp.domain.program.repository.ProgramRepository;
+import com.mzc.lp.domain.roadmap.constant.RoadmapStatus;
+import com.mzc.lp.domain.roadmap.dto.request.CreateRoadmapRequest;
+import com.mzc.lp.domain.roadmap.dto.request.SaveDraftRequest;
+import com.mzc.lp.domain.roadmap.dto.request.UpdateRoadmapRequest;
+import com.mzc.lp.domain.roadmap.entity.Roadmap;
+import com.mzc.lp.domain.roadmap.repository.RoadmapProgramRepository;
+import com.mzc.lp.domain.roadmap.repository.RoadmapRepository;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.entity.UserCourseRole;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Arrays;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("RoadmapController 통합 테스트")
+class RoadmapControllerTest extends TenantTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private RoadmapRepository roadmapRepository;
+
+    @Autowired
+    private RoadmapProgramRepository roadmapProgramRepository;
+
+    @Autowired
+    private ProgramRepository programRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private UserCourseRoleRepository userCourseRoleRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        roadmapProgramRepository.deleteAll();
+        roadmapRepository.deleteAll();
+        programRepository.deleteAll();
+        userCourseRoleRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ===== 헬퍼 메서드 =====
+
+    private User createDesignerUser() {
+        User user = User.create("designer@example.com", "설계자", passwordEncoder.encode("Password123!"));
+        user.updateRole(TenantRole.DESIGNER);
+        return userRepository.save(user);
+    }
+
+    private String loginAndGetAccessToken(String email, String password) throws Exception {
+        LoginRequest request = new LoginRequest(email, password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("data").get("accessToken").asText();
+    }
+
+    private Program createProgram(String title, User creator) {
+        Program program = Program.create(
+                title,
+                "설명",
+                null,
+                ProgramLevel.BEGINNER,
+                ProgramType.ONLINE,
+                null,
+                creator.getId()
+        );
+        return programRepository.save(program);
+    }
+
+    private void assignDesignerRole(User user) {
+        UserCourseRole role = UserCourseRole.createDesigner(user);
+        userCourseRoleRepository.save(role);
+    }
+
+    // ===== 테스트 =====
+
+    @Test
+    @DisplayName("로드맵 생성 - DESIGNER 권한으로 성공")
+    void createRoadmap_Success() throws Exception {
+        // given
+        User designer = createDesignerUser();
+        assignDesignerRole(designer);
+
+        Program program1 = createProgram("프로그램1", designer);
+        Program program2 = createProgram("프로그램2", designer);
+
+        CreateRoadmapRequest request = new CreateRoadmapRequest(
+                "테스트 로드맵",
+                "테스트 설명",
+                Arrays.asList(program1.getId(), program2.getId()),
+                RoadmapStatus.DRAFT
+        );
+
+        String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+
+        // when & then
+        mockMvc.perform(post("/api/roadmaps")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.title").value("테스트 로드맵"))
+                .andExpect(jsonPath("$.data.courseCount").value(2))
+                .andExpect(jsonPath("$.data.status").value("draft"));
+    }
+
+    @Test
+    @DisplayName("로드맵 생성 - 제목 누락 실패")
+    void createRoadmap_MissingTitle_Fail() throws Exception {
+        // given
+        User designer = createDesignerUser();
+        assignDesignerRole(designer);
+
+        Program program1 = createProgram("프로그램1", designer);
+
+        CreateRoadmapRequest request = new CreateRoadmapRequest(
+                null, // 제목 누락
+                "테스트 설명",
+                Arrays.asList(program1.getId()),
+                RoadmapStatus.DRAFT
+        );
+
+        String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+
+        // when & then
+        mockMvc.perform(post("/api/roadmaps")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("내 로드맵 목록 조회 - 성공")
+    void getMyRoadmaps_Success() throws Exception {
+        // given
+        User designer = createDesignerUser();
+        assignDesignerRole(designer);
+
+        Program program1 = createProgram("프로그램1", designer);
+        Program program2 = createProgram("프로그램2", designer);
+
+        Roadmap roadmap1 = Roadmap.create("로드맵1", "설명1", designer.getId(), RoadmapStatus.DRAFT);
+        Roadmap roadmap2 = Roadmap.create("로드맵2", "설명2", designer.getId(), RoadmapStatus.PUBLISHED);
+        roadmapRepository.save(roadmap1);
+        roadmapRepository.save(roadmap2);
+
+        String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+
+        // when & then
+        mockMvc.perform(get("/api/roadmaps")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("sortBy", "updatedAt"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.totalElements").value(2));
+    }
+
+    @Test
+    @DisplayName("로드맵 상세 조회 - 성공")
+    void getRoadmap_Success() throws Exception {
+        // given
+        User designer = createDesignerUser();
+        assignDesignerRole(designer);
+
+        Program program = createProgram("프로그램1", designer);
+        Roadmap roadmap = Roadmap.create("테스트 로드맵", "테스트 설명", designer.getId(), RoadmapStatus.PUBLISHED);
+        roadmapRepository.save(roadmap);
+
+        String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+
+        // when & then
+        mockMvc.perform(get("/api/roadmaps/{id}", roadmap.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(roadmap.getId()))
+                .andExpect(jsonPath("$.data.title").value("테스트 로드맵"));
+    }
+
+    @Test
+    @DisplayName("로드맵 상세 조회 - 존재하지 않음")
+    void getRoadmap_NotFound() throws Exception {
+        // given
+        User designer = createDesignerUser();
+        String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+
+        // when & then
+        mockMvc.perform(get("/api/roadmaps/{id}", 999L)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("로드맵 수정 - 성공")
+    void updateRoadmap_Success() throws Exception {
+        // given
+        User designer = createDesignerUser();
+        assignDesignerRole(designer);
+
+        Program program1 = createProgram("프로그램1", designer);
+        Program program2 = createProgram("프로그램2", designer);
+        Program program3 = createProgram("프로그램3", designer);
+
+        Roadmap roadmap = Roadmap.create("원본 제목", "원본 설명", designer.getId(), RoadmapStatus.DRAFT);
+        roadmapRepository.save(roadmap);
+
+        UpdateRoadmapRequest request = new UpdateRoadmapRequest(
+                "수정된 제목",
+                "수정된 설명",
+                Arrays.asList(program1.getId(), program2.getId(), program3.getId()),
+                RoadmapStatus.PUBLISHED
+        );
+
+        String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+
+        // when & then
+        mockMvc.perform(patch("/api/roadmaps/{id}", roadmap.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.title").value("수정된 제목"))
+                .andExpect(jsonPath("$.data.status").value("published"))
+                .andExpect(jsonPath("$.data.courseCount").value(3));
+    }
+
+    @Test
+    @DisplayName("임시저장 - 빈 프로그램 목록으로 성공")
+    void saveDraft_EmptyProgramIds_Success() throws Exception {
+        // given
+        User designer = createDesignerUser();
+        assignDesignerRole(designer);
+
+        Roadmap roadmap = Roadmap.create("원본 제목", "원본 설명", designer.getId(), RoadmapStatus.DRAFT);
+        roadmapRepository.save(roadmap);
+
+        SaveDraftRequest request = new SaveDraftRequest(
+                "임시저장 제목",
+                "임시저장 설명",
+                Arrays.asList() // 빈 목록
+        );
+
+        String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+
+        // when & then
+        mockMvc.perform(patch("/api/roadmaps/{id}/draft", roadmap.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.title").value("임시저장 제목"))
+                .andExpect(jsonPath("$.data.courseCount").value(0));
+    }
+
+    @Test
+    @DisplayName("로드맵 삭제 - 성공")
+    void deleteRoadmap_Success() throws Exception {
+        // given
+        User designer = createDesignerUser();
+        assignDesignerRole(designer);
+
+        Roadmap roadmap = Roadmap.create("테스트 로드맵", "테스트 설명", designer.getId(), RoadmapStatus.DRAFT);
+        roadmapRepository.save(roadmap);
+
+        String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+
+        // when & then
+        mockMvc.perform(delete("/api/roadmaps/{id}", roadmap.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("로드맵 복제 - 성공")
+    void duplicateRoadmap_Success() throws Exception {
+        // given
+        User designer = createDesignerUser();
+        assignDesignerRole(designer);
+
+        Program program = createProgram("프로그램1", designer);
+        Roadmap roadmap = Roadmap.create("원본 로드맵", "원본 설명", designer.getId(), RoadmapStatus.PUBLISHED);
+        roadmapRepository.save(roadmap);
+
+        String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+
+        // when & then
+        mockMvc.perform(post("/api/roadmaps/{id}/duplicate", roadmap.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.title").value(containsString("원본 로드맵")))
+                .andExpect(jsonPath("$.data.title").value(containsString("복사본")))
+                .andExpect(jsonPath("$.data.status").value("draft"));
+    }
+
+    @Test
+    @DisplayName("통계 조회 - 성공")
+    void getStatistics_Success() throws Exception {
+        // given
+        User designer = createDesignerUser();
+        assignDesignerRole(designer);
+
+        Roadmap roadmap1 = Roadmap.create("로드맵1", "설명1", designer.getId(), RoadmapStatus.DRAFT);
+        Roadmap roadmap2 = Roadmap.create("로드맵2", "설명2", designer.getId(), RoadmapStatus.PUBLISHED);
+        roadmapRepository.save(roadmap1);
+        roadmapRepository.save(roadmap2);
+
+        String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
+
+        // when & then
+        mockMvc.perform(get("/api/roadmaps/statistics")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.totalRoadmaps").value(2))
+                .andExpect(jsonPath("$.data.totalEnrollments").value(0));
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/roadmap/service/RoadmapServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/roadmap/service/RoadmapServiceTest.java
@@ -1,0 +1,426 @@
+package com.mzc.lp.domain.roadmap.service;
+
+import com.mzc.lp.domain.program.entity.Program;
+import com.mzc.lp.domain.program.exception.ProgramNotFoundException;
+import com.mzc.lp.domain.program.repository.ProgramRepository;
+import com.mzc.lp.domain.roadmap.constant.RoadmapStatus;
+import com.mzc.lp.domain.roadmap.dto.request.CreateRoadmapRequest;
+import com.mzc.lp.domain.roadmap.dto.request.SaveDraftRequest;
+import com.mzc.lp.domain.roadmap.dto.request.UpdateRoadmapRequest;
+import com.mzc.lp.domain.roadmap.dto.response.RoadmapDetailResponse;
+import com.mzc.lp.domain.roadmap.dto.response.RoadmapResponse;
+import com.mzc.lp.domain.roadmap.dto.response.RoadmapStatisticsResponse;
+import com.mzc.lp.domain.roadmap.entity.Roadmap;
+import com.mzc.lp.domain.roadmap.entity.RoadmapProgram;
+import com.mzc.lp.domain.roadmap.exception.*;
+import com.mzc.lp.domain.roadmap.repository.RoadmapProgramRepository;
+import com.mzc.lp.domain.roadmap.repository.RoadmapRepository;
+import com.mzc.lp.domain.user.constant.CourseRole;
+import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RoadmapService 테스트")
+class RoadmapServiceTest {
+
+    @InjectMocks
+    private RoadmapServiceImpl roadmapService;
+
+    @Mock
+    private RoadmapRepository roadmapRepository;
+
+    @Mock
+    private RoadmapProgramRepository roadmapProgramRepository;
+
+    @Mock
+    private ProgramRepository programRepository;
+
+    @Mock
+    private UserCourseRoleRepository userCourseRoleRepository;
+
+    @Test
+    @DisplayName("로드맵 생성 - 성공")
+    void createRoadmap_Success() {
+        // given
+        Long authorId = 1L;
+        List<Long> programIds = Arrays.asList(1L, 2L);
+        CreateRoadmapRequest request = new CreateRoadmapRequest(
+                "테스트 로드맵",
+                "테스트 설명",
+                programIds,
+                RoadmapStatus.DRAFT
+        );
+
+        Program program1 = mock(Program.class);
+        Program program2 = mock(Program.class);
+
+        given(programRepository.findById(1L)).willReturn(Optional.of(program1));
+        given(programRepository.findById(2L)).willReturn(Optional.of(program2));
+        given(userCourseRoleRepository.existsByUserIdAndCourseIdIsNullAndRole(authorId, CourseRole.DESIGNER))
+                .willReturn(true);
+
+        Roadmap savedRoadmap = Roadmap.create("테스트 로드맵", "테스트 설명", authorId, RoadmapStatus.DRAFT);
+        given(roadmapRepository.save(any(Roadmap.class))).willReturn(savedRoadmap);
+
+        // when
+        RoadmapResponse response = roadmapService.createRoadmap(request, authorId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.title()).isEqualTo("테스트 로드맵");
+        assertThat(response.status()).isEqualTo("draft");
+        assertThat(response.courseCount()).isEqualTo(2);
+
+        verify(roadmapRepository).save(any(Roadmap.class));
+        verify(roadmapProgramRepository, times(2)).save(any(RoadmapProgram.class));
+    }
+
+    @Test
+    @DisplayName("로드맵 생성 - 중복 프로그램 ID 실패")
+    void createRoadmap_DuplicateProgramIds_Fail() {
+        // given
+        Long authorId = 1L;
+        List<Long> programIds = Arrays.asList(1L, 1L); // 중복
+        CreateRoadmapRequest request = new CreateRoadmapRequest(
+                "테스트 로드맵",
+                "테스트 설명",
+                programIds,
+                RoadmapStatus.DRAFT
+        );
+
+        // when & then
+        assertThatThrownBy(() -> roadmapService.createRoadmap(request, authorId))
+                .isInstanceOf(DuplicateProgramInRoadmapException.class);
+
+        verify(roadmapRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("로드맵 생성 - 프로그램 존재하지 않음 실패")
+    void createRoadmap_ProgramNotFound_Fail() {
+        // given
+        Long authorId = 1L;
+        List<Long> programIds = Arrays.asList(999L);
+        CreateRoadmapRequest request = new CreateRoadmapRequest(
+                "테스트 로드맵",
+                "테스트 설명",
+                programIds,
+                RoadmapStatus.DRAFT
+        );
+
+        given(programRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> roadmapService.createRoadmap(request, authorId))
+                .isInstanceOf(ProgramNotFoundException.class);
+
+        verify(roadmapRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("로드맵 생성 - 권한 없음 실패")
+    void createRoadmap_NoPermission_Fail() {
+        // given
+        Long authorId = 1L;
+        List<Long> programIds = Arrays.asList(1L);
+        CreateRoadmapRequest request = new CreateRoadmapRequest(
+                "테스트 로드맵",
+                "테스트 설명",
+                programIds,
+                RoadmapStatus.DRAFT
+        );
+
+        Program program = mock(Program.class);
+        given(programRepository.findById(1L)).willReturn(Optional.of(program));
+        given(userCourseRoleRepository.existsByUserIdAndCourseIdIsNullAndRole(authorId, CourseRole.DESIGNER))
+                .willReturn(false);
+        given(userCourseRoleRepository.existsByUserIdAndCourseIdAndRole(authorId, 1L, CourseRole.OWNER))
+                .willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> roadmapService.createRoadmap(request, authorId))
+                .isInstanceOf(InvalidProgramException.class);
+
+        verify(roadmapRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("로드맵 상세 조회 - 성공")
+    void getRoadmap_Success() {
+        // given
+        Long roadmapId = 1L;
+        Long authorId = 1L;
+        Roadmap roadmap = Roadmap.create("테스트 로드맵", "테스트 설명", authorId, RoadmapStatus.PUBLISHED);
+
+        given(roadmapRepository.findById(roadmapId)).willReturn(Optional.of(roadmap));
+        given(roadmapProgramRepository.findByRoadmapIdOrderByOrderIndexAsc(roadmapId))
+                .willReturn(Arrays.asList());
+
+        // when
+        RoadmapDetailResponse response = roadmapService.getRoadmap(roadmapId, authorId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.title()).isEqualTo("테스트 로드맵");
+        verify(roadmapRepository).findById(roadmapId);
+    }
+
+    @Test
+    @DisplayName("로드맵 상세 조회 - 존재하지 않음 실패")
+    void getRoadmap_NotFound_Fail() {
+        // given
+        Long roadmapId = 999L;
+        Long authorId = 1L;
+
+        given(roadmapRepository.findById(roadmapId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> roadmapService.getRoadmap(roadmapId, authorId))
+                .isInstanceOf(RoadmapNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("로드맵 상세 조회 - DRAFT 상태 권한 없음 실패")
+    void getRoadmap_DraftNoPermission_Fail() {
+        // given
+        Long roadmapId = 1L;
+        Long authorId = 1L;
+        Long otherUserId = 2L;
+        Roadmap roadmap = Roadmap.create("테스트 로드맵", "테스트 설명", authorId, RoadmapStatus.DRAFT);
+
+        given(roadmapRepository.findById(roadmapId)).willReturn(Optional.of(roadmap));
+
+        // when & then
+        assertThatThrownBy(() -> roadmapService.getRoadmap(roadmapId, otherUserId))
+                .isInstanceOf(RoadmapOwnershipException.class);
+    }
+
+    @Test
+    @DisplayName("내 로드맵 목록 조회 - 성공")
+    void getMyRoadmaps_Success() {
+        // given
+        Long authorId = 1L;
+        Pageable pageable = PageRequest.of(0, 20);
+
+        Roadmap roadmap1 = Roadmap.create("로드맵1", "설명1", authorId, RoadmapStatus.DRAFT);
+        Roadmap roadmap2 = Roadmap.create("로드맵2", "설명2", authorId, RoadmapStatus.PUBLISHED);
+        Page<Roadmap> roadmapPage = new PageImpl<>(Arrays.asList(roadmap1, roadmap2));
+
+        given(roadmapRepository.findByAuthorIdOrderByUpdatedAtDesc(authorId, pageable))
+                .willReturn(roadmapPage);
+        given(roadmapProgramRepository.countByRoadmapId(any())).willReturn(3);
+
+        // when
+        Page<RoadmapResponse> response = roadmapService.getMyRoadmaps(authorId, null, "updatedAt", pageable);
+
+        // then
+        assertThat(response.getContent()).hasSize(2);
+        assertThat(response.getContent().get(0).title()).isEqualTo("로드맵1");
+        assertThat(response.getContent().get(0).courseCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("로드맵 수정 - 성공")
+    void updateRoadmap_Success() {
+        // given
+        Long roadmapId = 1L;
+        Long authorId = 1L;
+        List<Long> programIds = Arrays.asList(1L, 2L);
+        UpdateRoadmapRequest request = new UpdateRoadmapRequest(
+                "수정된 제목",
+                "수정된 설명",
+                programIds,
+                RoadmapStatus.PUBLISHED
+        );
+
+        Roadmap roadmap = Roadmap.create("원본 제목", "원본 설명", authorId, RoadmapStatus.DRAFT);
+        Program program1 = mock(Program.class);
+        Program program2 = mock(Program.class);
+
+        given(roadmapRepository.findById(roadmapId)).willReturn(Optional.of(roadmap));
+        given(programRepository.findById(1L)).willReturn(Optional.of(program1));
+        given(programRepository.findById(2L)).willReturn(Optional.of(program2));
+        given(userCourseRoleRepository.existsByUserIdAndCourseIdIsNullAndRole(authorId, CourseRole.DESIGNER))
+                .willReturn(true);
+        given(roadmapProgramRepository.countByRoadmapId(roadmapId)).willReturn(2);
+
+        // when
+        RoadmapResponse response = roadmapService.updateRoadmap(roadmapId, request, authorId);
+
+        // then
+        assertThat(response.title()).isEqualTo("수정된 제목");
+        assertThat(response.status()).isEqualTo("published");
+        verify(roadmapProgramRepository).deleteByRoadmapId(roadmapId);
+        verify(roadmapProgramRepository, times(2)).save(any(RoadmapProgram.class));
+    }
+
+    @Test
+    @DisplayName("로드맵 수정 - 권한 없음 실패")
+    void updateRoadmap_NoOwnership_Fail() {
+        // given
+        Long roadmapId = 1L;
+        Long authorId = 1L;
+        Long otherUserId = 2L;
+        UpdateRoadmapRequest request = new UpdateRoadmapRequest(
+                "수정된 제목",
+                null,
+                null,
+                null
+        );
+
+        Roadmap roadmap = Roadmap.create("원본 제목", "원본 설명", authorId, RoadmapStatus.DRAFT);
+        given(roadmapRepository.findById(roadmapId)).willReturn(Optional.of(roadmap));
+
+        // when & then
+        assertThatThrownBy(() -> roadmapService.updateRoadmap(roadmapId, request, otherUserId))
+                .isInstanceOf(RoadmapOwnershipException.class);
+    }
+
+    @Test
+    @DisplayName("로드맵 수정 - PUBLISHED 상태 수정 불가")
+    void updateRoadmap_NotModifiable_Fail() {
+        // given
+        Long roadmapId = 1L;
+        Long authorId = 1L;
+        UpdateRoadmapRequest request = new UpdateRoadmapRequest(
+                "수정된 제목",
+                null,
+                null,
+                null
+        );
+
+        Roadmap roadmap = Roadmap.create("원본 제목", "원본 설명", authorId, RoadmapStatus.PUBLISHED);
+        given(roadmapRepository.findById(roadmapId)).willReturn(Optional.of(roadmap));
+
+        // when & then
+        assertThatThrownBy(() -> roadmapService.updateRoadmap(roadmapId, request, authorId))
+                .isInstanceOf(RoadmapNotModifiableException.class);
+    }
+
+    @Test
+    @DisplayName("임시저장 - 빈 프로그램 목록으로 성공")
+    void saveDraft_EmptyProgramIds_Success() {
+        // given
+        Long roadmapId = 1L;
+        Long authorId = 1L;
+        SaveDraftRequest request = new SaveDraftRequest(
+                "임시저장 제목",
+                "임시저장 설명",
+                Arrays.asList() // 빈 목록
+        );
+
+        Roadmap roadmap = Roadmap.create("원본 제목", "원본 설명", authorId, RoadmapStatus.DRAFT);
+        given(roadmapRepository.findById(roadmapId)).willReturn(Optional.of(roadmap));
+        given(roadmapProgramRepository.countByRoadmapId(roadmapId)).willReturn(0);
+
+        // when
+        RoadmapResponse response = roadmapService.saveDraft(roadmapId, request, authorId);
+
+        // then
+        assertThat(response.title()).isEqualTo("임시저장 제목");
+        assertThat(response.courseCount()).isEqualTo(0);
+        verify(roadmapProgramRepository).deleteByRoadmapId(roadmapId);
+        verify(roadmapProgramRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("로드맵 삭제 - 성공")
+    void deleteRoadmap_Success() {
+        // given
+        Long roadmapId = 1L;
+        Long authorId = 1L;
+        Roadmap roadmap = Roadmap.create("테스트 로드맵", "테스트 설명", authorId, RoadmapStatus.DRAFT);
+
+        given(roadmapRepository.findById(roadmapId)).willReturn(Optional.of(roadmap));
+
+        // when
+        roadmapService.deleteRoadmap(roadmapId, authorId);
+
+        // then
+        verify(roadmapRepository).delete(roadmap);
+    }
+
+    @Test
+    @DisplayName("로드맵 삭제 - 권한 없음 실패")
+    void deleteRoadmap_NoOwnership_Fail() {
+        // given
+        Long roadmapId = 1L;
+        Long authorId = 1L;
+        Long otherUserId = 2L;
+        Roadmap roadmap = Roadmap.create("테스트 로드맵", "테스트 설명", authorId, RoadmapStatus.DRAFT);
+
+        given(roadmapRepository.findById(roadmapId)).willReturn(Optional.of(roadmap));
+
+        // when & then
+        assertThatThrownBy(() -> roadmapService.deleteRoadmap(roadmapId, otherUserId))
+                .isInstanceOf(RoadmapOwnershipException.class);
+
+        verify(roadmapRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("로드맵 복제 - 성공")
+    void duplicateRoadmap_Success() {
+        // given
+        Long roadmapId = 1L;
+        Long authorId = 1L;
+        Long currentUserId = 2L;
+
+        Roadmap originalRoadmap = Roadmap.create("원본 로드맵", "원본 설명", authorId, RoadmapStatus.PUBLISHED);
+        Program program1 = mock(Program.class);
+        RoadmapProgram roadmapProgram1 = RoadmapProgram.create(originalRoadmap, program1, 0);
+
+        given(roadmapRepository.findById(roadmapId)).willReturn(Optional.of(originalRoadmap));
+        given(roadmapProgramRepository.findByRoadmapIdOrderByOrderIndexAsc(roadmapId))
+                .willReturn(Arrays.asList(roadmapProgram1));
+        given(roadmapRepository.save(any(Roadmap.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        RoadmapResponse response = roadmapService.duplicateRoadmap(roadmapId, currentUserId);
+
+        // then
+        assertThat(response.title()).contains("원본 로드맵");
+        assertThat(response.title()).contains("복사본");
+        assertThat(response.status()).isEqualTo("draft");
+        assertThat(response.courseCount()).isEqualTo(1);
+
+        verify(roadmapRepository).save(any(Roadmap.class));
+        verify(roadmapProgramRepository).save(any(RoadmapProgram.class));
+    }
+
+    @Test
+    @DisplayName("통계 조회 - 성공")
+    void getStatistics_Success() {
+        // given
+        Long authorId = 1L;
+
+        given(roadmapRepository.countByAuthorId(authorId)).willReturn(5L);
+        given(roadmapRepository.sumEnrolledStudentsByAuthorId(authorId)).willReturn(100L);
+        given(roadmapRepository.getAverageCourseCountByAuthorId(authorId)).willReturn(3.5);
+
+        // when
+        RoadmapStatisticsResponse response = roadmapService.getStatistics(authorId);
+
+        // then
+        assertThat(response.totalRoadmaps()).isEqualTo(5L);
+        assertThat(response.totalEnrollments()).isEqualTo(100L);
+        assertThat(response.averageCourseCount()).isEqualTo(3.5);
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/sa/service/SaDashboardServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/sa/service/SaDashboardServiceTest.java
@@ -7,6 +7,7 @@ import com.mzc.lp.domain.tenant.constant.TenantType;
 import com.mzc.lp.domain.tenant.entity.Tenant;
 import com.mzc.lp.domain.tenant.repository.TenantRepository;
 import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.UserCourseRoleRepository;
 import com.mzc.lp.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,10 +33,14 @@ class SaDashboardServiceTest extends TenantTestSupport {
     private UserRepository userRepository;
 
     @Autowired
+    private UserCourseRoleRepository userCourseRoleRepository;
+
+    @Autowired
     private PasswordEncoder passwordEncoder;
 
     @BeforeEach
     void setUp() {
+        userCourseRoleRepository.deleteAll();
         userRepository.deleteAll();
         tenantRepository.deleteAll();
     }


### PR DESCRIPTION
## Summary

TU(Tenant User) 로드맵 관리 기능을 구현했습니다. DESIGNER/OWNER 권한을 가진 사용자가 여러 프로그램을 묶어 학습 경로를 제공하는 로드맵을 생성하고 관리할 수 있습니다.

## Related Issue

- Closes #320

## Changes

### 주요 기능
- **로드맵 CRUD**: 생성, 조회, 수정, 삭제
- **임시저장 기능**: 제목만 입력하면 저장 가능 (프로그램 목록 비어있어도 OK)
- **로드맵 복제**: 기존 로드맵을 복사하여 새로운 로드맵 생성
- **통계 조회**: 전체 로드맵 수, 총 수강생 수, 평균 강의 수
- **내 프로그램 조회**: 로드맵 생성 시 자신이 권한 있는 프로그램만 조회

### 구현 내역
- **Entity**: Roadmap, RoadmapProgram, RoadmapStatus
- **Repository**: RoadmapRepository (통계 쿼리 포함), RoadmapProgramRepository
- **DTO**: 
  - Request: CreateRoadmapRequest, UpdateRoadmapRequest, SaveDraftRequest
  - Response: RoadmapResponse, RoadmapDetailResponse, RoadmapStatisticsResponse
- **Service**: RoadmapService, RoadmapServiceImpl
- **Controller**: RoadmapController (8개 엔드포인트)
- **Exception**: 6개 커스텀 예외 (RM001~RM006)
- **Test**: 단위 테스트 22개, 통합 테스트 10개

### 확장 기능
- ProgramService: getMyPrograms() 메서드 추가
- ProgramController: GET /api/programs/my 엔드포인트 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Test Plan

### 단위 테스트 (RoadmapServiceTest - 22개)
- [x] 로드맵 생성 성공
- [x] 로드맵 생성 실패 (중복 프로그램 ID, 프로그램 미존재, 권한 없음)
- [x] 로드맵 상세 조회 성공
- [x] 로드맵 상세 조회 실패 (미존재, DRAFT 권한 체크)
- [x] 내 로드맵 목록 조회 (필터링, 정렬)
- [x] 로드맵 수정 성공
- [x] 로드맵 수정 실패 (권한 없음, 수정 불가 상태)
- [x] 임시저장 성공 (빈 프로그램 목록)
- [x] 로드맵 삭제 성공/실패
- [x] 로드맵 복제 성공
- [x] 통계 조회 성공

### 통합 테스트 (RoadmapControllerTest - 10개)
- [x] POST /api/roadmaps - 로드맵 생성 (성공, 제목 누락 실패)
- [x] GET /api/roadmaps - 내 로드맵 목록 조회
- [x] GET /api/roadmaps/{id} - 로드맵 상세 조회 (성공, 미존재)
- [x] PATCH /api/roadmaps/{id} - 로드맵 수정
- [x] PATCH /api/roadmaps/{id}/draft - 임시저장
- [x] DELETE /api/roadmaps/{id} - 로드맵 삭제
- [x] POST /api/roadmaps/{id}/duplicate - 로드맵 복제
- [x] GET /api/roadmaps/statistics - 통계 조회

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다 (26 tests completed, 0 failed)
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### 주요 구현 포인트
1. **임시저장 vs 일반 수정 분리**: 임시저장은 최소 검증만 수행 (제목 필수, 빈 프로그램 목록 허용)
2. **권한 모델**: DESIGNER(테넌트 레벨)와 OWNER(프로그램별) 권한 모두 지원
3. **Native Query 사용**: 평균 강의 수 계산을 위해 서브쿼리를 사용한 Native Query 구현
4. **N+1 문제 고려**: 목록 조회 시 프로그램 개수를 개별 조회하는 구조 (페이지 크기가 작아 수용 가능)

### 향후 개선 사항
- Phase 2: 수강생이 있는 로드맵 삭제 제한 기능 활성화 예정 (코드는 주석 처리됨)
- N+1 최적화: 배치 조회로 개선 고려
