### PR TITLE
feat: 코스 공지사항 기능 구현

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -40,6 +40,8 @@ public enum ErrorCode {
     CM_REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "CM012", "Review already exists for this course"),
     CM_NOT_COMPLETED_COURSE(HttpStatus.BAD_REQUEST, "CM013", "Cannot write review for incomplete course"),
     CM_NOT_REVIEW_OWNER(HttpStatus.FORBIDDEN, "CM014", "Not authorized to modify this review"),
+    CM_ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CM015", "Announcement not found"),
+    CM_NOT_ANNOUNCEMENT_AUTHOR(HttpStatus.FORBIDDEN, "CM016", "Not authorized to modify this announcement"),
 
     // Content (CMS)
     CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CT001", "Content not found"),

--- a/src/main/java/com/mzc/lp/domain/course/controller/CourseAnnouncementController.java
+++ b/src/main/java/com/mzc/lp/domain/course/controller/CourseAnnouncementController.java
@@ -1,0 +1,110 @@
+package com.mzc.lp.domain.course.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.course.dto.request.CreateAnnouncementRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateAnnouncementRequest;
+import com.mzc.lp.domain.course.dto.response.AnnouncementListResponse;
+import com.mzc.lp.domain.course.dto.response.AnnouncementResponse;
+import com.mzc.lp.domain.course.service.CourseAnnouncementService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 코스 공지사항 API
+ */
+@RestController
+@RequestMapping("/api/courses/{courseId}/announcements")
+@RequiredArgsConstructor
+@Validated
+public class CourseAnnouncementController {
+
+    private final CourseAnnouncementService announcementService;
+
+    /**
+     * 코스 공지 작성 (강사/운영자)
+     * POST /api/courses/{courseId}/announcements
+     */
+    @PostMapping
+    @PreAuthorize("hasAnyRole('INSTRUCTOR', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<AnnouncementResponse>> createAnnouncement(
+            @PathVariable Long courseId,
+            @Valid @RequestBody CreateAnnouncementRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        AnnouncementResponse response = announcementService.createAnnouncement(courseId, principal.id(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 코스 공지 목록 조회
+     * GET /api/courses/{courseId}/announcements
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<AnnouncementListResponse>> getAnnouncements(
+            @PathVariable Long courseId,
+            @RequestParam(required = false, defaultValue = "0") int page,
+            @RequestParam(required = false, defaultValue = "20") int pageSize
+    ) {
+        AnnouncementListResponse response = announcementService.getAnnouncementsByCourse(courseId, page, pageSize);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 공지 상세 조회
+     * GET /api/courses/{courseId}/announcements/{announcementId}
+     */
+    @GetMapping("/{announcementId}")
+    public ResponseEntity<ApiResponse<AnnouncementResponse>> getAnnouncement(
+            @PathVariable Long courseId,
+            @PathVariable Long announcementId
+    ) {
+        AnnouncementResponse response = announcementService.getAnnouncement(announcementId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 공지 수정 (작성자 또는 관리자)
+     * PUT /api/courses/{courseId}/announcements/{announcementId}
+     */
+    @PutMapping("/{announcementId}")
+    @PreAuthorize("hasAnyRole('INSTRUCTOR', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<AnnouncementResponse>> updateAnnouncement(
+            @PathVariable Long courseId,
+            @PathVariable Long announcementId,
+            @Valid @RequestBody UpdateAnnouncementRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        boolean isAdmin = isAdmin(principal);
+        AnnouncementResponse response = announcementService.updateAnnouncement(announcementId, principal.id(), request, isAdmin);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 공지 삭제 (작성자 또는 관리자)
+     * DELETE /api/courses/{courseId}/announcements/{announcementId}
+     */
+    @DeleteMapping("/{announcementId}")
+    @PreAuthorize("hasAnyRole('INSTRUCTOR', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> deleteAnnouncement(
+            @PathVariable Long courseId,
+            @PathVariable Long announcementId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        boolean isAdmin = isAdmin(principal);
+        announcementService.deleteAnnouncement(announcementId, principal.id(), isAdmin);
+        return ResponseEntity.noContent().build();
+    }
+
+    private boolean isAdmin(UserPrincipal principal) {
+        return "OPERATOR".equals(principal.role())
+                || "TENANT_ADMIN".equals(principal.role())
+                || "SYSTEM_ADMIN".equals(principal.role());
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/controller/CourseTimeAnnouncementController.java
+++ b/src/main/java/com/mzc/lp/domain/course/controller/CourseTimeAnnouncementController.java
@@ -1,0 +1,118 @@
+package com.mzc.lp.domain.course.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.course.dto.request.CreateAnnouncementRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateAnnouncementRequest;
+import com.mzc.lp.domain.course.dto.response.AnnouncementListResponse;
+import com.mzc.lp.domain.course.dto.response.AnnouncementResponse;
+import com.mzc.lp.domain.course.service.CourseAnnouncementService;
+import com.mzc.lp.domain.ts.repository.CourseTimeRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 차수별 공지사항 API
+ */
+@RestController
+@RequestMapping("/api/times/{timeId}/announcements")
+@RequiredArgsConstructor
+@Validated
+public class CourseTimeAnnouncementController {
+
+    private final CourseAnnouncementService announcementService;
+    private final CourseTimeRepository courseTimeRepository;
+
+    /**
+     * 차수별 공지 작성 (강사/운영자)
+     * POST /api/times/{timeId}/announcements
+     */
+    @PostMapping
+    @PreAuthorize("hasAnyRole('INSTRUCTOR', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<AnnouncementResponse>> createAnnouncement(
+            @PathVariable Long timeId,
+            @Valid @RequestBody CreateAnnouncementRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        // 차수에서 코스 ID 조회
+        Long courseId = courseTimeRepository.findById(timeId)
+                .map(ct -> ct.getCmCourseId())
+                .orElse(null);
+
+        AnnouncementResponse response = announcementService.createAnnouncementForCourseTime(
+                courseId, timeId, principal.id(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 차수별 공지 목록 조회
+     * GET /api/times/{timeId}/announcements
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<AnnouncementListResponse>> getAnnouncements(
+            @PathVariable Long timeId,
+            @RequestParam(required = false, defaultValue = "0") int page,
+            @RequestParam(required = false, defaultValue = "20") int pageSize
+    ) {
+        AnnouncementListResponse response = announcementService.getAnnouncementsByCourseTime(timeId, page, pageSize);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 공지 상세 조회
+     * GET /api/times/{timeId}/announcements/{announcementId}
+     */
+    @GetMapping("/{announcementId}")
+    public ResponseEntity<ApiResponse<AnnouncementResponse>> getAnnouncement(
+            @PathVariable Long timeId,
+            @PathVariable Long announcementId
+    ) {
+        AnnouncementResponse response = announcementService.getAnnouncement(announcementId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 공지 수정 (작성자 또는 관리자)
+     * PUT /api/times/{timeId}/announcements/{announcementId}
+     */
+    @PutMapping("/{announcementId}")
+    @PreAuthorize("hasAnyRole('INSTRUCTOR', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<AnnouncementResponse>> updateAnnouncement(
+            @PathVariable Long timeId,
+            @PathVariable Long announcementId,
+            @Valid @RequestBody UpdateAnnouncementRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        boolean isAdmin = isAdmin(principal);
+        AnnouncementResponse response = announcementService.updateAnnouncement(announcementId, principal.id(), request, isAdmin);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 공지 삭제 (작성자 또는 관리자)
+     * DELETE /api/times/{timeId}/announcements/{announcementId}
+     */
+    @DeleteMapping("/{announcementId}")
+    @PreAuthorize("hasAnyRole('INSTRUCTOR', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<Void> deleteAnnouncement(
+            @PathVariable Long timeId,
+            @PathVariable Long announcementId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        boolean isAdmin = isAdmin(principal);
+        announcementService.deleteAnnouncement(announcementId, principal.id(), isAdmin);
+        return ResponseEntity.noContent().build();
+    }
+
+    private boolean isAdmin(UserPrincipal principal) {
+        return "OPERATOR".equals(principal.role())
+                || "TENANT_ADMIN".equals(principal.role())
+                || "SYSTEM_ADMIN".equals(principal.role());
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/request/CreateAnnouncementRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/CreateAnnouncementRequest.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.domain.course.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 공지사항 생성 요청 DTO
+ */
+public record CreateAnnouncementRequest(
+        @NotBlank(message = "제목은 필수입니다")
+        @Size(max = 255, message = "제목은 255자 이내여야 합니다")
+        String title,
+
+        @NotBlank(message = "내용은 필수입니다")
+        String content,
+
+        Boolean isImportant
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateAnnouncementRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateAnnouncementRequest.java
@@ -1,0 +1,16 @@
+package com.mzc.lp.domain.course.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+/**
+ * 공지사항 수정 요청 DTO
+ */
+public record UpdateAnnouncementRequest(
+        @Size(max = 255, message = "제목은 255자 이내여야 합니다")
+        String title,
+
+        String content,
+
+        Boolean isImportant
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/AnnouncementListResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/AnnouncementListResponse.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.domain.course.dto.response;
+
+import java.util.List;
+
+/**
+ * 공지사항 목록 응답 DTO
+ */
+public record AnnouncementListResponse(
+        List<AnnouncementResponse> announcements,
+        long totalCount,
+        int page,
+        int pageSize,
+        int totalPages
+) {
+    public static AnnouncementListResponse of(List<AnnouncementResponse> announcements, long totalCount,
+                                               int page, int pageSize, int totalPages) {
+        return new AnnouncementListResponse(announcements, totalCount, page, pageSize, totalPages);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/AnnouncementResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/AnnouncementResponse.java
@@ -1,0 +1,51 @@
+package com.mzc.lp.domain.course.dto.response;
+
+import com.mzc.lp.domain.course.entity.CourseAnnouncement;
+import com.mzc.lp.domain.user.entity.User;
+
+import java.time.Instant;
+
+/**
+ * 공지사항 응답 DTO
+ */
+public record AnnouncementResponse(
+        Long id,
+        Long courseId,
+        Long courseTimeId,
+        String title,
+        String content,
+        Boolean isImportant,
+        Integer viewCount,
+        AuthorInfo author,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static AnnouncementResponse from(CourseAnnouncement announcement, User author) {
+        return new AnnouncementResponse(
+                announcement.getId(),
+                announcement.getCourseId(),
+                announcement.getCourseTimeId(),
+                announcement.getTitle(),
+                announcement.getContent(),
+                announcement.getIsImportant(),
+                announcement.getViewCount(),
+                author != null ? AuthorInfo.from(author) : null,
+                announcement.getCreatedAt(),
+                announcement.getUpdatedAt()
+        );
+    }
+
+    public record AuthorInfo(
+            Long id,
+            String name,
+            String profileImageUrl
+    ) {
+        public static AuthorInfo from(User user) {
+            return new AuthorInfo(
+                    user.getId(),
+                    user.getName(),
+                    user.getProfileImageUrl()
+            );
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/entity/CourseAnnouncement.java
+++ b/src/main/java/com/mzc/lp/domain/course/entity/CourseAnnouncement.java
@@ -1,0 +1,127 @@
+package com.mzc.lp.domain.course.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 코스 공지사항 엔티티
+ * 강사/운영자가 특정 코스 수강생에게 공지사항을 전달
+ */
+@Entity
+@Table(name = "course_announcements",
+        indexes = {
+                @Index(name = "idx_announcement_course", columnList = "course_id"),
+                @Index(name = "idx_announcement_course_time", columnList = "course_time_id"),
+                @Index(name = "idx_announcement_author", columnList = "author_id"),
+                @Index(name = "idx_announcement_created", columnList = "created_at")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CourseAnnouncement extends TenantEntity {
+
+    /**
+     * 코스 ID (코스 전체 공지)
+     */
+    @Column(name = "course_id")
+    private Long courseId;
+
+    /**
+     * 차수 ID (차수별 공지, null이면 코스 전체 공지)
+     */
+    @Column(name = "course_time_id")
+    private Long courseTimeId;
+
+    /**
+     * 작성자 ID
+     */
+    @Column(name = "author_id", nullable = false)
+    private Long authorId;
+
+    /**
+     * 공지 제목
+     */
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    /**
+     * 공지 내용
+     */
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    /**
+     * 중요 공지 여부 (상단 고정)
+     */
+    @Column(name = "is_important", nullable = false)
+    private Boolean isImportant = false;
+
+    /**
+     * 조회수
+     */
+    @Column(name = "view_count", nullable = false)
+    private Integer viewCount = 0;
+
+    /**
+     * 코스 전체 공지 생성
+     */
+    public static CourseAnnouncement createForCourse(Long courseId, Long authorId, String title, String content, Boolean isImportant) {
+        CourseAnnouncement announcement = new CourseAnnouncement();
+        announcement.courseId = courseId;
+        announcement.courseTimeId = null;
+        announcement.authorId = authorId;
+        announcement.title = title;
+        announcement.content = content;
+        announcement.isImportant = isImportant != null ? isImportant : false;
+        announcement.viewCount = 0;
+        return announcement;
+    }
+
+    /**
+     * 차수별 공지 생성
+     */
+    public static CourseAnnouncement createForCourseTime(Long courseId, Long courseTimeId, Long authorId,
+                                                          String title, String content, Boolean isImportant) {
+        CourseAnnouncement announcement = createForCourse(courseId, authorId, title, content, isImportant);
+        announcement.courseTimeId = courseTimeId;
+        return announcement;
+    }
+
+    /**
+     * 공지사항 수정
+     */
+    public void update(String title, String content, Boolean isImportant) {
+        if (title != null && !title.isBlank()) {
+            this.title = title;
+        }
+        if (content != null) {
+            this.content = content;
+        }
+        if (isImportant != null) {
+            this.isImportant = isImportant;
+        }
+    }
+
+    /**
+     * 조회수 증가
+     */
+    public void incrementViewCount() {
+        this.viewCount++;
+    }
+
+    /**
+     * 중요 공지로 설정
+     */
+    public void markAsImportant() {
+        this.isImportant = true;
+    }
+
+    /**
+     * 일반 공지로 변경
+     */
+    public void unmarkAsImportant() {
+        this.isImportant = false;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/exception/AnnouncementNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/course/exception/AnnouncementNotFoundException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.course.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class AnnouncementNotFoundException extends BusinessException {
+
+    public AnnouncementNotFoundException() {
+        super(ErrorCode.CM_ANNOUNCEMENT_NOT_FOUND);
+    }
+
+    public AnnouncementNotFoundException(Long announcementId) {
+        super(ErrorCode.CM_ANNOUNCEMENT_NOT_FOUND, "Announcement not found: " + announcementId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/exception/NotAnnouncementAuthorException.java
+++ b/src/main/java/com/mzc/lp/domain/course/exception/NotAnnouncementAuthorException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.course.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class NotAnnouncementAuthorException extends BusinessException {
+
+    public NotAnnouncementAuthorException() {
+        super(ErrorCode.CM_NOT_ANNOUNCEMENT_AUTHOR);
+    }
+
+    public NotAnnouncementAuthorException(Long announcementId) {
+        super(ErrorCode.CM_NOT_ANNOUNCEMENT_AUTHOR, "Not authorized to modify announcement: " + announcementId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/repository/CourseAnnouncementRepository.java
+++ b/src/main/java/com/mzc/lp/domain/course/repository/CourseAnnouncementRepository.java
@@ -1,0 +1,94 @@
+package com.mzc.lp.domain.course.repository;
+
+import com.mzc.lp.domain.course.entity.CourseAnnouncement;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CourseAnnouncementRepository extends JpaRepository<CourseAnnouncement, Long> {
+
+    /**
+     * 코스 전체 공지 목록 조회 (중요 공지 우선, 최신순)
+     */
+    @Query("SELECT a FROM CourseAnnouncement a WHERE a.courseId = :courseId AND a.tenantId = :tenantId " +
+            "AND a.courseTimeId IS NULL " +
+            "ORDER BY a.isImportant DESC, a.createdAt DESC")
+    Page<CourseAnnouncement> findByCourseId(
+            @Param("courseId") Long courseId,
+            @Param("tenantId") Long tenantId,
+            Pageable pageable
+    );
+
+    /**
+     * 차수별 공지 목록 조회 (중요 공지 우선, 최신순)
+     */
+    @Query("SELECT a FROM CourseAnnouncement a WHERE a.courseTimeId = :courseTimeId AND a.tenantId = :tenantId " +
+            "ORDER BY a.isImportant DESC, a.createdAt DESC")
+    Page<CourseAnnouncement> findByCourseTimeId(
+            @Param("courseTimeId") Long courseTimeId,
+            @Param("tenantId") Long tenantId,
+            Pageable pageable
+    );
+
+    /**
+     * 코스 + 차수 공지 통합 조회 (코스 공지 + 차수 공지 모두)
+     */
+    @Query("SELECT a FROM CourseAnnouncement a WHERE a.tenantId = :tenantId " +
+            "AND (a.courseId = :courseId AND a.courseTimeId IS NULL) " +
+            "OR (a.courseTimeId = :courseTimeId) " +
+            "ORDER BY a.isImportant DESC, a.createdAt DESC")
+    Page<CourseAnnouncement> findByCourseIdOrCourseTimeId(
+            @Param("courseId") Long courseId,
+            @Param("courseTimeId") Long courseTimeId,
+            @Param("tenantId") Long tenantId,
+            Pageable pageable
+    );
+
+    /**
+     * 공지사항 단건 조회
+     */
+    Optional<CourseAnnouncement> findByIdAndTenantId(Long id, Long tenantId);
+
+    /**
+     * 코스별 공지 단건 조회
+     */
+    @Query("SELECT a FROM CourseAnnouncement a WHERE a.id = :id AND a.courseId = :courseId AND a.tenantId = :tenantId")
+    Optional<CourseAnnouncement> findByIdAndCourseIdAndTenantId(
+            @Param("id") Long id,
+            @Param("courseId") Long courseId,
+            @Param("tenantId") Long tenantId
+    );
+
+    /**
+     * 차수별 공지 단건 조회
+     */
+    @Query("SELECT a FROM CourseAnnouncement a WHERE a.id = :id AND a.courseTimeId = :courseTimeId AND a.tenantId = :tenantId")
+    Optional<CourseAnnouncement> findByIdAndCourseTimeIdAndTenantId(
+            @Param("id") Long id,
+            @Param("courseTimeId") Long courseTimeId,
+            @Param("tenantId") Long tenantId
+    );
+
+    /**
+     * 조회수 증가
+     */
+    @Modifying
+    @Query("UPDATE CourseAnnouncement a SET a.viewCount = a.viewCount + 1 WHERE a.id = :id")
+    void incrementViewCount(@Param("id") Long id);
+
+    /**
+     * 코스 전체 공지 개수
+     */
+    @Query("SELECT COUNT(a) FROM CourseAnnouncement a WHERE a.courseId = :courseId AND a.tenantId = :tenantId AND a.courseTimeId IS NULL")
+    long countByCourseId(@Param("courseId") Long courseId, @Param("tenantId") Long tenantId);
+
+    /**
+     * 차수별 공지 개수
+     */
+    long countByCourseTimeIdAndTenantId(Long courseTimeId, Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseAnnouncementService.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseAnnouncementService.java
@@ -1,0 +1,45 @@
+package com.mzc.lp.domain.course.service;
+
+import com.mzc.lp.domain.course.dto.request.CreateAnnouncementRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateAnnouncementRequest;
+import com.mzc.lp.domain.course.dto.response.AnnouncementListResponse;
+import com.mzc.lp.domain.course.dto.response.AnnouncementResponse;
+
+public interface CourseAnnouncementService {
+
+    /**
+     * 코스 공지 작성
+     */
+    AnnouncementResponse createAnnouncement(Long courseId, Long authorId, CreateAnnouncementRequest request);
+
+    /**
+     * 차수별 공지 작성
+     */
+    AnnouncementResponse createAnnouncementForCourseTime(Long courseId, Long courseTimeId, Long authorId,
+                                                          CreateAnnouncementRequest request);
+
+    /**
+     * 코스 공지 목록 조회
+     */
+    AnnouncementListResponse getAnnouncementsByCourse(Long courseId, int page, int pageSize);
+
+    /**
+     * 차수별 공지 목록 조회
+     */
+    AnnouncementListResponse getAnnouncementsByCourseTime(Long courseTimeId, int page, int pageSize);
+
+    /**
+     * 공지 상세 조회
+     */
+    AnnouncementResponse getAnnouncement(Long announcementId);
+
+    /**
+     * 공지 수정
+     */
+    AnnouncementResponse updateAnnouncement(Long announcementId, Long userId, UpdateAnnouncementRequest request, boolean isAdmin);
+
+    /**
+     * 공지 삭제
+     */
+    void deleteAnnouncement(Long announcementId, Long userId, boolean isAdmin);
+}

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseAnnouncementServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseAnnouncementServiceImpl.java
@@ -1,0 +1,173 @@
+package com.mzc.lp.domain.course.service;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.domain.course.dto.request.CreateAnnouncementRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateAnnouncementRequest;
+import com.mzc.lp.domain.course.dto.response.AnnouncementListResponse;
+import com.mzc.lp.domain.course.dto.response.AnnouncementResponse;
+import com.mzc.lp.domain.course.entity.CourseAnnouncement;
+import com.mzc.lp.domain.course.exception.AnnouncementNotFoundException;
+import com.mzc.lp.domain.course.exception.NotAnnouncementAuthorException;
+import com.mzc.lp.domain.course.repository.CourseAnnouncementRepository;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class CourseAnnouncementServiceImpl implements CourseAnnouncementService {
+
+    private final CourseAnnouncementRepository announcementRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public AnnouncementResponse createAnnouncement(Long courseId, Long authorId, CreateAnnouncementRequest request) {
+        CourseAnnouncement announcement = CourseAnnouncement.createForCourse(
+                courseId,
+                authorId,
+                request.title(),
+                request.content(),
+                request.isImportant()
+        );
+
+        CourseAnnouncement saved = announcementRepository.save(announcement);
+        User author = userRepository.findById(authorId).orElse(null);
+
+        return AnnouncementResponse.from(saved, author);
+    }
+
+    @Override
+    @Transactional
+    public AnnouncementResponse createAnnouncementForCourseTime(Long courseId, Long courseTimeId, Long authorId,
+                                                                 CreateAnnouncementRequest request) {
+        CourseAnnouncement announcement = CourseAnnouncement.createForCourseTime(
+                courseId,
+                courseTimeId,
+                authorId,
+                request.title(),
+                request.content(),
+                request.isImportant()
+        );
+
+        CourseAnnouncement saved = announcementRepository.save(announcement);
+        User author = userRepository.findById(authorId).orElse(null);
+
+        return AnnouncementResponse.from(saved, author);
+    }
+
+    @Override
+    public AnnouncementListResponse getAnnouncementsByCourse(Long courseId, int page, int pageSize) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        Pageable pageable = PageRequest.of(page, pageSize);
+
+        Page<CourseAnnouncement> announcementPage = announcementRepository.findByCourseId(courseId, tenantId, pageable);
+
+        return toListResponse(announcementPage, page, pageSize);
+    }
+
+    @Override
+    public AnnouncementListResponse getAnnouncementsByCourseTime(Long courseTimeId, int page, int pageSize) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        Pageable pageable = PageRequest.of(page, pageSize);
+
+        Page<CourseAnnouncement> announcementPage = announcementRepository.findByCourseTimeId(courseTimeId, tenantId, pageable);
+
+        return toListResponse(announcementPage, page, pageSize);
+    }
+
+    @Override
+    @Transactional
+    public AnnouncementResponse getAnnouncement(Long announcementId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        CourseAnnouncement announcement = announcementRepository.findByIdAndTenantId(announcementId, tenantId)
+                .orElseThrow(() -> new AnnouncementNotFoundException(announcementId));
+
+        // 조회수 증가
+        announcementRepository.incrementViewCount(announcementId);
+        announcement.incrementViewCount();
+
+        User author = userRepository.findById(announcement.getAuthorId()).orElse(null);
+
+        return AnnouncementResponse.from(announcement, author);
+    }
+
+    @Override
+    @Transactional
+    public AnnouncementResponse updateAnnouncement(Long announcementId, Long userId, UpdateAnnouncementRequest request,
+                                                    boolean isAdmin) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        CourseAnnouncement announcement = announcementRepository.findByIdAndTenantId(announcementId, tenantId)
+                .orElseThrow(() -> new AnnouncementNotFoundException(announcementId));
+
+        // 권한 검증: 작성자이거나 관리자
+        if (!isAdmin && !announcement.getAuthorId().equals(userId)) {
+            throw new NotAnnouncementAuthorException(announcementId);
+        }
+
+        announcement.update(request.title(), request.content(), request.isImportant());
+
+        User author = userRepository.findById(announcement.getAuthorId()).orElse(null);
+
+        return AnnouncementResponse.from(announcement, author);
+    }
+
+    @Override
+    @Transactional
+    public void deleteAnnouncement(Long announcementId, Long userId, boolean isAdmin) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        CourseAnnouncement announcement = announcementRepository.findByIdAndTenantId(announcementId, tenantId)
+                .orElseThrow(() -> new AnnouncementNotFoundException(announcementId));
+
+        // 권한 검증: 작성자이거나 관리자
+        if (!isAdmin && !announcement.getAuthorId().equals(userId)) {
+            throw new NotAnnouncementAuthorException(announcementId);
+        }
+
+        announcementRepository.delete(announcement);
+    }
+
+    private AnnouncementListResponse toListResponse(Page<CourseAnnouncement> announcementPage, int page, int pageSize) {
+        List<CourseAnnouncement> announcements = announcementPage.getContent();
+
+        if (announcements.isEmpty()) {
+            return AnnouncementListResponse.of(List.of(), 0, page, pageSize, 0);
+        }
+
+        // 작성자 벌크 조회
+        Set<Long> authorIds = announcements.stream()
+                .map(CourseAnnouncement::getAuthorId)
+                .collect(Collectors.toSet());
+        Map<Long, User> authorMap = userRepository.findAllById(authorIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        List<AnnouncementResponse> responses = announcements.stream()
+                .map(a -> AnnouncementResponse.from(a, authorMap.get(a.getAuthorId())))
+                .toList();
+
+        return AnnouncementListResponse.of(
+                responses,
+                announcementPage.getTotalElements(),
+                page,
+                pageSize,
+                announcementPage.getTotalPages()
+        );
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/course/service/CourseAnnouncementServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/service/CourseAnnouncementServiceTest.java
@@ -1,0 +1,233 @@
+package com.mzc.lp.domain.course.service;
+
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.course.dto.request.CreateAnnouncementRequest;
+import com.mzc.lp.domain.course.dto.request.UpdateAnnouncementRequest;
+import com.mzc.lp.domain.course.dto.response.AnnouncementListResponse;
+import com.mzc.lp.domain.course.dto.response.AnnouncementResponse;
+import com.mzc.lp.domain.course.entity.CourseAnnouncement;
+import com.mzc.lp.domain.course.exception.AnnouncementNotFoundException;
+import com.mzc.lp.domain.course.exception.NotAnnouncementAuthorException;
+import com.mzc.lp.domain.course.repository.CourseAnnouncementRepository;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CourseAnnouncementService 테스트")
+class CourseAnnouncementServiceTest extends TenantTestSupport {
+
+    @InjectMocks
+    private CourseAnnouncementServiceImpl announcementService;
+
+    @Mock
+    private CourseAnnouncementRepository announcementRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private CourseAnnouncement createTestAnnouncement(Long id, Long courseId, Long authorId, boolean isImportant) {
+        CourseAnnouncement announcement = CourseAnnouncement.createForCourse(
+                courseId, authorId, "테스트 공지", "테스트 내용", isImportant);
+        setId(announcement, id);
+        return announcement;
+    }
+
+    private User createTestUser(Long id, String name) {
+        User user = User.create("test" + id + "@test.com", name, "encodedPassword");
+        setId(user, id);
+        return user;
+    }
+
+    private void setId(Object entity, Long id) {
+        try {
+            var idField = entity.getClass().getSuperclass().getSuperclass().getSuperclass().getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(entity, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Nested
+    @DisplayName("createAnnouncement - 코스 공지 작성")
+    class CreateAnnouncement {
+
+        @Test
+        @DisplayName("성공 - 코스 공지 작성")
+        void createAnnouncement_success() {
+            // given
+            Long courseId = 1L;
+            Long authorId = 100L;
+            CreateAnnouncementRequest request = new CreateAnnouncementRequest("테스트 공지", "테스트 내용", true);
+
+            CourseAnnouncement saved = createTestAnnouncement(1L, courseId, authorId, true);
+            given(announcementRepository.save(any(CourseAnnouncement.class))).willReturn(saved);
+            given(userRepository.findById(authorId)).willReturn(Optional.of(createTestUser(authorId, "작성자")));
+
+            // when
+            AnnouncementResponse response = announcementService.createAnnouncement(courseId, authorId, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.courseId()).isEqualTo(courseId);
+            assertThat(response.isImportant()).isTrue();
+            verify(announcementRepository).save(any(CourseAnnouncement.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("getAnnouncementsByCourse - 코스 공지 목록 조회")
+    class GetAnnouncementsByCourse {
+
+        @Test
+        @DisplayName("성공 - 코스 공지 목록 조회")
+        void getAnnouncementsByCourse_success() {
+            // given
+            Long courseId = 1L;
+            List<CourseAnnouncement> announcements = List.of(
+                    createTestAnnouncement(1L, courseId, 100L, true),
+                    createTestAnnouncement(2L, courseId, 100L, false)
+            );
+            Page<CourseAnnouncement> page = new PageImpl<>(announcements);
+
+            given(announcementRepository.findByCourseId(eq(courseId), eq(DEFAULT_TENANT_ID), any(Pageable.class)))
+                    .willReturn(page);
+            given(userRepository.findAllById(anySet()))
+                    .willReturn(List.of(createTestUser(100L, "작성자")));
+
+            // when
+            AnnouncementListResponse response = announcementService.getAnnouncementsByCourse(courseId, 0, 20);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.announcements()).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateAnnouncement - 공지 수정")
+    class UpdateAnnouncement {
+
+        @Test
+        @DisplayName("성공 - 작성자가 공지 수정")
+        void updateAnnouncement_success() {
+            // given
+            Long announcementId = 1L;
+            Long authorId = 100L;
+            CourseAnnouncement announcement = createTestAnnouncement(announcementId, 1L, authorId, false);
+
+            given(announcementRepository.findByIdAndTenantId(announcementId, DEFAULT_TENANT_ID))
+                    .willReturn(Optional.of(announcement));
+            given(userRepository.findById(authorId)).willReturn(Optional.of(createTestUser(authorId, "작성자")));
+
+            UpdateAnnouncementRequest request = new UpdateAnnouncementRequest("수정된 제목", "수정된 내용", true);
+
+            // when
+            AnnouncementResponse response = announcementService.updateAnnouncement(announcementId, authorId, request, false);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.title()).isEqualTo("수정된 제목");
+            assertThat(response.isImportant()).isTrue();
+        }
+
+        @Test
+        @DisplayName("실패 - 작성자가 아닌 경우")
+        void updateAnnouncement_fail_notAuthor() {
+            // given
+            Long announcementId = 1L;
+            Long authorId = 100L;
+            Long anotherUserId = 200L;
+            CourseAnnouncement announcement = createTestAnnouncement(announcementId, 1L, authorId, false);
+
+            given(announcementRepository.findByIdAndTenantId(announcementId, DEFAULT_TENANT_ID))
+                    .willReturn(Optional.of(announcement));
+
+            UpdateAnnouncementRequest request = new UpdateAnnouncementRequest("수정된 제목", null, null);
+
+            // when & then
+            assertThatThrownBy(() -> announcementService.updateAnnouncement(announcementId, anotherUserId, request, false))
+                    .isInstanceOf(NotAnnouncementAuthorException.class);
+        }
+
+        @Test
+        @DisplayName("성공 - 관리자가 다른 사람 공지 수정")
+        void updateAnnouncement_success_admin() {
+            // given
+            Long announcementId = 1L;
+            Long authorId = 100L;
+            Long adminId = 1L;
+            CourseAnnouncement announcement = createTestAnnouncement(announcementId, 1L, authorId, false);
+
+            given(announcementRepository.findByIdAndTenantId(announcementId, DEFAULT_TENANT_ID))
+                    .willReturn(Optional.of(announcement));
+            given(userRepository.findById(authorId)).willReturn(Optional.of(createTestUser(authorId, "작성자")));
+
+            UpdateAnnouncementRequest request = new UpdateAnnouncementRequest("관리자 수정", null, null);
+
+            // when
+            AnnouncementResponse response = announcementService.updateAnnouncement(announcementId, adminId, request, true);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.title()).isEqualTo("관리자 수정");
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteAnnouncement - 공지 삭제")
+    class DeleteAnnouncement {
+
+        @Test
+        @DisplayName("성공 - 작성자가 공지 삭제")
+        void deleteAnnouncement_success() {
+            // given
+            Long announcementId = 1L;
+            Long authorId = 100L;
+            CourseAnnouncement announcement = createTestAnnouncement(announcementId, 1L, authorId, false);
+
+            given(announcementRepository.findByIdAndTenantId(announcementId, DEFAULT_TENANT_ID))
+                    .willReturn(Optional.of(announcement));
+
+            // when
+            announcementService.deleteAnnouncement(announcementId, authorId, false);
+
+            // then
+            verify(announcementRepository).delete(announcement);
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 공지")
+        void deleteAnnouncement_fail_notFound() {
+            // given
+            Long announcementId = 999L;
+            Long userId = 100L;
+
+            given(announcementRepository.findByIdAndTenantId(announcementId, DEFAULT_TENANT_ID))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> announcementService.deleteAnnouncement(announcementId, userId, false))
+                    .isInstanceOf(AnnouncementNotFoundException.class);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

강사/운영자가 코스 수강생에게 공지사항을 전달할 수 있는 기능 추가

## Related Issue

- Closes #315

## Changes

- CourseAnnouncement 엔티티 생성 (코스/차수별 공지 지원)
- 코스 공지 API 구현 (/api/courses/{courseId}/announcements)
- 차수별 공지 API 구현 (/api/times/{timeId}/announcements)
- 중요 공지 상단 고정 기능 (isImportant)
- 작성자/관리자 권한 검증 로직
- 공지사항 서비스 테스트 작성

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 코스 전체 공지와 차수별 공지 모두 지원
- 중요 공지는 목록 상단에 고정 표시
- INSTRUCTOR, OPERATOR, TENANT_ADMIN 권한만 작성/수정/삭제 가능