### PR TITLE
feat: Course 엔티티에 status 필드 추가

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     CM_NOT_REVIEW_OWNER(HttpStatus.FORBIDDEN, "CM014", "Not authorized to modify this review"),
     CM_ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CM015", "Announcement not found"),
     CM_NOT_ANNOUNCEMENT_AUTHOR(HttpStatus.FORBIDDEN, "CM016", "Not authorized to modify this announcement"),
+    CM_COURSE_INCOMPLETE(HttpStatus.BAD_REQUEST, "CM017", "Course is incomplete and cannot be published"),
 
     // Content (CMS)
     CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CT001", "Content not found"),

--- a/src/main/java/com/mzc/lp/domain/course/constant/CourseStatus.java
+++ b/src/main/java/com/mzc/lp/domain/course/constant/CourseStatus.java
@@ -1,0 +1,14 @@
+package com.mzc.lp.domain.course.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CourseStatus {
+
+    DRAFT("작성중"),
+    PUBLISHED("발행됨");
+
+    private final String description;
+}

--- a/src/main/java/com/mzc/lp/domain/course/controller/CourseController.java
+++ b/src/main/java/com/mzc/lp/domain/course/controller/CourseController.java
@@ -113,4 +113,32 @@ public class CourseController {
         courseService.deleteCourse(courseId, principal.id(), isTenantAdmin);
         return ResponseEntity.noContent().build();
     }
+
+    /**
+     * 강의 발행
+     * POST /api/courses/{courseId}/publish
+     */
+    @PostMapping("/{courseId:\\d+}/publish")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseResponse>> publishCourse(
+            @PathVariable @Positive Long courseId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseResponse response = courseService.publishCourse(courseId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 강의 발행 취소
+     * POST /api/courses/{courseId}/unpublish
+     */
+    @PostMapping("/{courseId:\\d+}/unpublish")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseResponse>> unpublishCourse(
+            @PathVariable @Positive Long courseId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseResponse response = courseService.unpublishCourse(courseId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 }

--- a/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateCourseRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateCourseRequest.java
@@ -1,6 +1,7 @@
 package com.mzc.lp.domain.course.dto.request;
 
 import com.mzc.lp.domain.course.constant.CourseLevel;
+import com.mzc.lp.domain.course.constant.CourseStatus;
 import com.mzc.lp.domain.course.constant.CourseType;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
@@ -31,7 +32,9 @@ public record UpdateCourseRequest(
 
         LocalDate endDate,
 
-        List<String> tags
+        List<String> tags,
+
+        CourseStatus status
 ) {
     public UpdateCourseRequest {
         if (title != null) {

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseDetailResponse.java
@@ -1,6 +1,7 @@
 package com.mzc.lp.domain.course.dto.response;
 
 import com.mzc.lp.domain.course.constant.CourseLevel;
+import com.mzc.lp.domain.course.constant.CourseStatus;
 import com.mzc.lp.domain.course.constant.CourseType;
 import com.mzc.lp.domain.course.entity.Course;
 
@@ -15,6 +16,7 @@ public record CourseDetailResponse(
         String thumbnailUrl,
         CourseLevel level,
         CourseType type,
+        CourseStatus status,
         Integer estimatedHours,
         Long categoryId,
         LocalDate startDate,
@@ -60,6 +62,7 @@ public record CourseDetailResponse(
                 course.getThumbnailUrl(),
                 course.getLevel(),
                 course.getType(),
+                course.getStatus(),
                 course.getEstimatedHours(),
                 course.getCategoryId(),
                 course.getStartDate(),

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseResponse.java
@@ -1,6 +1,7 @@
 package com.mzc.lp.domain.course.dto.response;
 
 import com.mzc.lp.domain.course.constant.CourseLevel;
+import com.mzc.lp.domain.course.constant.CourseStatus;
 import com.mzc.lp.domain.course.constant.CourseType;
 import com.mzc.lp.domain.course.entity.Course;
 
@@ -15,6 +16,7 @@ public record CourseResponse(
         String thumbnailUrl,
         CourseLevel level,
         CourseType type,
+        CourseStatus status,
         Integer estimatedHours,
         Long categoryId,
         LocalDate startDate,
@@ -51,6 +53,7 @@ public record CourseResponse(
                 course.getThumbnailUrl(),
                 course.getLevel(),
                 course.getType(),
+                course.getStatus(),
                 course.getEstimatedHours(),
                 course.getCategoryId(),
                 course.getStartDate(),

--- a/src/main/java/com/mzc/lp/domain/course/entity/Course.java
+++ b/src/main/java/com/mzc/lp/domain/course/entity/Course.java
@@ -3,6 +3,7 @@ package com.mzc.lp.domain.course.entity;
 import com.mzc.lp.common.constant.ValidationMessages;
 import com.mzc.lp.common.entity.TenantEntity;
 import com.mzc.lp.domain.course.constant.CourseLevel;
+import com.mzc.lp.domain.course.constant.CourseStatus;
 import com.mzc.lp.domain.course.constant.CourseType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -40,6 +41,10 @@ public class Course extends TenantEntity {
     @Column(length = 20)
     private CourseType type;
 
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private CourseStatus status = CourseStatus.DRAFT;
+
     @Column
     private Integer estimatedHours;
 
@@ -68,6 +73,7 @@ public class Course extends TenantEntity {
         Course course = new Course();
         course.title = title;
         course.createdBy = createdBy;
+        course.status = CourseStatus.DRAFT;
         return course;
     }
 
@@ -88,6 +94,7 @@ public class Course extends TenantEntity {
         course.endDate = endDate;
         course.tags = tags != null ? new ArrayList<>(tags) : new ArrayList<>();
         course.createdBy = createdBy;
+        course.status = CourseStatus.DRAFT;
         return course;
     }
 
@@ -149,6 +156,27 @@ public class Course extends TenantEntity {
         this.startDate = startDate;
         this.endDate = endDate;
         this.tags = tags != null ? new ArrayList<>(tags) : new ArrayList<>();
+    }
+
+    // ===== Status 관련 비즈니스 메서드 =====
+    public void publish() {
+        this.status = CourseStatus.PUBLISHED;
+    }
+
+    public void unpublish() {
+        this.status = CourseStatus.DRAFT;
+    }
+
+    public void updateStatus(CourseStatus status) {
+        this.status = status;
+    }
+
+    public boolean isDraft() {
+        return this.status == CourseStatus.DRAFT;
+    }
+
+    public boolean isPublished() {
+        return this.status == CourseStatus.PUBLISHED;
     }
 
     // ===== 연관관계 편의 메서드 =====

--- a/src/main/java/com/mzc/lp/domain/course/exception/CourseIncompleteException.java
+++ b/src/main/java/com/mzc/lp/domain/course/exception/CourseIncompleteException.java
@@ -1,0 +1,15 @@
+package com.mzc.lp.domain.course.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class CourseIncompleteException extends BusinessException {
+
+    public CourseIncompleteException() {
+        super(ErrorCode.CM_COURSE_INCOMPLETE);
+    }
+
+    public CourseIncompleteException(Long courseId) {
+        super(ErrorCode.CM_COURSE_INCOMPLETE, "완성되지 않은 강의는 발행할 수 없습니다. ID: " + courseId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseService.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseService.java
@@ -56,4 +56,19 @@ public interface CourseService {
      * @return 강의 목록 페이지
      */
     Page<CourseResponse> getMyCourses(Long creatorId, Pageable pageable);
+
+    /**
+     * 강의 발행
+     * @param courseId 강의 ID
+     * @return 발행된 강의 정보
+     * @throws com.mzc.lp.domain.course.exception.CourseIncompleteException 완성되지 않은 강의인 경우
+     */
+    CourseResponse publishCourse(Long courseId);
+
+    /**
+     * 강의 발행 취소
+     * @param courseId 강의 ID
+     * @return 발행 취소된 강의 정보
+     */
+    CourseResponse unpublishCourse(Long courseId);
 }

--- a/src/main/resources/migration/V20260107__add_course_status.sql
+++ b/src/main/resources/migration/V20260107__add_course_status.sql
@@ -1,0 +1,19 @@
+-- ============================================
+-- Course status 필드 추가 마이그레이션
+-- 적용 대상: cm_courses 테이블
+-- 날짜: 2026-01-07
+-- 이슈: #333
+-- ============================================
+
+-- 1. status 컬럼 추가
+-- Hibernate DDL Auto가 컬럼을 자동 생성하지만, 명시적 스크립트 보관
+ALTER TABLE cm_courses
+ADD COLUMN IF NOT EXISTS status VARCHAR(20) NOT NULL DEFAULT 'DRAFT';
+
+-- 2. 기존 데이터 마이그레이션
+-- 정책 결정: 모든 기존 강의를 DRAFT로 유지 (안전)
+UPDATE cm_courses SET status = 'DRAFT' WHERE status IS NULL;
+
+-- 3. 인덱스 추가 (status 필터링 성능 최적화)
+CREATE INDEX IF NOT EXISTS idx_course_status ON cm_courses(status);
+CREATE INDEX IF NOT EXISTS idx_course_tenant_status ON cm_courses(tenant_id, status);

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseControllerTest.java
@@ -646,6 +646,7 @@ class CourseControllerTest extends TenantTestSupport {
                     null,
                     null,
                     null,
+                    null,
                     null
             );
 
@@ -673,6 +674,7 @@ class CourseControllerTest extends TenantTestSupport {
             Course course = createTestCourse("원래 제목");
             UpdateCourseRequest request = new UpdateCourseRequest(
                     "수정된 제목만",
+                    null,
                     null,
                     null,
                     null,
@@ -711,6 +713,7 @@ class CourseControllerTest extends TenantTestSupport {
                     null,
                     null,
                     null,
+                    null,
                     null
             );
 
@@ -734,6 +737,7 @@ class CourseControllerTest extends TenantTestSupport {
             Course course = createTestCourse("테스트 강의");
             UpdateCourseRequest request = new UpdateCourseRequest(
                     "수정 시도",
+                    null,
                     null,
                     null,
                     null,


### PR DESCRIPTION
## Summary
- Course 엔티티에 `status` 필드 추가 (DRAFT/PUBLISHED)
- 사용자 의도(임시저장/발행)와 시스템 검증(isComplete)을 명확히 분리
- 발행 시 완성도(isComplete) 검증 로직 구현

## Changes
### 신규 파일
- `CourseStatus.java` - DRAFT, PUBLISHED enum
- `CourseIncompleteException.java` - 미완성 강의 발행 예외
- `V20260107__add_course_status.sql` - DB 마이그레이션 스크립트

### 수정 파일
- `ErrorCode.java` - CM017 에러코드 추가
- `Course.java` - status 필드 및 publish/unpublish 메서드
- `CourseResponse.java`, `CourseDetailResponse.java` - status 필드 추가
- `UpdateCourseRequest.java` - status 파라미터 추가
- `CourseService.java`, `CourseServiceImpl.java` - 발행 로직 구현
- `CourseController.java` - publish/unpublish 엔드포인트 추가

## New API Endpoints
- `POST /api/courses/{courseId}/publish` - 강의 발행
- `POST /api/courses/{courseId}/unpublish` - 강의 발행 취소

## Test plan
- [ ] 강의 생성 시 status가 DRAFT로 설정되는지 확인
- [ ] 완성된 강의(isComplete=true) 발행 성공 확인
- [ ] 미완성 강의 발행 시 CM017 에러 반환 확인
- [ ] 발행된 강의 unpublish 동작 확인

Closes #333