### PR TITLE
Feat/tenant feature settings

### DIFF
--- a/src/main/java/com/mzc/lp/domain/tenant/controller/PublicTenantController.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/controller/PublicTenantController.java
@@ -2,6 +2,9 @@ package com.mzc.lp.domain.tenant.controller;
 
 import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.domain.tenant.dto.response.PublicBrandingResponse;
+import com.mzc.lp.domain.tenant.dto.response.TenantCategoryResponse;
+import com.mzc.lp.domain.tenant.dto.response.TenantFeaturesResponse;
+import com.mzc.lp.domain.tenant.service.TenantCategoryService;
 import com.mzc.lp.domain.tenant.service.TenantSettingsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -9,6 +12,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * 공개 테넌트 API 컨트롤러
@@ -21,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 public class PublicTenantController {
 
     private final TenantSettingsService tenantSettingsService;
+    private final TenantCategoryService tenantCategoryService;
 
     @Operation(
         summary = "테넌트 브랜딩 정보 조회 (공개)",
@@ -37,6 +43,40 @@ public class PublicTenantController {
             @RequestParam(defaultValue = "subdomain") String type
     ) {
         PublicBrandingResponse response = tenantSettingsService.getPublicBranding(identifier, type);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(
+        summary = "테넌트 기능 설정 조회 (공개)",
+        description = "subdomain 또는 customDomain으로 테넌트의 기능 On/Off 설정을 조회합니다. " +
+                     "인증이 필요하지 않으며, 테넌트를 찾을 수 없으면 기본 설정을 반환합니다."
+    )
+    @GetMapping("/features")
+    public ResponseEntity<ApiResponse<TenantFeaturesResponse>> getPublicFeatures(
+            @Parameter(description = "테넌트 식별자 (subdomain 또는 customDomain)", required = true)
+            @RequestParam String identifier,
+
+            @Parameter(description = "식별자 타입 (subdomain 또는 customDomain)", example = "subdomain")
+            @RequestParam(defaultValue = "subdomain") String type
+    ) {
+        TenantFeaturesResponse response = tenantSettingsService.getPublicTenantFeatures(identifier, type);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(
+        summary = "테넌트 카테고리 조회 (공개)",
+        description = "subdomain 또는 customDomain으로 테넌트의 커스텀 카테고리를 조회합니다. " +
+                     "인증이 필요하지 않으며, 활성화된 카테고리만 반환합니다."
+    )
+    @GetMapping("/categories")
+    public ResponseEntity<ApiResponse<List<TenantCategoryResponse>>> getPublicCategories(
+            @Parameter(description = "테넌트 식별자 (subdomain 또는 customDomain)", required = true)
+            @RequestParam String identifier,
+
+            @Parameter(description = "식별자 타입 (subdomain 또는 customDomain)", example = "subdomain")
+            @RequestParam(defaultValue = "subdomain") String type
+    ) {
+        List<TenantCategoryResponse> response = tenantCategoryService.getPublicCategories(identifier, type);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/tenant/controller/TenantCategoryController.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/controller/TenantCategoryController.java
@@ -1,0 +1,92 @@
+package com.mzc.lp.domain.tenant.controller;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.domain.tenant.dto.request.TenantCategoryRequest;
+import com.mzc.lp.domain.tenant.dto.response.TenantCategoryResponse;
+import com.mzc.lp.domain.tenant.service.TenantCategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 테넌트 카테고리 컨트롤러
+ * TA(Tenant Admin)가 자신의 테넌트의 커스텀 카테고리를 관리
+ */
+@Tag(name = "Tenant Categories", description = "테넌트 커스텀 카테고리 관리 API")
+@RestController
+@RequestMapping("/api/tenant/categories")
+@RequiredArgsConstructor
+public class TenantCategoryController {
+
+    private final TenantCategoryService tenantCategoryService;
+
+    @Operation(summary = "카테고리 목록 조회", description = "현재 테넌트의 모든 커스텀 카테고리를 조회합니다")
+    @GetMapping
+    @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'OPERATOR')")
+    public ResponseEntity<ApiResponse<List<TenantCategoryResponse>>> getCategories() {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        List<TenantCategoryResponse> response = tenantCategoryService.getCategories(tenantId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "활성화된 카테고리 목록 조회 (TU용)", description = "활성화된 커스텀 카테고리만 조회합니다")
+    @GetMapping("/public")
+    public ResponseEntity<ApiResponse<List<TenantCategoryResponse>>> getPublicCategories() {
+        Long tenantId = TenantContext.getCurrentTenantIdOrNull();
+        if (tenantId == null) {
+            return ResponseEntity.ok(ApiResponse.success(List.of()));
+        }
+        List<TenantCategoryResponse> response = tenantCategoryService.getEnabledCategories(tenantId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "카테고리 생성", description = "새로운 커스텀 카테고리를 추가합니다")
+    @PostMapping
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<TenantCategoryResponse>> createCategory(
+            @Valid @RequestBody TenantCategoryRequest request
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        TenantCategoryResponse response = tenantCategoryService.createCategory(tenantId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "카테고리 수정", description = "기존 커스텀 카테고리를 수정합니다")
+    @PutMapping("/{categoryId}")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<TenantCategoryResponse>> updateCategory(
+            @PathVariable Long categoryId,
+            @Valid @RequestBody TenantCategoryRequest request
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        TenantCategoryResponse response = tenantCategoryService.updateCategory(tenantId, categoryId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "카테고리 삭제", description = "커스텀 카테고리를 삭제합니다")
+    @DeleteMapping("/{categoryId}")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<Void>> deleteCategory(@PathVariable Long categoryId) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        tenantCategoryService.deleteCategory(tenantId, categoryId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @Operation(summary = "카테고리 순서 변경", description = "커스텀 카테고리의 순서를 변경합니다")
+    @PutMapping("/reorder")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<TenantCategoryResponse>>> reorderCategories(
+            @RequestBody List<Long> categoryIds
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        List<TenantCategoryResponse> response = tenantCategoryService.reorderCategories(tenantId, categoryIds);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
@@ -63,7 +63,10 @@ public class TenantSettingsController {
     @Operation(summary = "현재 테넌트 브랜딩 조회", description = "로그인한 사용자의 테넌트 브랜딩 정보를 조회합니다")
     @GetMapping("/branding")
     public ResponseEntity<ApiResponse<PublicBrandingResponse>> getBranding() {
-        Long tenantId = TenantContext.getCurrentTenantId();
+        Long tenantId = TenantContext.getCurrentTenantIdOrNull();
+        if (tenantId == null) {
+            return ResponseEntity.ok(ApiResponse.success(PublicBrandingResponse.defaultBranding()));
+        }
         PublicBrandingResponse response = tenantSettingsService.getBrandingByTenantId(tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
@@ -5,10 +5,12 @@ import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.domain.tenant.dto.request.NavigationItemRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateDesignSettingsRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateLayoutSettingsRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateTenantFeaturesRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateTenantSettingsRequest;
 import com.mzc.lp.domain.tenant.dto.response.NavigationItemResponse;
 import com.mzc.lp.domain.tenant.dto.response.PublicBrandingResponse;
 import com.mzc.lp.domain.tenant.dto.response.PublicLayoutResponse;
+import com.mzc.lp.domain.tenant.dto.response.TenantFeaturesResponse;
 import com.mzc.lp.domain.tenant.dto.response.TenantSettingsResponse;
 import com.mzc.lp.domain.tenant.service.TenantSettingsService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -229,6 +231,41 @@ public class TenantSettingsController {
             return ResponseEntity.ok(ApiResponse.success(List.of()));
         }
         List<NavigationItemResponse> response = tenantSettingsService.getEnabledNavigationItems(tenantId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // ============================================
+    // 테넌트 기능 On/Off 설정 API
+    // ============================================
+
+    @Operation(summary = "테넌트 기능 설정 조회", description = "현재 테넌트의 기능 On/Off 설정을 조회합니다")
+    @GetMapping("/features")
+    @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'OPERATOR')")
+    public ResponseEntity<ApiResponse<TenantFeaturesResponse>> getTenantFeatures() {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        TenantFeaturesResponse response = tenantSettingsService.getTenantFeatures(tenantId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "테넌트 기능 설정 업데이트", description = "현재 테넌트의 기능 On/Off 설정을 업데이트합니다")
+    @PutMapping("/features")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<TenantFeaturesResponse>> updateTenantFeatures(
+            @Valid @RequestBody UpdateTenantFeaturesRequest request
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        TenantFeaturesResponse response = tenantSettingsService.updateTenantFeatures(tenantId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "현재 테넌트 기능 설정 조회 (TU용)", description = "로그인한 사용자의 테넌트 기능 설정을 조회합니다")
+    @GetMapping("/features/public")
+    public ResponseEntity<ApiResponse<TenantFeaturesResponse>> getPublicTenantFeatures() {
+        Long tenantId = TenantContext.getCurrentTenantIdOrNull();
+        if (tenantId == null) {
+            return ResponseEntity.ok(ApiResponse.success(TenantFeaturesResponse.defaultFeatures()));
+        }
+        TenantFeaturesResponse response = tenantSettingsService.getFeaturesByTenantId(tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/request/TenantCategoryRequest.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/request/TenantCategoryRequest.java
@@ -1,0 +1,36 @@
+package com.mzc.lp.domain.tenant.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 테넌트 카테고리 생성/수정 요청 DTO
+ */
+public record TenantCategoryRequest(
+        @NotBlank(message = "카테고리 이름은 필수입니다")
+        @Size(max = 100, message = "카테고리 이름은 100자 이하여야 합니다")
+        String name,
+
+        @NotBlank(message = "카테고리 슬러그는 필수입니다")
+        @Size(max = 100, message = "카테고리 슬러그는 100자 이하여야 합니다")
+        String slug,
+
+        @Size(max = 500, message = "설명은 500자 이하여야 합니다")
+        String description,
+
+        @Size(max = 50, message = "아이콘은 50자 이하여야 합니다")
+        String icon,
+
+        Integer displayOrder,
+
+        Boolean enabled
+) {
+    public TenantCategoryRequest {
+        if (slug != null) {
+            slug = slug.trim().toLowerCase().replaceAll("\\s+", "-");
+        }
+        if (name != null) {
+            name = name.trim();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateTenantFeaturesRequest.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateTenantFeaturesRequest.java
@@ -1,0 +1,13 @@
+package com.mzc.lp.domain.tenant.dto.request;
+
+/**
+ * 테넌트 기능 On/Off 설정 업데이트 요청 DTO
+ */
+public record UpdateTenantFeaturesRequest(
+        Boolean communityEnabled,
+        Boolean userCourseCreationEnabled,
+        Boolean cartEnabled,
+        Boolean wishlistEnabled,
+        Boolean instructorTabEnabled
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/response/TenantCategoryResponse.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/response/TenantCategoryResponse.java
@@ -1,0 +1,34 @@
+package com.mzc.lp.domain.tenant.dto.response;
+
+import com.mzc.lp.domain.tenant.entity.TenantCategory;
+
+import java.time.Instant;
+
+/**
+ * 테넌트 카테고리 응답 DTO
+ */
+public record TenantCategoryResponse(
+        Long id,
+        String name,
+        String slug,
+        String description,
+        String icon,
+        Integer displayOrder,
+        Boolean enabled,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static TenantCategoryResponse from(TenantCategory category) {
+        return new TenantCategoryResponse(
+                category.getId(),
+                category.getName(),
+                category.getSlug(),
+                category.getDescription(),
+                category.getIcon(),
+                category.getDisplayOrder(),
+                category.getEnabled(),
+                category.getCreatedAt(),
+                category.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/response/TenantFeaturesResponse.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/response/TenantFeaturesResponse.java
@@ -1,0 +1,37 @@
+package com.mzc.lp.domain.tenant.dto.response;
+
+import com.mzc.lp.domain.tenant.entity.TenantSettings;
+
+/**
+ * 테넌트 기능 On/Off 설정 응답 DTO
+ */
+public record TenantFeaturesResponse(
+        Boolean communityEnabled,
+        Boolean userCourseCreationEnabled,
+        Boolean cartEnabled,
+        Boolean wishlistEnabled,
+        Boolean instructorTabEnabled
+) {
+    public static TenantFeaturesResponse from(TenantSettings settings) {
+        return new TenantFeaturesResponse(
+                settings.getCommunityEnabled(),
+                settings.getUserCourseCreationEnabled(),
+                settings.getCartEnabled(),
+                settings.getWishlistEnabled(),
+                settings.getInstructorTabEnabled()
+        );
+    }
+
+    /**
+     * 기본값 (모든 기능 활성화)
+     */
+    public static TenantFeaturesResponse defaultFeatures() {
+        return new TenantFeaturesResponse(
+                true,   // communityEnabled
+                false,  // userCourseCreationEnabled
+                true,   // cartEnabled
+                true,   // wishlistEnabled
+                true    // instructorTabEnabled
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/entity/TenantCategory.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/entity/TenantCategory.java
@@ -1,0 +1,70 @@
+package com.mzc.lp.domain.tenant.entity;
+
+import com.mzc.lp.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 테넌트별 커스텀 카테고리 엔티티
+ * 각 테넌트가 자체적으로 강의 카테고리를 관리할 수 있음
+ */
+@Entity
+@Table(name = "tenant_categories",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"tenant_id", "slug"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TenantCategory extends BaseTimeEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tenant_id", nullable = false)
+    private Tenant tenant;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false, length = 100)
+    private String slug;
+
+    @Column(length = 500)
+    private String description;
+
+    @Column(length = 50)
+    private String icon;
+
+    @Column(nullable = false)
+    private Integer displayOrder = 0;
+
+    @Column(nullable = false)
+    private Boolean enabled = true;
+
+    // 정적 팩토리 메서드
+    public static TenantCategory create(Tenant tenant, String name, String slug,
+                                        String description, String icon, Integer displayOrder) {
+        TenantCategory category = new TenantCategory();
+        category.tenant = tenant;
+        category.name = name;
+        category.slug = slug;
+        category.description = description;
+        category.icon = icon;
+        category.displayOrder = displayOrder != null ? displayOrder : 0;
+        category.enabled = true;
+        return category;
+    }
+
+    // 업데이트 메서드
+    public void update(String name, String slug, String description,
+                       String icon, Boolean enabled) {
+        if (name != null) this.name = name;
+        if (slug != null) this.slug = slug;
+        if (description != null) this.description = description;
+        if (icon != null) this.icon = icon;
+        if (enabled != null) this.enabled = enabled;
+    }
+
+    // 순서 변경 메서드
+    public void updateOrder(Integer displayOrder) {
+        if (displayOrder != null) this.displayOrder = displayOrder;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/entity/TenantSettings.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/entity/TenantSettings.java
@@ -131,6 +131,25 @@ public class TenantSettings extends BaseTimeEntity {
     @Column(nullable = false)
     private Boolean apiAccessEnabled = false;
 
+    // ============================================
+    // 테넌트 기능 On/Off 설정
+    // ============================================
+
+    @Column(nullable = false)
+    private Boolean communityEnabled = true;
+
+    @Column(nullable = false)
+    private Boolean userCourseCreationEnabled = false;
+
+    @Column(nullable = false)
+    private Boolean cartEnabled = true;
+
+    @Column(nullable = false)
+    private Boolean wishlistEnabled = true;
+
+    @Column(nullable = false)
+    private Boolean instructorTabEnabled = true;
+
     // 정적 팩토리 메서드
     public static TenantSettings createDefault(Tenant tenant) {
         TenantSettings settings = new TenantSettings();
@@ -225,5 +244,16 @@ public class TenantSettings extends BaseTimeEntity {
         if (allowCustomBranding != null) this.allowCustomBranding = allowCustomBranding;
         if (ssoEnabled != null) this.ssoEnabled = ssoEnabled;
         if (apiAccessEnabled != null) this.apiAccessEnabled = apiAccessEnabled;
+    }
+
+    // 테넌트 기능 On/Off 설정 업데이트
+    public void updateTenantFeatures(Boolean communityEnabled, Boolean userCourseCreationEnabled,
+                                     Boolean cartEnabled, Boolean wishlistEnabled,
+                                     Boolean instructorTabEnabled) {
+        if (communityEnabled != null) this.communityEnabled = communityEnabled;
+        if (userCourseCreationEnabled != null) this.userCourseCreationEnabled = userCourseCreationEnabled;
+        if (cartEnabled != null) this.cartEnabled = cartEnabled;
+        if (wishlistEnabled != null) this.wishlistEnabled = wishlistEnabled;
+        if (instructorTabEnabled != null) this.instructorTabEnabled = instructorTabEnabled;
     }
 }

--- a/src/main/java/com/mzc/lp/domain/tenant/repository/TenantCategoryRepository.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/repository/TenantCategoryRepository.java
@@ -1,0 +1,56 @@
+package com.mzc.lp.domain.tenant.repository;
+
+import com.mzc.lp.domain.tenant.entity.TenantCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 테넌트 카테고리 리포지토리
+ */
+@Repository
+public interface TenantCategoryRepository extends JpaRepository<TenantCategory, Long> {
+
+    /**
+     * 테넌트의 모든 카테고리 조회 (정렬)
+     */
+    List<TenantCategory> findByTenantIdOrderByDisplayOrderAsc(Long tenantId);
+
+    /**
+     * 테넌트의 활성화된 카테고리만 조회 (정렬)
+     */
+    List<TenantCategory> findByTenantIdAndEnabledTrueOrderByDisplayOrderAsc(Long tenantId);
+
+    /**
+     * 특정 테넌트의 특정 카테고리 조회
+     */
+    Optional<TenantCategory> findByIdAndTenantId(Long id, Long tenantId);
+
+    /**
+     * 테넌트에 해당 슬러그가 존재하는지 확인
+     */
+    boolean existsByTenantIdAndSlug(Long tenantId, String slug);
+
+    /**
+     * 테넌트에 해당 슬러그가 존재하는지 확인 (자기 자신 제외)
+     */
+    @Query("SELECT COUNT(c) > 0 FROM TenantCategory c WHERE c.tenant.id = :tenantId AND c.slug = :slug AND c.id != :excludeId")
+    boolean existsByTenantIdAndSlugAndIdNot(@Param("tenantId") Long tenantId,
+                                             @Param("slug") String slug,
+                                             @Param("excludeId") Long excludeId);
+
+    /**
+     * 테넌트의 최대 displayOrder 조회
+     */
+    @Query("SELECT COALESCE(MAX(c.displayOrder), 0) FROM TenantCategory c WHERE c.tenant.id = :tenantId")
+    int findMaxDisplayOrderByTenantId(@Param("tenantId") Long tenantId);
+
+    /**
+     * 테넌트의 카테고리 개수
+     */
+    long countByTenantId(Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantCategoryService.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantCategoryService.java
@@ -1,0 +1,47 @@
+package com.mzc.lp.domain.tenant.service;
+
+import com.mzc.lp.domain.tenant.dto.request.TenantCategoryRequest;
+import com.mzc.lp.domain.tenant.dto.response.TenantCategoryResponse;
+
+import java.util.List;
+
+/**
+ * 테넌트 카테고리 서비스 인터페이스
+ */
+public interface TenantCategoryService {
+
+    /**
+     * 테넌트의 모든 카테고리 조회
+     */
+    List<TenantCategoryResponse> getCategories(Long tenantId);
+
+    /**
+     * 테넌트의 활성화된 카테고리만 조회
+     */
+    List<TenantCategoryResponse> getEnabledCategories(Long tenantId);
+
+    /**
+     * 카테고리 생성
+     */
+    TenantCategoryResponse createCategory(Long tenantId, TenantCategoryRequest request);
+
+    /**
+     * 카테고리 수정
+     */
+    TenantCategoryResponse updateCategory(Long tenantId, Long categoryId, TenantCategoryRequest request);
+
+    /**
+     * 카테고리 삭제
+     */
+    void deleteCategory(Long tenantId, Long categoryId);
+
+    /**
+     * 카테고리 순서 변경
+     */
+    List<TenantCategoryResponse> reorderCategories(Long tenantId, List<Long> categoryIds);
+
+    /**
+     * 공개 API: 서브도메인/커스텀도메인으로 카테고리 조회
+     */
+    List<TenantCategoryResponse> getPublicCategories(String identifier, String type);
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantCategoryServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantCategoryServiceImpl.java
@@ -1,0 +1,152 @@
+package com.mzc.lp.domain.tenant.service;
+
+import com.mzc.lp.domain.tenant.constant.TenantStatus;
+import com.mzc.lp.domain.tenant.dto.request.TenantCategoryRequest;
+import com.mzc.lp.domain.tenant.dto.response.TenantCategoryResponse;
+import com.mzc.lp.domain.tenant.entity.Tenant;
+import com.mzc.lp.domain.tenant.entity.TenantCategory;
+import com.mzc.lp.domain.tenant.exception.TenantDomainNotFoundException;
+import com.mzc.lp.domain.tenant.repository.TenantCategoryRepository;
+import com.mzc.lp.domain.tenant.repository.TenantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 테넌트 카테고리 서비스 구현체
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TenantCategoryServiceImpl implements TenantCategoryService {
+
+    private final TenantCategoryRepository tenantCategoryRepository;
+    private final TenantRepository tenantRepository;
+
+    @Override
+    public List<TenantCategoryResponse> getCategories(Long tenantId) {
+        return tenantCategoryRepository.findByTenantIdOrderByDisplayOrderAsc(tenantId)
+                .stream()
+                .map(TenantCategoryResponse::from)
+                .toList();
+    }
+
+    @Override
+    public List<TenantCategoryResponse> getEnabledCategories(Long tenantId) {
+        return tenantCategoryRepository.findByTenantIdAndEnabledTrueOrderByDisplayOrderAsc(tenantId)
+                .stream()
+                .map(TenantCategoryResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public TenantCategoryResponse createCategory(Long tenantId, TenantCategoryRequest request) {
+        Tenant tenant = tenantRepository.findById(tenantId)
+                .orElseThrow(() -> new TenantDomainNotFoundException("Tenant not found: " + tenantId));
+
+        // 슬러그 중복 검사
+        if (tenantCategoryRepository.existsByTenantIdAndSlug(tenantId, request.slug())) {
+            throw new IllegalArgumentException("이미 존재하는 카테고리 슬러그입니다: " + request.slug());
+        }
+
+        // displayOrder 설정
+        int maxOrder = tenantCategoryRepository.findMaxDisplayOrderByTenantId(tenantId);
+        int newOrder = request.displayOrder() != null ? request.displayOrder() : maxOrder + 1;
+
+        TenantCategory category = TenantCategory.create(
+                tenant,
+                request.name(),
+                request.slug(),
+                request.description(),
+                request.icon(),
+                newOrder
+        );
+
+        TenantCategory saved = tenantCategoryRepository.save(category);
+        return TenantCategoryResponse.from(saved);
+    }
+
+    @Override
+    @Transactional
+    public TenantCategoryResponse updateCategory(Long tenantId, Long categoryId, TenantCategoryRequest request) {
+        TenantCategory category = tenantCategoryRepository.findByIdAndTenantId(categoryId, tenantId)
+                .orElseThrow(() -> new TenantDomainNotFoundException("Category not found: " + categoryId));
+
+        // 슬러그 변경 시 중복 검사
+        if (request.slug() != null && !request.slug().equals(category.getSlug())) {
+            if (tenantCategoryRepository.existsByTenantIdAndSlugAndIdNot(tenantId, request.slug(), categoryId)) {
+                throw new IllegalArgumentException("이미 존재하는 카테고리 슬러그입니다: " + request.slug());
+            }
+        }
+
+        category.update(
+                request.name(),
+                request.slug(),
+                request.description(),
+                request.icon(),
+                request.enabled()
+        );
+
+        if (request.displayOrder() != null) {
+            category.updateOrder(request.displayOrder());
+        }
+
+        return TenantCategoryResponse.from(category);
+    }
+
+    @Override
+    @Transactional
+    public void deleteCategory(Long tenantId, Long categoryId) {
+        TenantCategory category = tenantCategoryRepository.findByIdAndTenantId(categoryId, tenantId)
+                .orElseThrow(() -> new TenantDomainNotFoundException("Category not found: " + categoryId));
+
+        tenantCategoryRepository.delete(category);
+    }
+
+    @Override
+    @Transactional
+    public List<TenantCategoryResponse> reorderCategories(Long tenantId, List<Long> categoryIds) {
+        List<TenantCategory> categories = tenantCategoryRepository.findByTenantIdOrderByDisplayOrderAsc(tenantId);
+
+        for (int i = 0; i < categoryIds.size(); i++) {
+            final int order = i + 1;
+            final Long id = categoryIds.get(i);
+            categories.stream()
+                    .filter(cat -> cat.getId().equals(id))
+                    .findFirst()
+                    .ifPresent(cat -> cat.updateOrder(order));
+        }
+
+        return categories.stream()
+                .sorted((a, b) -> a.getDisplayOrder().compareTo(b.getDisplayOrder()))
+                .map(TenantCategoryResponse::from)
+                .toList();
+    }
+
+    @Override
+    public List<TenantCategoryResponse> getPublicCategories(String identifier, String type) {
+        Tenant tenant = findTenantByIdentifier(identifier, type);
+        if (tenant == null) {
+            return Collections.emptyList();
+        }
+
+        return getEnabledCategories(tenant.getId());
+    }
+
+    private Tenant findTenantByIdentifier(String identifier, String type) {
+        if ("subdomain".equals(type)) {
+            return tenantRepository.findBySubdomain(identifier)
+                    .filter(t -> t.getStatus() == TenantStatus.ACTIVE)
+                    .orElse(null);
+        } else if ("customDomain".equals(type)) {
+            return tenantRepository.findByCustomDomain(identifier)
+                    .filter(t -> t.getStatus() == TenantStatus.ACTIVE)
+                    .orElse(null);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsService.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsService.java
@@ -3,10 +3,12 @@ package com.mzc.lp.domain.tenant.service;
 import com.mzc.lp.domain.tenant.dto.request.NavigationItemRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateDesignSettingsRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateLayoutSettingsRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateTenantFeaturesRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateTenantSettingsRequest;
 import com.mzc.lp.domain.tenant.dto.response.NavigationItemResponse;
 import com.mzc.lp.domain.tenant.dto.response.PublicBrandingResponse;
 import com.mzc.lp.domain.tenant.dto.response.PublicLayoutResponse;
+import com.mzc.lp.domain.tenant.dto.response.TenantFeaturesResponse;
 import com.mzc.lp.domain.tenant.dto.response.TenantSettingsResponse;
 
 import java.util.List;
@@ -148,4 +150,38 @@ public interface TenantSettingsService {
      * @return 활성화된 네비게이션 항목 목록
      */
     List<NavigationItemResponse> getEnabledNavigationItems(Long tenantId);
+
+    // ============================================
+    // 테넌트 기능 On/Off 설정
+    // ============================================
+
+    /**
+     * 테넌트 기능 설정 조회
+     * @param tenantId 테넌트 ID
+     * @return 기능 설정
+     */
+    TenantFeaturesResponse getTenantFeatures(Long tenantId);
+
+    /**
+     * 테넌트 기능 설정 업데이트
+     * @param tenantId 테넌트 ID
+     * @param request 업데이트 요청
+     * @return 업데이트된 기능 설정
+     */
+    TenantFeaturesResponse updateTenantFeatures(Long tenantId, UpdateTenantFeaturesRequest request);
+
+    /**
+     * 공개 기능 설정 조회 (인증 불필요)
+     * @param identifier subdomain 또는 customDomain
+     * @param type "subdomain" 또는 "customDomain"
+     * @return 기능 설정
+     */
+    TenantFeaturesResponse getPublicTenantFeatures(String identifier, String type);
+
+    /**
+     * 테넌트 ID로 기능 설정 조회 (인증된 사용자용)
+     * @param tenantId 테넌트 ID
+     * @return 기능 설정
+     */
+    TenantFeaturesResponse getFeaturesByTenantId(Long tenantId);
 }

--- a/src/main/java/com/mzc/lp/domain/user/constant/TenantRole.java
+++ b/src/main/java/com/mzc/lp/domain/user/constant/TenantRole.java
@@ -5,5 +5,6 @@ public enum TenantRole {
     TENANT_ADMIN,   // 테넌트 최고 관리자
     OPERATOR,       // 운영자 (강의 검토, 차수 생성, 역할 부여)
     DESIGNER,       // 설계자 (강의 개설 신청)
+    INSTRUCTOR,     // 강사 (강의 진행)
     USER            // 일반 사용자 (수강)
 }

--- a/src/main/java/com/mzc/lp/domain/user/dto/response/UserDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/response/UserDetailResponse.java
@@ -19,8 +19,33 @@ public record UserDetailResponse(
         String tenantCustomDomain,
         Instant createdAt,
         Instant updatedAt,
-        List<CourseRoleResponse> courseRoles
+        List<CourseRoleResponse> courseRoles,
+        Boolean profileCompleted
 ) {
+    /**
+     * 프로필 완성 여부 판단
+     * - 이름이 이메일 로컬파트와 동일하면 미완성 (단체 계정 생성 시 이메일 prefix를 이름으로 사용)
+     * - 이름이 null이거나 빈 문자열이면 미완성
+     */
+    private static Boolean isProfileCompleted(User user) {
+        String name = user.getName();
+        String email = user.getEmail();
+
+        if (name == null || name.isBlank()) {
+            return false;
+        }
+
+        // 이메일 로컬파트(@ 앞부분) 추출
+        String emailLocalPart = email.contains("@") ? email.substring(0, email.indexOf("@")) : email;
+
+        // 이름이 이메일 로컬파트와 동일하면 단체 생성된 계정으로 간주
+        if (name.equals(emailLocalPart)) {
+            return false;
+        }
+
+        return true;
+    }
+
     public static UserDetailResponse from(User user) {
         return new UserDetailResponse(
                 user.getId(),
@@ -35,7 +60,8 @@ public record UserDetailResponse(
                 null,
                 user.getCreatedAt(),
                 user.getUpdatedAt(),
-                Collections.emptyList()
+                Collections.emptyList(),
+                isProfileCompleted(user)
         );
     }
 
@@ -53,7 +79,8 @@ public record UserDetailResponse(
                 null,
                 user.getCreatedAt(),
                 user.getUpdatedAt(),
-                courseRoles != null ? courseRoles : Collections.emptyList()
+                courseRoles != null ? courseRoles : Collections.emptyList(),
+                isProfileCompleted(user)
         );
     }
 
@@ -71,7 +98,8 @@ public record UserDetailResponse(
                 tenantCustomDomain,
                 user.getCreatedAt(),
                 user.getUpdatedAt(),
-                courseRoles != null ? courseRoles : Collections.emptyList()
+                courseRoles != null ? courseRoles : Collections.emptyList(),
+                isProfileCompleted(user)
         );
     }
 }


### PR DESCRIPTION
## Summary

테넌트 관리자가 자신의 테넌트에서 사용할 기능들을 On/Off 할 수 있는 API와 단체 계정 생성 사용자의 프로필 완성 여부를 판별하는 기능을 구현합니다.

## Related Issue

- Closes #

## Changes

### 테넌트 기능 On/Off 설정
- TenantSettings 엔티티에 기능 On/Off 필드 추가
  - communityEnabled: 커뮤니티 기능
  - userCourseCreationEnabled: 유저 강의 개설 기능
  - cartEnabled: 장바구니 기능
  - wishlistEnabled: 찜 기능
  - instructorTabEnabled: 강사탭 기능
- TenantFeaturesResponse/UpdateTenantFeaturesRequest DTO 추가
- TenantSettingsController에 기능 설정 API 추가
  - GET /api/tenant/settings/features
  - PUT /api/tenant/settings/features
  - GET /api/tenant/settings/features/public (공개 API)

### 테넌트별 커스텀 카테고리
- TenantCategory 엔티티 생성
- TenantCategoryRepository 생성
- TenantCategoryService/Impl 구현
- TenantCategoryController CRUD API 구현

### 프로필 완성 여부 판별
- UserDetailResponse에 profileCompleted 필드 추가
- 이름이 이메일 로컬파트와 동일하면 미완성으로 판별 (단체 계정 생성 시 이메일 prefix를 이름으로 사용)

### TenantRole 확장
- INSTRUCTOR, DESIGNER 역할 추가

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 프론트엔드 PR과 함께 병합되어야 합니다