### PR TITLE
Fix/navigation deadlock

### DIFF
--- a/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
@@ -63,7 +63,10 @@ public class TenantSettingsController {
     @Operation(summary = "현재 테넌트 브랜딩 조회", description = "로그인한 사용자의 테넌트 브랜딩 정보를 조회합니다")
     @GetMapping("/branding")
     public ResponseEntity<ApiResponse<PublicBrandingResponse>> getBranding() {
-        Long tenantId = TenantContext.getCurrentTenantId();
+        Long tenantId = TenantContext.getCurrentTenantIdOrNull();
+        if (tenantId == null) {
+            return ResponseEntity.ok(ApiResponse.success(PublicBrandingResponse.defaultBranding()));
+        }
         PublicBrandingResponse response = tenantSettingsService.getBrandingByTenantId(tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/mzc/lp/domain/tenant/repository/TenantRepository.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/repository/TenantRepository.java
@@ -2,9 +2,13 @@ package com.mzc.lp.domain.tenant.repository;
 
 import com.mzc.lp.domain.tenant.constant.TenantStatus;
 import com.mzc.lp.domain.tenant.entity.Tenant;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -28,4 +32,11 @@ public interface TenantRepository extends JpaRepository<Tenant, Long> {
 
     Page<Tenant> findByNameContainingIgnoreCaseOrCodeContainingIgnoreCase(
             String name, String code, Pageable pageable);
+
+    /**
+     * 비관적 락으로 테넌트 조회 (동시성 제어용)
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT t FROM Tenant t WHERE t.id = :tenantId")
+    Optional<Tenant> findByIdWithLock(@Param("tenantId") Long tenantId);
 }


### PR DESCRIPTION
## Summary

네비게이션 항목 초기화 시 동시 요청으로 인한 데드락 문제를 해결합니다.

## Related Issue

- N/A (운영 중 발견된 버그)

## Changes

- `TenantRepository`에 비관적 락 메서드 추가 (`findByIdWithLock`)
- `initializeDefaultNavigationItems`에서 동시성 제어 적용
  - 락 획득 후 이미 초기화 여부 재확인 (Double-checked locking)
  - `DataIntegrityViolationException` catch로 동시성 예외 처리
- `getEnabledNavigationItems`에서 초기화 실패 시에도 조회 가능하도록 예외 처리

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### 문제 상황
여러 동시 요청이 같은 테넌트의 네비게이션 항목을 초기화하려 할 때 MySQL 데드락 발생:
```
Deadlock found when trying to get lock; try restarting transaction
at TenantSettingsServiceImpl.initializeDefaultNavigationItems
```

### 해결 방법
1. 비관적 락(`SELECT ... FOR UPDATE`)으로 테넌트 행 락 획득
2. 락 획득 후 Double-checked locking 패턴 적용
3. 예외 발생 시에도 graceful하게 기존 데이터 조회