### PR TITLE
Feat/tenant branding tu integration

### DIFF
--- a/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
@@ -8,6 +8,7 @@ import com.mzc.lp.domain.tenant.dto.request.UpdateLayoutSettingsRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateTenantSettingsRequest;
 import com.mzc.lp.domain.tenant.dto.response.NavigationItemResponse;
 import com.mzc.lp.domain.tenant.dto.response.PublicBrandingResponse;
+import com.mzc.lp.domain.tenant.dto.response.PublicLayoutResponse;
 import com.mzc.lp.domain.tenant.dto.response.TenantSettingsResponse;
 import com.mzc.lp.domain.tenant.service.TenantSettingsService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -202,6 +203,32 @@ public class TenantSettingsController {
     public ResponseEntity<ApiResponse<List<NavigationItemResponse>>> resetNavigationItems() {
         Long tenantId = TenantContext.getCurrentTenantId();
         List<NavigationItemResponse> response = tenantSettingsService.initializeDefaultNavigationItems(tenantId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // ============================================
+    // 공개 레이아웃 API (TU용, 인증 불필요)
+    // ============================================
+
+    @Operation(summary = "현재 테넌트 레이아웃 조회", description = "로그인한 사용자의 테넌트 레이아웃 정보를 조회합니다 (네비게이션 포함)")
+    @GetMapping("/layout/public")
+    public ResponseEntity<ApiResponse<PublicLayoutResponse>> getPublicLayout() {
+        Long tenantId = TenantContext.getCurrentTenantIdOrNull();
+        if (tenantId == null) {
+            return ResponseEntity.ok(ApiResponse.success(PublicLayoutResponse.defaultLayout()));
+        }
+        PublicLayoutResponse response = tenantSettingsService.getLayoutByTenantId(tenantId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "활성화된 네비게이션 항목 조회 (TU용)", description = "활성화된 네비게이션 메뉴 항목만 조회합니다")
+    @GetMapping("/navigation/public")
+    public ResponseEntity<ApiResponse<List<NavigationItemResponse>>> getPublicNavigationItems() {
+        Long tenantId = TenantContext.getCurrentTenantIdOrNull();
+        if (tenantId == null) {
+            return ResponseEntity.ok(ApiResponse.success(List.of()));
+        }
+        List<NavigationItemResponse> response = tenantSettingsService.getEnabledNavigationItems(tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/response/PublicLayoutResponse.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/response/PublicLayoutResponse.java
@@ -1,0 +1,55 @@
+package com.mzc.lp.domain.tenant.dto.response;
+
+import com.mzc.lp.domain.tenant.entity.TenantSettings;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * TU용 공개 레이아웃 설정 응답 DTO
+ * 인증 없이 접근 가능한 레이아웃 정보
+ */
+public record PublicLayoutResponse(
+        Map<String, Object> headerSettings,
+        Map<String, Object> footerSettings,
+        Map<String, Object> contentSettings,
+        List<NavigationItemResponse> navigationItems
+) {
+    public static PublicLayoutResponse from(
+            TenantSettings settings,
+            List<NavigationItemResponse> navigationItems
+    ) {
+        return new PublicLayoutResponse(
+                settings.getHeaderSettings(),
+                settings.getFooterSettings(),
+                settings.getContentSettings(),
+                navigationItems
+        );
+    }
+
+    /**
+     * 기본 레이아웃 설정 반환
+     */
+    public static PublicLayoutResponse defaultLayout() {
+        return new PublicLayoutResponse(
+                Map.of(
+                        "style", "fixed",
+                        "height", "default",
+                        "showLogo", true,
+                        "showSearch", true,
+                        "showNotifications", true
+                ),
+                Map.of(
+                        "enabled", true,
+                        "showLinks", true,
+                        "showCopyright", true,
+                        "showSocialLinks", true
+                ),
+                Map.of(
+                        "maxWidth", "xl",
+                        "padding", "normal"
+                ),
+                List.of()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsService.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsService.java
@@ -6,6 +6,7 @@ import com.mzc.lp.domain.tenant.dto.request.UpdateLayoutSettingsRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateTenantSettingsRequest;
 import com.mzc.lp.domain.tenant.dto.response.NavigationItemResponse;
 import com.mzc.lp.domain.tenant.dto.response.PublicBrandingResponse;
+import com.mzc.lp.domain.tenant.dto.response.PublicLayoutResponse;
 import com.mzc.lp.domain.tenant.dto.response.TenantSettingsResponse;
 
 import java.util.List;
@@ -121,4 +122,30 @@ public interface TenantSettingsService {
      * @return 브랜딩 정보
      */
     PublicBrandingResponse getBrandingByTenantId(Long tenantId);
+
+    // ============================================
+    // 공개 레이아웃 정보 (TU용)
+    // ============================================
+
+    /**
+     * 공개 레이아웃 정보 조회 (인증 불필요)
+     * @param identifier subdomain 또는 customDomain
+     * @param type "subdomain" 또는 "customDomain"
+     * @return 공개 레이아웃 정보
+     */
+    PublicLayoutResponse getPublicLayout(String identifier, String type);
+
+    /**
+     * 테넌트 ID로 레이아웃 정보 조회 (인증된 사용자용)
+     * @param tenantId 테넌트 ID
+     * @return 레이아웃 정보
+     */
+    PublicLayoutResponse getLayoutByTenantId(Long tenantId);
+
+    /**
+     * 활성화된 네비게이션 항목만 조회 (TU용)
+     * @param tenantId 테넌트 ID
+     * @return 활성화된 네비게이션 항목 목록
+     */
+    List<NavigationItemResponse> getEnabledNavigationItems(Long tenantId);
 }

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsServiceImpl.java
@@ -6,6 +6,7 @@ import com.mzc.lp.domain.tenant.dto.request.UpdateLayoutSettingsRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateTenantSettingsRequest;
 import com.mzc.lp.domain.tenant.dto.response.NavigationItemResponse;
 import com.mzc.lp.domain.tenant.dto.response.PublicBrandingResponse;
+import com.mzc.lp.domain.tenant.dto.response.PublicLayoutResponse;
 import com.mzc.lp.domain.tenant.dto.response.TenantSettingsResponse;
 import com.mzc.lp.domain.tenant.constant.TenantStatus;
 import com.mzc.lp.domain.tenant.entity.NavigationItem;
@@ -301,6 +302,65 @@ public class TenantSettingsServiceImpl implements TenantSettingsService {
 
         TenantSettingsResponse settingsResponse = TenantSettingsResponse.from(settings);
         return PublicBrandingResponse.from(settingsResponse, tenant.getName());
+    }
+
+    // ============================================
+    // 공개 레이아웃 정보 (TU용)
+    // ============================================
+
+    @Override
+    public PublicLayoutResponse getPublicLayout(String identifier, String type) {
+        final Tenant tenant;
+
+        if ("subdomain".equals(type)) {
+            tenant = tenantRepository.findBySubdomain(identifier)
+                    .filter(t -> t.getStatus() == TenantStatus.ACTIVE)
+                    .orElse(null);
+        } else if ("customDomain".equals(type)) {
+            tenant = tenantRepository.findByCustomDomain(identifier)
+                    .filter(t -> t.getStatus() == TenantStatus.ACTIVE)
+                    .orElse(null);
+        } else {
+            tenant = null;
+        }
+
+        if (tenant == null) {
+            return PublicLayoutResponse.defaultLayout();
+        }
+
+        return getLayoutByTenantId(tenant.getId());
+    }
+
+    @Override
+    @Transactional
+    public PublicLayoutResponse getLayoutByTenantId(Long tenantId) {
+        Tenant tenant = tenantRepository.findById(tenantId)
+                .orElse(null);
+
+        if (tenant == null) {
+            return PublicLayoutResponse.defaultLayout();
+        }
+
+        TenantSettings settings = tenantSettingsRepository.findByTenantId(tenantId)
+                .orElseGet(() -> TenantSettings.createDefault(tenant));
+
+        List<NavigationItemResponse> navigationItems = getEnabledNavigationItems(tenantId);
+
+        return PublicLayoutResponse.from(settings, navigationItems);
+    }
+
+    @Override
+    @Transactional
+    public List<NavigationItemResponse> getEnabledNavigationItems(Long tenantId) {
+        // 네비게이션 항목이 없으면 기본 항목 초기화
+        if (!navigationItemRepository.existsByTenantId(tenantId)) {
+            initializeDefaultNavigationItems(tenantId);
+        }
+
+        return navigationItemRepository.findByTenantIdAndEnabledTrueOrderByDisplayOrderAsc(tenantId)
+                .stream()
+                .map(NavigationItemResponse::from)
+                .toList();
     }
 
     private TenantSettings initializeAndGet(Long tenantId) {


### PR DESCRIPTION
## Summary

TA(Tenant Admin)에서 설정한 레이아웃 및 네비게이션 설정을 TU(Tenant User) 사용자가 동적으로 조회할 수 있도록 공개 API를 추가했습니다.

## Related Issue

- Closes #322

## Changes

- `PublicLayoutResponse` DTO 생성 (헤더, 푸터, 콘텐츠 설정 포함)
- `/api/tenant/settings/layout/public` 공개 엔드포인트 추가
- `/api/tenant/settings/navigation/public` 공개 엔드포인트 추가
- `TenantSettingsService`에 `getLayoutByTenantId()` 및 `getEnabledNavigationItems()` 메서드 구현
- 인증/비인증 사용자 모두 지원 (tenantId null인 경우 기본값 반환)
- 활성화된 네비게이션 항목만 필터링하여 반환

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 공개 API는 인증이 필요하지 않지만, tenantId는 컨텍스트에서 자동 추출됩니다
- tenantId가 null인 경우 기본 레이아웃 및 빈 네비게이션을 반환하여 안전성 확보
- 프론트엔드 PR과 함께 배포되어야 정상 작동합니다
