### PR TITLE
feat: 코스 리뷰 작성 및 조회 기능 구현

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -36,6 +36,10 @@ public enum ErrorCode {
     CM_LEARNING_OBJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "CM008", "LearningObject not found"),
     CM_SNAPSHOT_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "CM009", "SnapshotItem not found"),
     CM_UNAUTHORIZED_COURSE_ACCESS(HttpStatus.FORBIDDEN, "CM010", "Not authorized to access this course"),
+    CM_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "CM011", "Course review not found"),
+    CM_REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "CM012", "Review already exists for this course"),
+    CM_NOT_COMPLETED_COURSE(HttpStatus.BAD_REQUEST, "CM013", "Cannot write review for incomplete course"),
+    CM_NOT_REVIEW_OWNER(HttpStatus.FORBIDDEN, "CM014", "Not authorized to modify this review"),
 
     // Content (CMS)
     CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CT001", "Content not found"),

--- a/src/main/java/com/mzc/lp/domain/course/controller/CourseReviewController.java
+++ b/src/main/java/com/mzc/lp/domain/course/controller/CourseReviewController.java
@@ -1,0 +1,119 @@
+package com.mzc.lp.domain.course.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.course.dto.request.CreateReviewRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateReviewRequest;
+import com.mzc.lp.domain.course.dto.response.CourseReviewListResponse;
+import com.mzc.lp.domain.course.dto.response.CourseReviewResponse;
+import com.mzc.lp.domain.course.dto.response.CourseReviewStatsResponse;
+import com.mzc.lp.domain.course.service.CourseReviewService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/courses/{courseId}/reviews")
+@RequiredArgsConstructor
+@Validated
+public class CourseReviewController {
+
+    private final CourseReviewService reviewService;
+
+    /**
+     * 리뷰 작성
+     * POST /api/courses/{courseId}/reviews
+     */
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<CourseReviewResponse>> createReview(
+            @PathVariable Long courseId,
+            @Valid @RequestBody CreateReviewRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseReviewResponse response = reviewService.createReview(courseId, principal.id(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 리뷰 목록 조회
+     * GET /api/courses/{courseId}/reviews
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<CourseReviewListResponse>> getReviews(
+            @PathVariable Long courseId,
+            @RequestParam(required = false, defaultValue = "latest") String sortBy,
+            @RequestParam(required = false, defaultValue = "0") int page,
+            @RequestParam(required = false, defaultValue = "20") int pageSize
+    ) {
+        CourseReviewListResponse response = reviewService.getReviews(courseId, sortBy, page, pageSize);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 리뷰 통계 조회
+     * GET /api/courses/{courseId}/reviews/stats
+     */
+    @GetMapping("/stats")
+    public ResponseEntity<ApiResponse<CourseReviewStatsResponse>> getReviewStats(
+            @PathVariable Long courseId
+    ) {
+        CourseReviewStatsResponse response = reviewService.getReviewStats(courseId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 내 리뷰 조회
+     * GET /api/courses/{courseId}/reviews/my
+     */
+    @GetMapping("/my")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<CourseReviewResponse>> getMyReview(
+            @PathVariable Long courseId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseReviewResponse response = reviewService.getMyReview(courseId, principal.id());
+        if (response == null) {
+            return ResponseEntity.ok(ApiResponse.success(null));
+        }
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 리뷰 수정
+     * PUT /api/courses/{courseId}/reviews/{reviewId}
+     */
+    @PutMapping("/{reviewId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<CourseReviewResponse>> updateReview(
+            @PathVariable Long courseId,
+            @PathVariable Long reviewId,
+            @Valid @RequestBody UpdateReviewRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseReviewResponse response = reviewService.updateReview(courseId, reviewId, principal.id(), request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 리뷰 삭제
+     * DELETE /api/courses/{courseId}/reviews/{reviewId}
+     */
+    @DeleteMapping("/{reviewId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> deleteReview(
+            @PathVariable Long courseId,
+            @PathVariable Long reviewId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        boolean isAdmin = "TENANT_ADMIN".equals(principal.role())
+                || "SYSTEM_ADMIN".equals(principal.role());
+        reviewService.deleteReview(courseId, reviewId, principal.id(), isAdmin);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/request/CreateReviewRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/CreateReviewRequest.java
@@ -1,0 +1,22 @@
+package com.mzc.lp.domain.course.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateReviewRequest(
+        @NotNull(message = "별점은 필수입니다")
+        @Min(value = 1, message = "별점은 1점 이상이어야 합니다")
+        @Max(value = 5, message = "별점은 5점 이하여야 합니다")
+        Integer rating,
+
+        @Size(max = 2000, message = "리뷰 내용은 2000자 이하여야 합니다")
+        String content
+) {
+    public CreateReviewRequest {
+        if (content != null) {
+            content = content.trim();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateReviewRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateReviewRequest.java
@@ -1,0 +1,22 @@
+package com.mzc.lp.domain.course.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UpdateReviewRequest(
+        @NotNull(message = "별점은 필수입니다")
+        @Min(value = 1, message = "별점은 1점 이상이어야 합니다")
+        @Max(value = 5, message = "별점은 5점 이하여야 합니다")
+        Integer rating,
+
+        @Size(max = 2000, message = "리뷰 내용은 2000자 이하여야 합니다")
+        String content
+) {
+    public UpdateReviewRequest {
+        if (content != null) {
+            content = content.trim();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseDetailResponse.java
@@ -23,6 +23,8 @@ public record CourseDetailResponse(
         List<CourseItemResponse> items,
         int itemCount,
         boolean isComplete,
+        Double averageRating,
+        long reviewCount,
         Instant createdAt,
         Instant updatedAt
 ) {
@@ -42,10 +44,15 @@ public record CourseDetailResponse(
 
     public static CourseDetailResponse from(Course course, List<CourseItemResponse> items) {
         int count = items != null ? items.size() : 0;
-        return from(course, items, count);
+        return from(course, items, count, null, 0L);
     }
 
     public static CourseDetailResponse from(Course course, List<CourseItemResponse> items, int itemCount) {
+        return from(course, items, itemCount, null, 0L);
+    }
+
+    public static CourseDetailResponse from(Course course, List<CourseItemResponse> items, int itemCount,
+                                             Double averageRating, long reviewCount) {
         return new CourseDetailResponse(
                 course.getId(),
                 course.getTitle(),
@@ -61,6 +68,8 @@ public record CourseDetailResponse(
                 items,
                 itemCount,
                 checkCompleteness(course, itemCount),
+                averageRating != null ? Math.round(averageRating * 10.0) / 10.0 : 0.0,
+                reviewCount,
                 course.getCreatedAt(),
                 course.getUpdatedAt()
         );

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseReviewListResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseReviewListResponse.java
@@ -1,0 +1,33 @@
+package com.mzc.lp.domain.course.dto.response;
+
+import java.util.List;
+
+public record CourseReviewListResponse(
+        List<CourseReviewResponse> reviews,
+        int totalPages,
+        long totalElements,
+        int currentPage,
+        int pageSize,
+        Double averageRating,
+        long reviewCount
+) {
+    public static CourseReviewListResponse of(
+            List<CourseReviewResponse> reviews,
+            int totalPages,
+            long totalElements,
+            int currentPage,
+            int pageSize,
+            Double averageRating,
+            long reviewCount
+    ) {
+        return new CourseReviewListResponse(
+                reviews,
+                totalPages,
+                totalElements,
+                currentPage,
+                pageSize,
+                averageRating != null ? Math.round(averageRating * 10.0) / 10.0 : 0.0,
+                reviewCount
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseReviewResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseReviewResponse.java
@@ -1,0 +1,29 @@
+package com.mzc.lp.domain.course.dto.response;
+
+import com.mzc.lp.domain.course.entity.CourseReview;
+
+import java.time.Instant;
+
+public record CourseReviewResponse(
+        Long reviewId,
+        Long courseId,
+        Long userId,
+        String userName,
+        Integer rating,
+        String content,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static CourseReviewResponse from(CourseReview review, String userName) {
+        return new CourseReviewResponse(
+                review.getId(),
+                review.getCourseId(),
+                review.getUserId(),
+                userName,
+                review.getRating(),
+                review.getContent(),
+                review.getCreatedAt(),
+                review.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseReviewStatsResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseReviewStatsResponse.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.course.dto.response;
+
+public record CourseReviewStatsResponse(
+        Long courseId,
+        Double averageRating,
+        long reviewCount
+) {
+    public static CourseReviewStatsResponse of(Long courseId, Double averageRating, long reviewCount) {
+        return new CourseReviewStatsResponse(
+                courseId,
+                averageRating != null ? Math.round(averageRating * 10.0) / 10.0 : 0.0,
+                reviewCount
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/entity/CourseReview.java
+++ b/src/main/java/com/mzc/lp/domain/course/entity/CourseReview.java
@@ -1,0 +1,80 @@
+package com.mzc.lp.domain.course.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "cm_course_reviews",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_course_review",
+                columnNames = {"tenant_id", "course_id", "user_id"}
+        ),
+        indexes = {
+                @Index(name = "idx_course_review_course", columnList = "tenant_id, course_id"),
+                @Index(name = "idx_course_review_user", columnList = "tenant_id, user_id"),
+                @Index(name = "idx_course_review_rating", columnList = "tenant_id, rating")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CourseReview extends TenantEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Version
+    private Long version;
+
+    @Column(name = "course_id", nullable = false)
+    private Long courseId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private Integer rating;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    // ===== 정적 팩토리 메서드 =====
+    public static CourseReview create(Long courseId, Long userId, Integer rating, String content) {
+        CourseReview review = new CourseReview();
+        review.courseId = courseId;
+        review.userId = userId;
+        review.validateAndSetRating(rating);
+        review.content = content;
+        return review;
+    }
+
+    // ===== 비즈니스 메서드 =====
+    public void update(Integer rating, String content) {
+        validateAndSetRating(rating);
+        this.content = content;
+    }
+
+    public void updateRating(Integer rating) {
+        validateAndSetRating(rating);
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    // ===== Private 검증 메서드 =====
+    private void validateAndSetRating(Integer rating) {
+        if (rating == null || rating < 1 || rating > 5) {
+            throw new IllegalArgumentException("Rating must be between 1 and 5");
+        }
+        this.rating = rating;
+    }
+
+    // ===== 검증 메서드 =====
+    public boolean isOwner(Long userId) {
+        return this.userId.equals(userId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/exception/CourseNotCompletedException.java
+++ b/src/main/java/com/mzc/lp/domain/course/exception/CourseNotCompletedException.java
@@ -1,0 +1,16 @@
+package com.mzc.lp.domain.course.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class CourseNotCompletedException extends BusinessException {
+
+    public CourseNotCompletedException() {
+        super(ErrorCode.CM_NOT_COMPLETED_COURSE);
+    }
+
+    public CourseNotCompletedException(Long courseId) {
+        super(ErrorCode.CM_NOT_COMPLETED_COURSE,
+            "수강 완료한 강의만 리뷰를 작성할 수 있습니다. CourseId: " + courseId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/exception/CourseReviewAlreadyExistsException.java
+++ b/src/main/java/com/mzc/lp/domain/course/exception/CourseReviewAlreadyExistsException.java
@@ -1,0 +1,16 @@
+package com.mzc.lp.domain.course.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class CourseReviewAlreadyExistsException extends BusinessException {
+
+    public CourseReviewAlreadyExistsException() {
+        super(ErrorCode.CM_REVIEW_ALREADY_EXISTS);
+    }
+
+    public CourseReviewAlreadyExistsException(Long courseId, Long userId) {
+        super(ErrorCode.CM_REVIEW_ALREADY_EXISTS,
+            "이미 작성한 리뷰가 있습니다. CourseId: " + courseId + ", UserId: " + userId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/exception/CourseReviewNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/course/exception/CourseReviewNotFoundException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.course.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class CourseReviewNotFoundException extends BusinessException {
+
+    public CourseReviewNotFoundException() {
+        super(ErrorCode.CM_REVIEW_NOT_FOUND);
+    }
+
+    public CourseReviewNotFoundException(Long reviewId) {
+        super(ErrorCode.CM_REVIEW_NOT_FOUND, "리뷰를 찾을 수 없습니다. ID: " + reviewId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/exception/NotReviewOwnerException.java
+++ b/src/main/java/com/mzc/lp/domain/course/exception/NotReviewOwnerException.java
@@ -1,0 +1,16 @@
+package com.mzc.lp.domain.course.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class NotReviewOwnerException extends BusinessException {
+
+    public NotReviewOwnerException() {
+        super(ErrorCode.CM_NOT_REVIEW_OWNER);
+    }
+
+    public NotReviewOwnerException(Long reviewId, Long userId) {
+        super(ErrorCode.CM_NOT_REVIEW_OWNER,
+            "본인의 리뷰만 수정/삭제할 수 있습니다. ReviewId: " + reviewId + ", UserId: " + userId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/repository/CourseReviewRepository.java
+++ b/src/main/java/com/mzc/lp/domain/course/repository/CourseReviewRepository.java
@@ -1,0 +1,29 @@
+package com.mzc.lp.domain.course.repository;
+
+import com.mzc.lp.domain.course.entity.CourseReview;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CourseReviewRepository extends JpaRepository<CourseReview, Long> {
+
+    Optional<CourseReview> findByIdAndTenantId(Long id, Long tenantId);
+
+    Optional<CourseReview> findByCourseIdAndUserIdAndTenantId(Long courseId, Long userId, Long tenantId);
+
+    Page<CourseReview> findByCourseIdAndTenantId(Long courseId, Long tenantId, Pageable pageable);
+
+    boolean existsByCourseIdAndUserIdAndTenantId(Long courseId, Long userId, Long tenantId);
+
+    long countByCourseIdAndTenantId(Long courseId, Long tenantId);
+
+    @Query("SELECT AVG(r.rating) FROM CourseReview r WHERE r.courseId = :courseId AND r.tenantId = :tenantId")
+    Double findAverageRatingByCourseId(@Param("courseId") Long courseId, @Param("tenantId") Long tenantId);
+
+    @Query("SELECT COUNT(r), AVG(r.rating) FROM CourseReview r WHERE r.courseId = :courseId AND r.tenantId = :tenantId")
+    Object[] findReviewStatsForCourse(@Param("courseId") Long courseId, @Param("tenantId") Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseReviewService.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseReviewService.java
@@ -1,0 +1,63 @@
+package com.mzc.lp.domain.course.service;
+
+import com.mzc.lp.domain.course.dto.request.CreateReviewRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateReviewRequest;
+import com.mzc.lp.domain.course.dto.response.CourseReviewListResponse;
+import com.mzc.lp.domain.course.dto.response.CourseReviewResponse;
+import com.mzc.lp.domain.course.dto.response.CourseReviewStatsResponse;
+
+public interface CourseReviewService {
+
+    /**
+     * 코스 리뷰 작성
+     * @param courseId 코스 ID
+     * @param userId 사용자 ID
+     * @param request 리뷰 작성 요청
+     * @return 생성된 리뷰 정보
+     */
+    CourseReviewResponse createReview(Long courseId, Long userId, CreateReviewRequest request);
+
+    /**
+     * 코스 리뷰 목록 조회 (페이징)
+     * @param courseId 코스 ID
+     * @param sortBy 정렬 기준 (latest, rating)
+     * @param page 페이지 번호
+     * @param pageSize 페이지 크기
+     * @return 리뷰 목록 및 통계
+     */
+    CourseReviewListResponse getReviews(Long courseId, String sortBy, int page, int pageSize);
+
+    /**
+     * 코스 리뷰 통계 조회
+     * @param courseId 코스 ID
+     * @return 평균 별점 및 리뷰 개수
+     */
+    CourseReviewStatsResponse getReviewStats(Long courseId);
+
+    /**
+     * 내 리뷰 조회
+     * @param courseId 코스 ID
+     * @param userId 사용자 ID
+     * @return 리뷰 정보 (없으면 null)
+     */
+    CourseReviewResponse getMyReview(Long courseId, Long userId);
+
+    /**
+     * 리뷰 수정
+     * @param courseId 코스 ID
+     * @param reviewId 리뷰 ID
+     * @param userId 사용자 ID
+     * @param request 리뷰 수정 요청
+     * @return 수정된 리뷰 정보
+     */
+    CourseReviewResponse updateReview(Long courseId, Long reviewId, Long userId, UpdateReviewRequest request);
+
+    /**
+     * 리뷰 삭제 (본인 또는 관리자)
+     * @param courseId 코스 ID
+     * @param reviewId 리뷰 ID
+     * @param userId 사용자 ID
+     * @param isAdmin 관리자 여부
+     */
+    void deleteReview(Long courseId, Long reviewId, Long userId, boolean isAdmin);
+}

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseReviewServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseReviewServiceImpl.java
@@ -1,0 +1,223 @@
+package com.mzc.lp.domain.course.service;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.domain.course.dto.request.CreateReviewRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateReviewRequest;
+import com.mzc.lp.domain.course.dto.response.CourseReviewListResponse;
+import com.mzc.lp.domain.course.dto.response.CourseReviewResponse;
+import com.mzc.lp.domain.course.dto.response.CourseReviewStatsResponse;
+import com.mzc.lp.domain.course.entity.CourseReview;
+import com.mzc.lp.domain.course.exception.*;
+import com.mzc.lp.domain.course.repository.CourseRepository;
+import com.mzc.lp.domain.course.repository.CourseReviewRepository;
+import com.mzc.lp.domain.student.constant.EnrollmentStatus;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.exception.UserNotFoundException;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CourseReviewServiceImpl implements CourseReviewService {
+
+    private final CourseReviewRepository reviewRepository;
+    private final CourseRepository courseRepository;
+    private final EnrollmentRepository enrollmentRepository;
+    private final CourseTimeRepository courseTimeRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public CourseReviewResponse createReview(Long courseId, Long userId, CreateReviewRequest request) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 1. 코스 존재 확인
+        courseRepository.findByIdAndTenantId(courseId, tenantId)
+                .orElseThrow(() -> new CourseNotFoundException(courseId));
+
+        // 2. 이미 작성한 리뷰가 있는지 확인
+        if (reviewRepository.existsByCourseIdAndUserIdAndTenantId(courseId, userId, tenantId)) {
+            throw new CourseReviewAlreadyExistsException(courseId, userId);
+        }
+
+        // 3. 수강 완료 여부 확인 - 해당 코스의 어느 차수라도 완료했으면 OK
+        boolean hasCompletedCourse = hasCompletedAnyCourseTime(courseId, userId, tenantId);
+        if (!hasCompletedCourse) {
+            throw new CourseNotCompletedException(courseId);
+        }
+
+        // 4. 리뷰 생성
+        CourseReview review = CourseReview.create(courseId, userId, request.rating(), request.content());
+        CourseReview savedReview = reviewRepository.save(review);
+
+        // 5. 사용자 이름 조회 및 응답 생성
+        String userName = getUserName(userId);
+        return CourseReviewResponse.from(savedReview, userName);
+    }
+
+    @Override
+    public CourseReviewListResponse getReviews(Long courseId, String sortBy, int page, int pageSize) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 1. 코스 존재 확인
+        courseRepository.findByIdAndTenantId(courseId, tenantId)
+                .orElseThrow(() -> new CourseNotFoundException(courseId));
+
+        // 2. 정렬 기준 설정
+        Sort sort = switch (sortBy != null ? sortBy : "latest") {
+            case "rating" -> Sort.by(Sort.Direction.DESC, "rating").and(Sort.by(Sort.Direction.DESC, "createdAt"));
+            default -> Sort.by(Sort.Direction.DESC, "createdAt");
+        };
+
+        // 3. 리뷰 목록 조회
+        PageRequest pageable = PageRequest.of(page, pageSize, sort);
+        Page<CourseReview> reviewPage = reviewRepository.findByCourseIdAndTenantId(courseId, tenantId, pageable);
+
+        // 4. 사용자 이름과 함께 응답 생성
+        List<CourseReviewResponse> reviews = reviewPage.getContent().stream()
+                .map(review -> {
+                    String userName = getUserName(review.getUserId());
+                    return CourseReviewResponse.from(review, userName);
+                })
+                .collect(Collectors.toList());
+
+        // 5. 리뷰 통계 조회
+        Object[] stats = reviewRepository.findReviewStatsForCourse(courseId, tenantId);
+        Long reviewCount = stats != null && stats[0] != null ? ((Number) stats[0]).longValue() : 0L;
+        Double averageRating = stats != null && stats[1] != null ? ((Number) stats[1]).doubleValue() : null;
+
+        return CourseReviewListResponse.of(
+                reviews,
+                reviewPage.getTotalPages(),
+                reviewPage.getTotalElements(),
+                page,
+                pageSize,
+                averageRating,
+                reviewCount
+        );
+    }
+
+    @Override
+    public CourseReviewStatsResponse getReviewStats(Long courseId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 코스 존재 확인
+        courseRepository.findByIdAndTenantId(courseId, tenantId)
+                .orElseThrow(() -> new CourseNotFoundException(courseId));
+
+        Object[] stats = reviewRepository.findReviewStatsForCourse(courseId, tenantId);
+        Long reviewCount = stats != null && stats[0] != null ? ((Number) stats[0]).longValue() : 0L;
+        Double averageRating = stats != null && stats[1] != null ? ((Number) stats[1]).doubleValue() : null;
+
+        return CourseReviewStatsResponse.of(courseId, averageRating, reviewCount);
+    }
+
+    @Override
+    public CourseReviewResponse getMyReview(Long courseId, Long userId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 코스 존재 확인
+        courseRepository.findByIdAndTenantId(courseId, tenantId)
+                .orElseThrow(() -> new CourseNotFoundException(courseId));
+
+        return reviewRepository.findByCourseIdAndUserIdAndTenantId(courseId, userId, tenantId)
+                .map(review -> {
+                    String userName = getUserName(userId);
+                    return CourseReviewResponse.from(review, userName);
+                })
+                .orElse(null);
+    }
+
+    @Override
+    @Transactional
+    public CourseReviewResponse updateReview(Long courseId, Long reviewId, Long userId, UpdateReviewRequest request) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 1. 리뷰 조회
+        CourseReview review = reviewRepository.findByIdAndTenantId(reviewId, tenantId)
+                .orElseThrow(() -> new CourseReviewNotFoundException(reviewId));
+
+        // 2. 코스 ID 일치 확인
+        if (!review.getCourseId().equals(courseId)) {
+            throw new CourseReviewNotFoundException(reviewId);
+        }
+
+        // 3. 본인 확인
+        if (!review.isOwner(userId)) {
+            throw new NotReviewOwnerException(reviewId, userId);
+        }
+
+        // 4. 리뷰 수정
+        review.update(request.rating(), request.content());
+
+        // 5. 응답 생성
+        String userName = getUserName(userId);
+        return CourseReviewResponse.from(review, userName);
+    }
+
+    @Override
+    @Transactional
+    public void deleteReview(Long courseId, Long reviewId, Long userId, boolean isAdmin) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 1. 리뷰 조회
+        CourseReview review = reviewRepository.findByIdAndTenantId(reviewId, tenantId)
+                .orElseThrow(() -> new CourseReviewNotFoundException(reviewId));
+
+        // 2. 코스 ID 일치 확인
+        if (!review.getCourseId().equals(courseId)) {
+            throw new CourseReviewNotFoundException(reviewId);
+        }
+
+        // 3. 권한 확인 (본인 또는 관리자)
+        if (!isAdmin && !review.isOwner(userId)) {
+            throw new NotReviewOwnerException(reviewId, userId);
+        }
+
+        // 4. 리뷰 삭제
+        reviewRepository.delete(review);
+    }
+
+    /**
+     * 해당 코스의 어느 차수라도 완료했는지 확인
+     */
+    private boolean hasCompletedAnyCourseTime(Long courseId, Long userId, Long tenantId) {
+        // 1. 해당 코스의 모든 차수 ID 조회
+        List<Long> courseTimeIds = courseTimeRepository.findByCmCourseIdAndTenantId(courseId, tenantId)
+                .stream()
+                .map(ct -> ct.getId())
+                .toList();
+
+        if (courseTimeIds.isEmpty()) {
+            return false;
+        }
+
+        // 2. 해당 차수들 중 COMPLETED 상태인 수강 신청이 있는지 확인
+        return courseTimeIds.stream()
+                .anyMatch(courseTimeId ->
+                        enrollmentRepository.findByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, tenantId)
+                                .map(enrollment -> enrollment.getStatus() == EnrollmentStatus.COMPLETED)
+                                .orElse(false)
+                );
+    }
+
+    /**
+     * 사용자 이름 조회
+     */
+    private String getUserName(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+        return user.getName();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
@@ -92,8 +92,19 @@ public class CourseServiceImpl implements CourseService {
 
         // 리뷰 통계 조회
         Object[] stats = reviewRepository.findReviewStatsForCourse(courseId, tenantId);
-        Long reviewCount = stats != null && stats[0] != null ? ((Number) stats[0]).longValue() : 0L;
-        Double averageRating = stats != null && stats[1] != null ? ((Number) stats[1]).doubleValue() : null;
+        Long reviewCount = 0L;
+        Double averageRating = null;
+
+        if (stats != null && stats.length >= 2) {
+            // stats[0]은 COUNT, stats[1]은 AVG
+            // 리뷰가 없을 경우 COUNT는 0, AVG는 null
+            if (stats[0] instanceof Number count) {
+                reviewCount = count.longValue();
+            }
+            if (stats[1] instanceof Number avg) {
+                averageRating = avg.doubleValue();
+            }
+        }
 
         return CourseDetailResponse.from(course, items, items.size(), averageRating, reviewCount);
     }

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseControllerTest.java
@@ -521,7 +521,9 @@ class CourseControllerTest extends TenantTestSupport {
                     .andExpect(jsonPath("$.data.title").value("Spring Boot 기초"))
                     .andExpect(jsonPath("$.data.items").isArray())
                     .andExpect(jsonPath("$.data.itemCount").value(0))
-                    .andExpect(jsonPath("$.data.isComplete").value(false)); // items가 없으므로 미완성
+                    .andExpect(jsonPath("$.data.isComplete").value(false)) // items가 없으므로 미완성
+                    .andExpect(jsonPath("$.data.averageRating").value(0.0))
+                    .andExpect(jsonPath("$.data.reviewCount").value(0));
         }
 
         @Test
@@ -560,7 +562,9 @@ class CourseControllerTest extends TenantTestSupport {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.data.isComplete").value(true))
-                    .andExpect(jsonPath("$.data.itemCount").value(1));
+                    .andExpect(jsonPath("$.data.itemCount").value(1))
+                    .andExpect(jsonPath("$.data.averageRating").value(0.0))
+                    .andExpect(jsonPath("$.data.reviewCount").value(0));
         }
 
         @Test
@@ -597,7 +601,9 @@ class CourseControllerTest extends TenantTestSupport {
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.isComplete").value(false));
+                    .andExpect(jsonPath("$.data.isComplete").value(false))
+                    .andExpect(jsonPath("$.data.averageRating").value(0.0))
+                    .andExpect(jsonPath("$.data.reviewCount").value(0));
         }
 
         @Test

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseReviewControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseReviewControllerTest.java
@@ -1,0 +1,241 @@
+package com.mzc.lp.domain.course.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.course.dto.request.CreateReviewRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateReviewRequest;
+import com.mzc.lp.domain.course.entity.Course;
+import com.mzc.lp.domain.course.entity.CourseReview;
+import com.mzc.lp.domain.course.repository.CourseRepository;
+import com.mzc.lp.domain.course.repository.CourseReviewRepository;
+import com.mzc.lp.domain.student.entity.Enrollment;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.ts.constant.DeliveryType;
+import com.mzc.lp.domain.ts.constant.EnrollmentMethod;
+import com.mzc.lp.domain.ts.entity.CourseTime;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.dto.request.LoginRequest;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.RefreshTokenRepository;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("코스 리뷰 API 테스트")
+class CourseReviewControllerTest extends TenantTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CourseReviewRepository reviewRepository;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @Autowired
+    private CourseTimeRepository courseTimeRepository;
+
+    @Autowired
+    private EnrollmentRepository enrollmentRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private User testUser;
+    private Course testCourse;
+    private CourseTime testCourseTime;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        reviewRepository.deleteAll();
+        enrollmentRepository.deleteAll();
+        courseTimeRepository.deleteAll();
+        courseRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+
+        // 테스트 사용자 생성 및 로그인
+        testUser = User.create("student@example.com", "학생", passwordEncoder.encode("Password123!"));
+        testUser.updateRole(TenantRole.USER);
+        testUser = userRepository.save(testUser);
+
+        LoginRequest loginRequest = new LoginRequest("student@example.com", "Password123!");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        accessToken = objectMapper.readTree(response).get("data").get("accessToken").asText();
+
+        // 테스트 코스 생성
+        testCourse = Course.create("테스트 코스", testUser.getId());
+        testCourse = courseRepository.save(testCourse);
+
+        // 테스트 차수 생성
+        testCourseTime = CourseTime.create(
+                "테스트 차수",
+                DeliveryType.ONLINE,
+                LocalDate.now(),
+                LocalDate.now().plusDays(30),
+                LocalDate.now(),
+                LocalDate.now().plusDays(30),
+                100,
+                0,
+                EnrollmentMethod.FIRST_COME,
+                80,
+                BigDecimal.ZERO,
+                true,
+                null,
+                false,
+                testUser.getId()
+        );
+        testCourseTime = courseTimeRepository.save(testCourseTime);
+    }
+
+    @Test
+    @DisplayName("리뷰 작성 성공 - 수강 완료한 코스")
+    void createReview_Success() throws Exception {
+        // Given - 수강 완료 상태 생성
+        Enrollment enrollment = Enrollment.createVoluntary(testUser.getId(), testCourseTime.getId());
+        enrollment.complete(100);
+        enrollmentRepository.save(enrollment);
+
+        CreateReviewRequest request = new CreateReviewRequest(5, "정말 좋은 강의였습니다!");
+
+        // When & Then
+        mockMvc.perform(post("/api/courses/{courseId}/reviews", testCourse.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.rating").value(5))
+                .andExpect(jsonPath("$.data.content").value("정말 좋은 강의였습니다!"));
+    }
+
+    @Test
+    @DisplayName("리뷰 작성 실패 - 수강 완료하지 않음")
+    void createReview_Fail_NotCompleted() throws Exception {
+        // Given - 수강 중 상태
+        Enrollment enrollment = Enrollment.createVoluntary(testUser.getId(), testCourseTime.getId());
+        enrollmentRepository.save(enrollment);
+
+        CreateReviewRequest request = new CreateReviewRequest(5, "좋아요");
+
+        // When & Then
+        mockMvc.perform(post("/api/courses/{courseId}/reviews", testCourse.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("리뷰 목록 조회 성공")
+    void getReviews_Success() throws Exception {
+        // Given - 리뷰 생성
+        CourseReview review1 = CourseReview.create(testCourse.getId(), testUser.getId(), 5, "좋아요");
+        CourseReview review2 = CourseReview.create(testCourse.getId(), testUser.getId(), 4, "괜찮아요");
+        reviewRepository.save(review1);
+        reviewRepository.save(review2);
+
+        // When & Then
+        mockMvc.perform(get("/api/courses/{courseId}/reviews", testCourse.getId())
+                        .param("page", "0")
+                        .param("pageSize", "20")
+                        .param("sortBy", "latest"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews").isArray())
+                .andExpect(jsonPath("$.data.averageRating").exists())
+                .andExpect(jsonPath("$.data.reviewCount").exists());
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 성공")
+    void updateReview_Success() throws Exception {
+        // Given
+        Enrollment enrollment = Enrollment.createVoluntary(testUser.getId(), testCourseTime.getId());
+        enrollment.complete(100);
+        enrollmentRepository.save(enrollment);
+
+        CourseReview review = CourseReview.create(testCourse.getId(), testUser.getId(), 4, "괜찮아요");
+        review = reviewRepository.save(review);
+
+        UpdateReviewRequest request = new UpdateReviewRequest(5, "수정: 정말 좋아요!");
+
+        // When & Then
+        mockMvc.perform(put("/api/courses/{courseId}/reviews/{reviewId}", testCourse.getId(), review.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.rating").value(5))
+                .andExpect(jsonPath("$.data.content").value("수정: 정말 좋아요!"));
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 성공")
+    void deleteReview_Success() throws Exception {
+        // Given
+        CourseReview review = CourseReview.create(testCourse.getId(), testUser.getId(), 5, "좋아요");
+        review = reviewRepository.save(review);
+
+        // When & Then
+        mockMvc.perform(delete("/api/courses/{courseId}/reviews/{reviewId}", testCourse.getId(), review.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("리뷰 통계 조회 성공")
+    void getReviewStats_Success() throws Exception {
+        // Given
+        CourseReview review1 = CourseReview.create(testCourse.getId(), testUser.getId(), 5, "좋아요");
+        CourseReview review2 = CourseReview.create(testCourse.getId(), testUser.getId(), 4, "괜찮아요");
+        reviewRepository.save(review1);
+        reviewRepository.save(review2);
+
+        // When & Then
+        mockMvc.perform(get("/api/courses/{courseId}/reviews/stats", testCourse.getId()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.courseId").value(testCourse.getId()))
+                .andExpect(jsonPath("$.data.averageRating").exists())
+                .andExpect(jsonPath("$.data.reviewCount").value(2));
+    }
+}


### PR DESCRIPTION
## Summary

코스 리뷰 작성 및 조회 기능을 구현했습니다. 수강 완료한 학습자가 코스에 대한 별점(1-5점)과 텍스트 리뷰를 작성할 수 있으며, 코스 상세 정보에 평균 별점과 리뷰 개수가 표시됩니다.

## Related Issue

- Closes #323

## Changes

- **Entity**: CourseReview 엔티티 생성 (별점 1-5, 텍스트 리뷰, 코스당 1개 제약)
- **Repository**: 리뷰 CRUD 및 평균 별점 계산 쿼리 구현
- **DTO**: Request/Response DTO 6개 생성 (CreateReviewRequest, UpdateReviewRequest, CourseReviewResponse, CourseReviewListResponse, CourseReviewStatsResponse)
- **Exception**: 리뷰 관련 예외 클래스 4개 및 ErrorCode 추가 (CM011-CM014)
- **Service**: 수강 완료 검증 로직 및 리뷰 CRUD 구현
- **Controller**: 리뷰 API 6개 엔드포인트 구현
- **CourseDetailResponse**: 평균 별점 및 리뷰 개수 필드 추가
- **Test**: CourseReviewControllerTest 작성 (6개 테스트 케이스)

### API 엔드포인트
- `POST /api/courses/{courseId}/reviews` - 리뷰 작성
- `GET /api/courses/{courseId}/reviews` - 리뷰 목록 조회 (최신순/별점순 정렬)
- `GET /api/courses/{courseId}/reviews/stats` - 리뷰 통계 조회
- `GET /api/courses/{courseId}/reviews/my` - 내 리뷰 조회
- `PUT /api/courses/{courseId}/reviews/{reviewId}` - 리뷰 수정
- `DELETE /api/courses/{courseId}/reviews/{reviewId}` - 리뷰 삭제

### 비즈니스 로직
- 수강 완료한 학습자만 리뷰 작성 가능 (해당 코스의 어느 차수라도 COMPLETED 상태)
- 코스당 1개의 리뷰만 작성 가능 (수정 가능)
- 본인 리뷰만 수정 가능
- 본인 또는 관리자(TENANT_ADMIN, SYSTEM_ADMIN)가 삭제 가능
- 평균 별점 소수점 첫째자리까지 반올림
- 별점 1-5점 검증 (@Min, @Max)

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A - 백엔드 API 구현

## Additional Notes

- 테넌트별 데이터 분리 적용 (TenantEntity 상속)
- 낙관적 락(@Version) 적용으로 동시성 제어
- CourseTime의 cmCourseId 필드 사용 (deprecated이지만 현재 시스템에서 사용 중)
- 리뷰 통계는 실시간 계산으로 구현 (캐싱은 추후 필요시 적용 가능)