### PR TITLE
fix: /api/courses/my permitAll 제외 처리

### DIFF
--- a/src/main/java/com/mzc/lp/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mzc/lp/common/security/JwtAuthenticationFilter.java
@@ -61,9 +61,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         // GET 메서드로만 허용된 공개 API
+        // 주의: /api/courses/my는 인증이 필요하므로 제외
         if ("GET".equalsIgnoreCase(method)) {
             if (path.equals("/api/tenant/settings/branding") ||
-                path.startsWith("/api/courses") ||
+                (path.startsWith("/api/courses") && !path.equals("/api/courses/my")) ||
                 path.startsWith("/api/community/posts") ||
                 path.equals("/api/community/categories") ||
                 path.startsWith("/api/public/course-times")) {


### PR DESCRIPTION
## Summary

- `/api/courses/my` API가 `path.startsWith("/api/courses")`에 의해 permitAll로 잘못 처리되는 문제 수정
- 강의 디자인 페이지 403 에러 해결

## 원인

```java
// 기존: /api/courses/my도 매칭되어 토큰 검증 건너뜀
path.startsWith("/api/courses")
```

## 수정

```java
// 변경: /api/courses/my는 인증 필요
(path.startsWith("/api/courses") && !path.equals("/api/courses/my"))
```

## Test plan

- [x] DESIGNER 권한 사용자로 로그인
- [x] `/tu/teaching/courses` 페이지 접근 확인 (403 → 정상)
- [x] `/api/courses` (목록) 공개 접근 여전히 가능
- [x] `/api/courses/{id}` (상세) 공개 접근 여전히 가능

Closes #326