### PR TITLE
feat: 코스 커뮤니티 댓글 API 추가

### DIFF
--- a/src/main/java/com/mzc/lp/domain/community/controller/CourseCommunityCommentController.java
+++ b/src/main/java/com/mzc/lp/domain/community/controller/CourseCommunityCommentController.java
@@ -1,0 +1,123 @@
+package com.mzc.lp.domain.community.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.community.dto.request.CreateCommentRequest;
+import com.mzc.lp.domain.community.dto.request.UpdateCommentRequest;
+import com.mzc.lp.domain.community.dto.response.CommentListResponse;
+import com.mzc.lp.domain.community.dto.response.CommentResponse;
+import com.mzc.lp.domain.community.service.CommunityCommentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 코스 커뮤니티 댓글 API
+ * /api/times/{timeId}/community/posts/{postId}/comments
+ */
+@RestController
+@RequestMapping("/api/times/{timeId}/community/posts/{postId}/comments")
+@RequiredArgsConstructor
+@Validated
+public class CourseCommunityCommentController {
+
+    private final CommunityCommentService commentService;
+
+    /**
+     * 댓글 목록 조회
+     */
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<CommentListResponse>> getComments(
+            @PathVariable Long timeId,
+            @PathVariable Long postId,
+            @RequestParam(required = false, defaultValue = "0") int page,
+            @RequestParam(required = false, defaultValue = "20") int pageSize,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Long userId = principal != null ? principal.id() : null;
+        CommentListResponse response = commentService.getComments(postId, page, pageSize, userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 댓글 작성
+     */
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<CommentResponse>> createComment(
+            @PathVariable Long timeId,
+            @PathVariable Long postId,
+            @Valid @RequestBody CreateCommentRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CommentResponse response = commentService.createComment(principal.id(), postId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 댓글 수정
+     */
+    @PatchMapping("/{commentId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<CommentResponse>> updateComment(
+            @PathVariable Long timeId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @Valid @RequestBody UpdateCommentRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CommentResponse response = commentService.updateComment(principal.id(), postId, commentId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 댓글 삭제
+     */
+    @DeleteMapping("/{commentId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable Long timeId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        commentService.deleteComment(principal.id(), postId, commentId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 댓글 좋아요
+     */
+    @PostMapping("/{commentId}/like")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> likeComment(
+            @PathVariable Long timeId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        commentService.likeComment(principal.id(), postId, commentId);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 댓글 좋아요 취소
+     */
+    @DeleteMapping("/{commentId}/like")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> unlikeComment(
+            @PathVariable Long timeId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        commentService.unlikeComment(principal.id(), postId, commentId);
+        return ResponseEntity.ok().build();
+    }
+}


### PR DESCRIPTION
## Summary

코스 커뮤니티 댓글 API를 구현했습니다. 기존 전역 커뮤니티 댓글과 달리 차수(CourseTime) 기반 댓글 API를 제공합니다.

## Related Issue

- Related to #315

## Changes

- CourseCommunityCommentController 생성
- `/api/times/{timeId}/community/posts/{postId}/comments` 엔드포인트 구현
- 댓글 조회, 작성, 수정, 삭제 기능
- 댓글 좋아요/좋아요 취소 기능
- 기존 CommunityCommentService 재사용으로 중복 코드 제거

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/times/{timeId}/community/posts/{postId}/comments` | 댓글 목록 조회 (페이징) |
| POST | `/api/times/{timeId}/community/posts/{postId}/comments` | 댓글 작성 |
| PATCH | `/api/times/{timeId}/community/posts/{postId}/comments/{commentId}` | 댓글 수정 |
| DELETE | `/api/times/{timeId}/community/posts/{postId}/comments/{commentId}` | 댓글 삭제 |
| POST | `/api/times/{timeId}/community/posts/{postId}/comments/{commentId}/like` | 댓글 좋아요 |
| DELETE | `/api/times/{timeId}/community/posts/{postId}/comments/{commentId}/like` | 좋아요 취소 |

## Additional Notes

- 인증 필수 (`@PreAuthorize("isAuthenticated()")`)
- 페이징 지원 (기본 20개)
- 대댓글 지원
- 프론트엔드 연동 테스트 완료