### PR TITLE
fix: 코스 커뮤니티 조회 권한 변경

### DIFF
--- a/src/main/java/com/mzc/lp/domain/community/service/CourseCommunityService.java
+++ b/src/main/java/com/mzc/lp/domain/community/service/CourseCommunityService.java
@@ -65,9 +65,6 @@ public class CourseCommunityService {
      */
     public PostListResponse getPosts(Long courseTimeId, String keyword, String category,
                                      String type, String sortBy, int page, int pageSize, Long userId) {
-        // 수강 검증
-        validateEnrollment(courseTimeId, userId);
-
         PostType postType = null;
         if (type != null && !type.equalsIgnoreCase("all")) {
             try {
@@ -130,9 +127,6 @@ public class CourseCommunityService {
      */
     @Transactional
     public PostDetailResponse getPost(Long courseTimeId, Long postId, Long userId) {
-        // 수강 검증
-        validateEnrollment(courseTimeId, userId);
-
         CommunityPost post = postRepository.findByIdAndCourseTimeId(postId, courseTimeId)
                 .orElseThrow(() -> new PostNotFoundException(postId));
 
@@ -287,9 +281,6 @@ public class CourseCommunityService {
      * 코스 커뮤니티 카테고리 목록 조회
      */
     public CategoryResponse getCategories(Long courseTimeId, Long userId) {
-        // 수강 검증
-        validateEnrollment(courseTimeId, userId);
-
         List<CategoryResponse.CategoryItem> categories = List.of(
                 CategoryResponse.CategoryItem.of("all", "전체", null,
                         postRepository.countByCourseTimeId(courseTimeId), "grid"),

--- a/src/test/java/com/mzc/lp/domain/community/service/CourseCommunityServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/community/service/CourseCommunityServiceTest.java
@@ -114,15 +114,12 @@ class CourseCommunityServiceTest extends TenantTestSupport {
     class GetPosts {
 
         @Test
-        @DisplayName("성공 - 수강생이 게시글 목록 조회")
+        @DisplayName("성공 - 게시글 목록 조회")
         void getPosts_success() {
             // given
             Long courseTimeId = 1L;
             Long userId = 100L;
             int page = 0, pageSize = 20;
-
-            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, TENANT_ID))
-                    .willReturn(true);
 
             List<CommunityPost> posts = List.of(
                     createTestPost(1L, courseTimeId, userId),
@@ -150,22 +147,6 @@ class CourseCommunityServiceTest extends TenantTestSupport {
             // then
             assertThat(response).isNotNull();
             assertThat(response.posts()).hasSize(2);
-        }
-
-        @Test
-        @DisplayName("실패 - 수강생이 아닌 경우")
-        void getPosts_fail_notEnrolled() {
-            // given
-            Long courseTimeId = 1L;
-            Long userId = 100L;
-
-            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, TENANT_ID))
-                    .willReturn(false);
-
-            // when & then
-            assertThatThrownBy(() -> courseCommunityService.getPosts(
-                    courseTimeId, null, null, null, "latest", 0, 20, userId))
-                    .isInstanceOf(NotEnrolledException.class);
         }
     }
 
@@ -237,15 +218,12 @@ class CourseCommunityServiceTest extends TenantTestSupport {
     class GetPost {
 
         @Test
-        @DisplayName("성공 - 수강생이 게시글 상세 조회")
+        @DisplayName("성공 - 게시글 상세 조회")
         void getPost_success() {
             // given
             Long courseTimeId = 1L;
             Long postId = 1L;
             Long userId = 100L;
-
-            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, TENANT_ID))
-                    .willReturn(true);
 
             CommunityPost post = createTestPost(postId, courseTimeId, userId);
             given(postRepository.findByIdAndCourseTimeId(postId, courseTimeId))
@@ -277,8 +255,6 @@ class CourseCommunityServiceTest extends TenantTestSupport {
             Long postId = 999L;
             Long userId = 100L;
 
-            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, TENANT_ID))
-                    .willReturn(true);
             given(postRepository.findByIdAndCourseTimeId(postId, courseTimeId))
                     .willReturn(Optional.empty());
 
@@ -401,9 +377,6 @@ class CourseCommunityServiceTest extends TenantTestSupport {
             // given
             Long courseTimeId = 1L;
             Long userId = 100L;
-
-            given(enrollmentRepository.existsByUserIdAndCourseTimeIdAndTenantId(userId, courseTimeId, TENANT_ID))
-                    .willReturn(true);
 
             given(postRepository.countByCourseTimeId(courseTimeId)).willReturn(10L);
             given(postRepository.countByCourseTimeIdAndCategory(courseTimeId, "question")).willReturn(5L);


### PR DESCRIPTION
## Summary

코스 커뮤니티 조회 권한을 개선하여 수강하지 않은 강의의 커뮤니티도 조회할 수 있도록 변경했습니다.

## Changes

- CourseCommunityService의 조회 메서드에서 수강 여부 검증 제거
- `getPosts()`, `getPost()`, `getCategories()` 메서드를 모든 인증된 사용자에게 허용
- 작성/수정/삭제/좋아요는 수강생만 가능하도록 유지

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## 권한 변경 사항

| 작업 | 이전 | 변경 후 |
|------|------|---------|
| 게시글 목록 조회 | 수강생만 | 모든 인증 사용자 |
| 게시글 상세 조회 | 수강생만 | 모든 인증 사용자 |
| 카테고리 조회 | 수강생만 | 모든 인증 사용자 |
| 게시글 작성 | 수강생만 | 수강생만 (유지) |
| 게시글 수정 | 수강생만 | 수강생만 (유지) |
| 게시글 삭제 | 수강생만 | 수강생만 (유지) |
| 좋아요/취소 | 수강생만 | 수강생만 (유지) |

## Additional Notes

- 프론트엔드에서 `canWrite={isAlreadyEnrolled}`로 수강생만 글쓰기 버튼 표시
- 조회는 모두 허용하되 작성은 수강생만 가능한 구조로 개선