### PR TITLE
fix: 로드맵 수정/삭제 기능 이슈 해결

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -172,7 +172,8 @@ public enum ErrorCode {
     UNAUTHORIZED_ROADMAP_ACCESS(HttpStatus.FORBIDDEN, "RM003", "Not authorized to access this roadmap"),
     INVALID_PROGRAM_FOR_ROADMAP(HttpStatus.BAD_REQUEST, "RM004", "Invalid program for roadmap"),
     DUPLICATE_PROGRAM_IN_ROADMAP(HttpStatus.CONFLICT, "RM005", "Program already exists in roadmap"),
-    ROADMAP_HAS_ENROLLMENTS(HttpStatus.BAD_REQUEST, "RM006", "Cannot delete roadmap with enrollments");
+    ROADMAP_HAS_ENROLLMENTS(HttpStatus.BAD_REQUEST, "RM006", "Cannot delete roadmap with enrollments"),
+    DESTRUCTIVE_UPDATE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "RM007", "Destructive update not allowed for published roadmap with enrollments");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/mzc/lp/domain/roadmap/exception/DestructiveUpdateNotAllowedException.java
+++ b/src/main/java/com/mzc/lp/domain/roadmap/exception/DestructiveUpdateNotAllowedException.java
@@ -1,0 +1,12 @@
+package com.mzc.lp.domain.roadmap.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class DestructiveUpdateNotAllowedException extends BusinessException {
+
+    public DestructiveUpdateNotAllowedException(Long roadmapId) {
+        super(ErrorCode.DESTRUCTIVE_UPDATE_NOT_ALLOWED,
+            "수강생이 있는 공개된 로드맵은 프로그램 삭제 또는 순서 변경이 불가능합니다. ID: " + roadmapId);
+    }
+}


### PR DESCRIPTION
## Summary

Issue #325의 두 가지 버그를 해결하고, 수강생 보호를 위한 Safe vs Destructive Update 구분 기능을 추가로 구현했습니다.

- Bug Fix 1: PUBLISHED 로드맵 수정 불가 -> isModifiable 체크 제거
- Bug Fix 2: 로드맵 삭제 시 500 에러 -> RoadmapProgram 선 삭제 로직 추가
- New Feature: 수강생이 있는 PUBLISHED 로드맵의 파괴적 업데이트 차단

## Related Issue

- Closes #325

## Changes

### Safe vs Destructive 업데이트 구분

**Safe Updates (항상 허용):**
- 메타데이터 변경 (제목, 설명)
- 프로그램 추가 (append)
- DRAFT 상태의 모든 변경

**Destructive Updates (조건부 차단):**
- 프로그램 삭제 -> PUBLISHED + 수강생 있음 시 차단
- 프로그램 순서 변경 -> PUBLISHED + 수강생 있음 시 차단

### 구현 내용

- `RoadmapServiceImpl.isDestructiveUpdate()` 메서드 추가 - 파괴적 업데이트 감지 로직
- `RoadmapServiceImpl.updateRoadmap()` - 파괴적 업데이트 검증 추가
- `RoadmapServiceImpl.deleteRoadmap()` - RoadmapProgram 선 삭제로 외래키 제약 해결
- `DestructiveUpdateNotAllowedException` 예외 클래스 추가
- `DESTRUCTIVE_UPDATE_NOT_ALLOWED (RM007)` 에러 코드 추가

### 파일 변경 목록

**Modified:**
- `RoadmapServiceImpl.java` - Safe/Destructive 로직 구현
- `ErrorCode.java` - RM007 에러 코드 추가
- `RoadmapServiceTest.java` - 7개 테스트 추가

**Added:**
- `DestructiveUpdateNotAllowedException.java` - 새 예외 클래스

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [x] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Test Plan

### Unit Tests
- [x] 추가/수정된 단위 테스트가 통과합니다 (22/22 tests passed)
- [x] 테스트 커버리지가 적절합니다

**추가된 테스트 케이스:**
1. Safe Update: 메타데이터만 변경 (성공)
2. Safe Update: 프로그램 추가 (성공)
3. Destructive Update: 프로그램 삭제 + 수강생 있음 (차단)
4. Destructive Update: 순서 변경 + 수강생 있음 (차단)
5. Destructive Update: 프로그램 삭제 + 수강생 없음 (성공)
6. Destructive Update: DRAFT 상태 (성공)
7. PUBLISHED 상태 기본 수정 (성공)

### Integration Tests
- [x] 통합 테스트 시나리오를 확인했습니다
- [x] 예외 상황에 대한 테스트를 작성했습니다

### Manual Testing
- [x] PUBLISHED + 수강생 있음: 제목/설명 변경 -> 200 OK
- [x] PUBLISHED + 수강생 있음: 프로그램 추가 -> 200 OK
- [x] PUBLISHED + 수강생 있음: 프로그램 삭제 -> 400 RM007
- [x] PUBLISHED + 수강생 있음: 순서 변경 -> 400 RM007
- [x] PUBLISHED + 수강생 없음: 프로그램 삭제 -> 200 OK
- [x] DRAFT: 모든 변경 -> 200 OK
- [x] 로드맵 삭제 시 500 에러 발생하지 않음

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### API 동작 예시

**Safe Update: 프로그램 추가**
```http
PATCH /api/roadmaps/2
Content-Type: application/json

{
  "title": "수정된 제목",
  "programIds": [1, 2, 3],
  "status": "PUBLISHED"
}

Response: 200 OK
```

**Destructive Update: 순서 변경**
```http
PATCH /api/roadmaps/2
Content-Type: application/json

{
  "programIds": [2, 1]
}

Response: 400 Bad Request
{
  "code": "RM007",
  "message": "수강생이 있는 공개된 로드맵은 프로그램 삭제 또는 순서 변경이 불가능합니다."
}
```

### 리뷰 포인트

- `isDestructiveUpdate()` 로직: 프로그램 삭제 및 순서 변경 감지가 정확한지 확인
- 검증 조건: `PUBLISHED && enrolledStudents > 0` 조건이 적절한지 검토
- 예외 메시지: 사용자에게 명확한 안내를 제공하는지 확인

### 프론트엔드 연동 필요

프론트엔드에서 다음 작업이 필요합니다:
- RM007 에러 핸들링 추가
- 파괴적 업데이트 시도 시 사전 경고 표시
- 수강생 있는 PUBLISHED 로드맵: 삭제/드래그 UI 비활성화
- 변경사항 감지 로직 구현
