### PR TITLE
feat: 학습자용 콘텐츠 스트리밍 API #303

### DIFF
--- a/src/main/java/com/mzc/lp/domain/snapshot/dto/response/SnapshotLearningObjectResponse.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/dto/response/SnapshotLearningObjectResponse.java
@@ -10,6 +10,7 @@ public record SnapshotLearningObjectResponse(
         Integer duration,
         String thumbnailUrl,
         String resolution,
+        String externalUrl,
         Boolean isCustomized
 ) {
     public static SnapshotLearningObjectResponse from(SnapshotLearningObject slo) {
@@ -24,6 +25,7 @@ public record SnapshotLearningObjectResponse(
                 slo.getDuration(),
                 slo.getThumbnailUrl(),
                 slo.getResolution(),
+                slo.getExternalUrl(),
                 slo.getIsCustomized()
         );
     }

--- a/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotLearningObject.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotLearningObject.java
@@ -47,6 +47,9 @@ public class SnapshotLearningObject extends TenantEntity {
     @Column(name = "page_count")
     private Integer pageCount;
 
+    @Column(name = "external_url", length = 2000)
+    private String externalUrl;
+
     @Column(name = "is_customized", nullable = false)
     private Boolean isCustomized;
 
@@ -62,7 +65,8 @@ public class SnapshotLearningObject extends TenantEntity {
     public static SnapshotLearningObject createFromLo(Long sourceLoId, Long contentId,
                                                        String displayName, Integer duration,
                                                        String thumbnailUrl, String resolution,
-                                                       String codec, Long bitrate, Integer pageCount) {
+                                                       String codec, Long bitrate, Integer pageCount,
+                                                       String externalUrl) {
         SnapshotLearningObject slo = new SnapshotLearningObject();
         slo.sourceLoId = sourceLoId;
         slo.contentId = contentId;
@@ -73,6 +77,7 @@ public class SnapshotLearningObject extends TenantEntity {
         slo.codec = codec;
         slo.bitrate = bitrate;
         slo.pageCount = pageCount;
+        slo.externalUrl = externalUrl;
         slo.isCustomized = false;
         return slo;
     }

--- a/src/main/java/com/mzc/lp/domain/snapshot/service/SnapshotServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/service/SnapshotServiceImpl.java
@@ -280,7 +280,8 @@ public class SnapshotServiceImpl implements SnapshotService {
                             content.getResolution(),
                             null,  // codec - Content에 없음
                             null,  // bitrate - Content에 없음
-                            content.getPageCount()
+                            content.getPageCount(),
+                            content.getExternalUrl()           // 외부링크 URL
                     );
                     snapshotLo = snapshotLoRepository.save(snapshotLo);
 

--- a/src/main/java/com/mzc/lp/domain/student/controller/ItemProgressController.java
+++ b/src/main/java/com/mzc/lp/domain/student/controller/ItemProgressController.java
@@ -1,0 +1,95 @@
+package com.mzc.lp.domain.student.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.student.dto.request.UpdateItemProgressRequest;
+import com.mzc.lp.domain.student.dto.response.ItemProgressResponse;
+import com.mzc.lp.domain.student.service.ItemProgressService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/enrollments/{enrollmentId}/items")
+public class ItemProgressController {
+
+    private final ItemProgressService itemProgressService;
+
+    /**
+     * 수강별 전체 아이템 진도 목록 조회
+     */
+    @GetMapping("/progress")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<List<ItemProgressResponse>>> getItemProgressList(
+            @PathVariable Long enrollmentId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        boolean isAdmin = hasAdminRole(principal);
+        List<ItemProgressResponse> response = itemProgressService.getItemProgressList(
+                enrollmentId, principal.id(), isAdmin);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 특정 아이템 진도 조회
+     */
+    @GetMapping("/{itemId}/progress")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<ItemProgressResponse>> getItemProgress(
+            @PathVariable Long enrollmentId,
+            @PathVariable Long itemId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        boolean isAdmin = hasAdminRole(principal);
+        ItemProgressResponse response = itemProgressService.getItemProgress(
+                enrollmentId, itemId, principal.id(), isAdmin);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 아이템 진도 업데이트
+     */
+    @PatchMapping("/{itemId}/progress")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<ItemProgressResponse>> updateItemProgress(
+            @PathVariable Long enrollmentId,
+            @PathVariable Long itemId,
+            @Valid @RequestBody UpdateItemProgressRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        boolean isAdmin = hasAdminRole(principal);
+        ItemProgressResponse response = itemProgressService.updateItemProgress(
+                enrollmentId, itemId, request, principal.id(), isAdmin);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 아이템 완료 처리
+     */
+    @PostMapping("/{itemId}/complete")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<ItemProgressResponse>> markItemComplete(
+            @PathVariable Long enrollmentId,
+            @PathVariable Long itemId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        boolean isAdmin = hasAdminRole(principal);
+        ItemProgressResponse response = itemProgressService.markItemComplete(
+                enrollmentId, itemId, principal.id(), isAdmin);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 관리자 역할 여부 확인 (OPERATOR, TENANT_ADMIN)
+     */
+    private boolean hasAdminRole(UserPrincipal principal) {
+        String role = principal.role();
+        return "OPERATOR".equals(role) || "TENANT_ADMIN".equals(role);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/student/controller/LearnerContentController.java
+++ b/src/main/java/com/mzc/lp/domain/student/controller/LearnerContentController.java
@@ -1,0 +1,81 @@
+package com.mzc.lp.domain.student.controller;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.content.service.ContentService;
+import com.mzc.lp.domain.student.service.LearnerContentAccessService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 학습자용 콘텐츠 스트리밍/다운로드 컨트롤러
+ * 수강 신청한 강의의 콘텐츠에 대한 접근 권한을 검증 후 파일 제공
+ */
+@RestController
+@RequestMapping("/api/learning")
+@RequiredArgsConstructor
+public class LearnerContentController {
+
+    private final LearnerContentAccessService learnerContentAccessService;
+    private final ContentService contentService;
+
+    /**
+     * 학습자용 콘텐츠 스트리밍
+     * - 수강 신청한 강의의 콘텐츠만 접근 가능
+     */
+    @GetMapping("/contents/{contentId}/stream")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Resource> streamContent(
+            @PathVariable Long contentId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        Long userId = principal.id();
+
+        // 접근 권한 검증
+        learnerContentAccessService.validateContentAccess(contentId, userId, tenantId);
+
+        // 콘텐츠 파일 스트리밍
+        ContentService.ContentDownloadInfo downloadInfo =
+                contentService.getFileForPreview(contentId, tenantId);
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(downloadInfo.contentType()))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "inline")
+                .body(downloadInfo.resource());
+    }
+
+    /**
+     * 학습자용 콘텐츠 다운로드
+     * - 수강 신청한 강의의 콘텐츠만 접근 가능
+     * - 다운로드 허용된 콘텐츠만 다운로드 가능
+     */
+    @GetMapping("/contents/{contentId}/download")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Resource> downloadContent(
+            @PathVariable Long contentId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        Long userId = principal.id();
+
+        // 접근 권한 검증
+        learnerContentAccessService.validateContentAccess(contentId, userId, tenantId);
+
+        // 콘텐츠 파일 다운로드
+        ContentService.ContentDownloadInfo downloadInfo =
+                contentService.getFileForDownload(contentId, tenantId);
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(downloadInfo.contentType()))
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"" + downloadInfo.originalFileName() + "\"")
+                .body(downloadInfo.resource());
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/student/dto/request/UpdateItemProgressRequest.java
+++ b/src/main/java/com/mzc/lp/domain/student/dto/request/UpdateItemProgressRequest.java
@@ -1,0 +1,17 @@
+package com.mzc.lp.domain.student.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record UpdateItemProgressRequest(
+        @Min(value = 0, message = "진도율은 0 이상이어야 합니다")
+        @Max(value = 100, message = "진도율은 100 이하여야 합니다")
+        Integer progressPercent,
+
+        @Min(value = 0, message = "시청 시간은 0 이상이어야 합니다")
+        Integer watchedSeconds,
+
+        @Min(value = 0, message = "마지막 재생 위치는 0 이상이어야 합니다")
+        Integer lastPositionSeconds
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/student/dto/request/UpdateProgressRequest.java
+++ b/src/main/java/com/mzc/lp/domain/student/dto/request/UpdateProgressRequest.java
@@ -5,9 +5,14 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record UpdateProgressRequest(
+        @NotNull(message = "아이템 ID는 필수입니다")
+        Long itemId,
+
         @NotNull(message = "진도율은 필수입니다")
         @Min(value = 0, message = "진도율은 0 이상이어야 합니다")
         @Max(value = 100, message = "진도율은 100 이하여야 합니다")
-        Integer progressPercent
+        Integer progressPercent,
+
+        Integer watchedSeconds
 ) {
 }

--- a/src/main/java/com/mzc/lp/domain/student/dto/response/ItemProgressResponse.java
+++ b/src/main/java/com/mzc/lp/domain/student/dto/response/ItemProgressResponse.java
@@ -1,0 +1,29 @@
+package com.mzc.lp.domain.student.dto.response;
+
+import com.mzc.lp.domain.student.entity.ItemProgress;
+
+import java.time.Instant;
+
+public record ItemProgressResponse(
+        Long id,
+        Long enrollmentId,
+        Long itemId,
+        Integer progressPercent,
+        Integer watchedSeconds,
+        Boolean completed,
+        Instant completedAt,
+        Integer lastPositionSeconds
+) {
+    public static ItemProgressResponse from(ItemProgress entity) {
+        return new ItemProgressResponse(
+                entity.getId(),
+                entity.getEnrollmentId(),
+                entity.getItemId(),
+                entity.getProgressPercent(),
+                entity.getWatchedSeconds(),
+                entity.getCompleted(),
+                entity.getCompletedAt(),
+                entity.getLastPositionSeconds()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/student/entity/ItemProgress.java
+++ b/src/main/java/com/mzc/lp/domain/student/entity/ItemProgress.java
@@ -1,0 +1,107 @@
+package com.mzc.lp.domain.student.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+/**
+ * 아이템(차시)별 학습 진도 엔티티
+ * - 수강(Enrollment)에 속한 각 학습 아이템의 진도를 추적
+ */
+@Entity
+@Table(name = "sis_item_progress",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_sis_item_progress",
+                columnNames = {"tenant_id", "enrollment_id", "item_id"}
+        ),
+        indexes = {
+                @Index(name = "idx_sis_item_progress_enrollment", columnList = "tenant_id, enrollment_id"),
+                @Index(name = "idx_sis_item_progress_item", columnList = "tenant_id, item_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemProgress extends TenantEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "enrollment_id", nullable = false)
+    private Long enrollmentId;
+
+    @Column(name = "item_id", nullable = false)
+    private Long itemId;
+
+    @Column(name = "progress_percent", nullable = false)
+    private Integer progressPercent;
+
+    @Column(name = "watched_seconds")
+    private Integer watchedSeconds;
+
+    @Column(nullable = false)
+    private Boolean completed;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    @Column(name = "last_position_seconds")
+    private Integer lastPositionSeconds;
+
+    // 정적 팩토리 메서드
+    public static ItemProgress create(Long enrollmentId, Long itemId) {
+        ItemProgress progress = new ItemProgress();
+        progress.enrollmentId = enrollmentId;
+        progress.itemId = itemId;
+        progress.progressPercent = 0;
+        progress.watchedSeconds = 0;
+        progress.completed = false;
+        progress.lastPositionSeconds = 0;
+        return progress;
+    }
+
+    // 비즈니스 메서드
+
+    /**
+     * 진도 업데이트
+     */
+    public void updateProgress(Integer progressPercent, Integer watchedSeconds, Integer lastPositionSeconds) {
+        if (progressPercent != null) {
+            if (progressPercent < 0 || progressPercent > 100) {
+                throw new IllegalArgumentException("Progress percent must be between 0 and 100");
+            }
+            this.progressPercent = progressPercent;
+        }
+        if (watchedSeconds != null) {
+            this.watchedSeconds = watchedSeconds;
+        }
+        if (lastPositionSeconds != null) {
+            this.lastPositionSeconds = lastPositionSeconds;
+        }
+    }
+
+    /**
+     * 완료 처리
+     */
+    public void markAsCompleted() {
+        this.completed = true;
+        this.completedAt = Instant.now();
+        this.progressPercent = 100;
+    }
+
+    /**
+     * 완료 취소 (관리자용)
+     */
+    public void unmarkCompleted() {
+        this.completed = false;
+        this.completedAt = null;
+    }
+
+    public boolean isCompleted() {
+        return this.completed;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/student/exception/ContentAccessDeniedException.java
+++ b/src/main/java/com/mzc/lp/domain/student/exception/ContentAccessDeniedException.java
@@ -1,0 +1,16 @@
+package com.mzc.lp.domain.student.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class ContentAccessDeniedException extends BusinessException {
+
+    public ContentAccessDeniedException() {
+        super(ErrorCode.UNAUTHORIZED_CONTENT_ACCESS);
+    }
+
+    public ContentAccessDeniedException(Long contentId, Long userId) {
+        super(ErrorCode.UNAUTHORIZED_CONTENT_ACCESS,
+                "User " + userId + " is not authorized to access content " + contentId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/student/repository/ItemProgressRepository.java
+++ b/src/main/java/com/mzc/lp/domain/student/repository/ItemProgressRepository.java
@@ -1,0 +1,58 @@
+package com.mzc.lp.domain.student.repository;
+
+import com.mzc.lp.domain.student.entity.ItemProgress;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ItemProgressRepository extends JpaRepository<ItemProgress, Long> {
+
+    /**
+     * 수강 ID와 아이템 ID로 진도 조회
+     */
+    Optional<ItemProgress> findByEnrollmentIdAndItemIdAndTenantId(
+            Long enrollmentId, Long itemId, Long tenantId);
+
+    /**
+     * 수강별 전체 아이템 진도 목록 조회
+     */
+    List<ItemProgress> findByEnrollmentIdAndTenantId(Long enrollmentId, Long tenantId);
+
+    /**
+     * 수강별 완료된 아이템 수
+     */
+    long countByEnrollmentIdAndCompletedAndTenantId(Long enrollmentId, Boolean completed, Long tenantId);
+
+    /**
+     * 수강별 전체 아이템 수
+     */
+    long countByEnrollmentIdAndTenantId(Long enrollmentId, Long tenantId);
+
+    /**
+     * 수강별 평균 진도율
+     */
+    @Query("SELECT AVG(ip.progressPercent) FROM ItemProgress ip " +
+            "WHERE ip.enrollmentId = :enrollmentId AND ip.tenantId = :tenantId")
+    Double findAverageProgressByEnrollmentId(
+            @Param("enrollmentId") Long enrollmentId,
+            @Param("tenantId") Long tenantId);
+
+    /**
+     * 수강별 완료율 (완료된 아이템 / 전체 아이템 * 100)
+     */
+    @Query("SELECT COUNT(CASE WHEN ip.completed = true THEN 1 END) * 100.0 / NULLIF(COUNT(ip), 0) " +
+            "FROM ItemProgress ip " +
+            "WHERE ip.enrollmentId = :enrollmentId AND ip.tenantId = :tenantId")
+    Double getCompletionRateByEnrollmentId(
+            @Param("enrollmentId") Long enrollmentId,
+            @Param("tenantId") Long tenantId);
+
+    /**
+     * 특정 아이템의 완료 여부 확인
+     */
+    boolean existsByEnrollmentIdAndItemIdAndCompletedAndTenantId(
+            Long enrollmentId, Long itemId, Boolean completed, Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/student/service/ItemProgressService.java
+++ b/src/main/java/com/mzc/lp/domain/student/service/ItemProgressService.java
@@ -1,0 +1,35 @@
+package com.mzc.lp.domain.student.service;
+
+import com.mzc.lp.domain.student.dto.request.UpdateItemProgressRequest;
+import com.mzc.lp.domain.student.dto.response.ItemProgressResponse;
+
+import java.util.List;
+
+public interface ItemProgressService {
+
+    /**
+     * 수강별 전체 아이템 진도 목록 조회
+     */
+    List<ItemProgressResponse> getItemProgressList(Long enrollmentId, Long userId, boolean isAdmin);
+
+    /**
+     * 특정 아이템 진도 조회
+     */
+    ItemProgressResponse getItemProgress(Long enrollmentId, Long itemId, Long userId, boolean isAdmin);
+
+    /**
+     * 아이템 진도 업데이트
+     */
+    ItemProgressResponse updateItemProgress(
+            Long enrollmentId,
+            Long itemId,
+            UpdateItemProgressRequest request,
+            Long userId,
+            boolean isAdmin
+    );
+
+    /**
+     * 아이템 완료 처리
+     */
+    ItemProgressResponse markItemComplete(Long enrollmentId, Long itemId, Long userId, boolean isAdmin);
+}

--- a/src/main/java/com/mzc/lp/domain/student/service/ItemProgressServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/student/service/ItemProgressServiceImpl.java
@@ -1,0 +1,161 @@
+package com.mzc.lp.domain.student.service;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.domain.student.dto.request.UpdateItemProgressRequest;
+import com.mzc.lp.domain.student.dto.response.ItemProgressResponse;
+import com.mzc.lp.domain.student.entity.Enrollment;
+import com.mzc.lp.domain.student.entity.ItemProgress;
+import com.mzc.lp.domain.student.exception.EnrollmentNotFoundException;
+import com.mzc.lp.domain.student.exception.UnauthorizedEnrollmentAccessException;
+import com.mzc.lp.domain.student.repository.EnrollmentRepository;
+import com.mzc.lp.domain.student.repository.ItemProgressRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ItemProgressServiceImpl implements ItemProgressService {
+
+    private final ItemProgressRepository itemProgressRepository;
+    private final EnrollmentRepository enrollmentRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ItemProgressResponse> getItemProgressList(Long enrollmentId, Long userId, boolean isAdmin) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 수강 정보 확인 및 권한 검증
+        Enrollment enrollment = getEnrollmentWithAccessCheck(enrollmentId, userId, isAdmin, tenantId);
+
+        List<ItemProgress> progressList = itemProgressRepository.findByEnrollmentIdAndTenantId(enrollmentId, tenantId);
+
+        log.info("Retrieved item progress list: enrollmentId={}, count={}", enrollmentId, progressList.size());
+
+        return progressList.stream()
+                .map(ItemProgressResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ItemProgressResponse getItemProgress(Long enrollmentId, Long itemId, Long userId, boolean isAdmin) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 수강 정보 확인 및 권한 검증
+        getEnrollmentWithAccessCheck(enrollmentId, userId, isAdmin, tenantId);
+
+        ItemProgress progress = itemProgressRepository
+                .findByEnrollmentIdAndItemIdAndTenantId(enrollmentId, itemId, tenantId)
+                .orElse(null);
+
+        if (progress == null) {
+            // 진도 기록이 없으면 빈 응답 반환 (아직 학습 시작 안 함)
+            return new ItemProgressResponse(null, enrollmentId, itemId, 0, 0, false, null, 0);
+        }
+
+        return ItemProgressResponse.from(progress);
+    }
+
+    @Override
+    @Transactional
+    public ItemProgressResponse updateItemProgress(
+            Long enrollmentId,
+            Long itemId,
+            UpdateItemProgressRequest request,
+            Long userId,
+            boolean isAdmin
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 수강 정보 확인 및 권한 검증
+        getEnrollmentWithAccessCheck(enrollmentId, userId, isAdmin, tenantId);
+
+        // 기존 진도 조회 또는 새로 생성 (tenantId는 @PrePersist에서 자동 설정됨)
+        ItemProgress progress = itemProgressRepository
+                .findByEnrollmentIdAndItemIdAndTenantId(enrollmentId, itemId, tenantId)
+                .orElseGet(() -> ItemProgress.create(enrollmentId, itemId));
+
+        // 진도 업데이트
+        progress.updateProgress(
+                request.progressPercent(),
+                request.watchedSeconds(),
+                request.lastPositionSeconds()
+        );
+
+        ItemProgress saved = itemProgressRepository.save(progress);
+
+        log.info("Updated item progress: enrollmentId={}, itemId={}, progressPercent={}",
+                enrollmentId, itemId, request.progressPercent());
+
+        // 전체 수강 진도율 업데이트
+        updateEnrollmentProgress(enrollmentId, tenantId);
+
+        return ItemProgressResponse.from(saved);
+    }
+
+    @Override
+    @Transactional
+    public ItemProgressResponse markItemComplete(Long enrollmentId, Long itemId, Long userId, boolean isAdmin) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 수강 정보 확인 및 권한 검증
+        getEnrollmentWithAccessCheck(enrollmentId, userId, isAdmin, tenantId);
+
+        // 기존 진도 조회 또는 새로 생성 (tenantId는 @PrePersist에서 자동 설정됨)
+        ItemProgress progress = itemProgressRepository
+                .findByEnrollmentIdAndItemIdAndTenantId(enrollmentId, itemId, tenantId)
+                .orElseGet(() -> ItemProgress.create(enrollmentId, itemId));
+
+        // 완료 처리
+        progress.markAsCompleted();
+
+        ItemProgress saved = itemProgressRepository.save(progress);
+
+        log.info("Marked item as complete: enrollmentId={}, itemId={}", enrollmentId, itemId);
+
+        // 전체 수강 진도율 업데이트
+        updateEnrollmentProgress(enrollmentId, tenantId);
+
+        return ItemProgressResponse.from(saved);
+    }
+
+    /**
+     * 수강 정보 조회 및 접근 권한 확인
+     */
+    private Enrollment getEnrollmentWithAccessCheck(Long enrollmentId, Long userId, boolean isAdmin, Long tenantId) {
+        Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, tenantId)
+                .orElseThrow(() -> new EnrollmentNotFoundException(enrollmentId));
+
+        // 본인 확인 (관리자가 아닌 경우)
+        if (!isAdmin && !enrollment.getUserId().equals(userId)) {
+            throw new UnauthorizedEnrollmentAccessException(enrollmentId, userId);
+        }
+
+        return enrollment;
+    }
+
+    /**
+     * 전체 수강 진도율 업데이트 (아이템 완료율 기반)
+     */
+    private void updateEnrollmentProgress(Long enrollmentId, Long tenantId) {
+        Double completionRate = itemProgressRepository.getCompletionRateByEnrollmentId(enrollmentId, tenantId);
+
+        if (completionRate != null) {
+            Enrollment enrollment = enrollmentRepository.findByIdAndTenantId(enrollmentId, tenantId)
+                    .orElse(null);
+
+            if (enrollment != null) {
+                enrollment.updateProgress(completionRate.intValue());
+                enrollmentRepository.save(enrollment);
+
+                log.info("Updated enrollment progress: enrollmentId={}, progressPercent={}",
+                        enrollmentId, completionRate.intValue());
+            }
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/student/service/LearnerContentAccessService.java
+++ b/src/main/java/com/mzc/lp/domain/student/service/LearnerContentAccessService.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.domain.student.service;
+
+/**
+ * 학습자의 콘텐츠 접근 권한 검증 서비스
+ * 수강 신청한 강의의 콘텐츠에 대한 접근 권한을 검증
+ */
+public interface LearnerContentAccessService {
+
+    /**
+     * 콘텐츠 접근 권한 검증
+     * - 사용자가 해당 콘텐츠가 포함된 강의에 수강 신청했는지 확인
+     *
+     * @param contentId 콘텐츠 ID
+     * @param userId 사용자 ID
+     * @param tenantId 테넌트 ID
+     * @throws com.mzc.lp.domain.student.exception.ContentAccessDeniedException 접근 권한이 없는 경우
+     */
+    void validateContentAccess(Long contentId, Long userId, Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/student/service/LearnerContentAccessServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/student/service/LearnerContentAccessServiceImpl.java
@@ -1,0 +1,66 @@
+package com.mzc.lp.domain.student.service;
+
+import com.mzc.lp.domain.student.constant.EnrollmentStatus;
+import com.mzc.lp.domain.student.exception.ContentAccessDeniedException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import java.util.List;
+
+/**
+ * 학습자의 콘텐츠 접근 권한 검증 서비스 구현
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class LearnerContentAccessServiceImpl implements LearnerContentAccessService {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public void validateContentAccess(Long contentId, Long userId, Long tenantId) {
+        boolean hasAccess = checkUserAccessToContent(userId, contentId, tenantId);
+
+        if (!hasAccess) {
+            log.warn("User {} denied access to content {} for tenant {}", userId, contentId, tenantId);
+            throw new ContentAccessDeniedException(contentId, userId);
+        }
+
+        log.debug("User {} granted access to content {} for tenant {}", userId, contentId, tenantId);
+    }
+
+    /**
+     * 사용자가 해당 콘텐츠에 접근 권한이 있는지 확인
+     * 접근 조건: 사용자가 수강 중인 강의(CourseTime)의 스냅샷에 해당 콘텐츠가 포함되어 있어야 함
+     *
+     * 조회 경로: Enrollment -> CourseTime -> Program -> Snapshot -> SnapshotItem -> SnapshotLearningObject(contentId)
+     */
+    private boolean checkUserAccessToContent(Long userId, Long contentId, Long tenantId) {
+        String jpql = """
+            SELECT COUNT(e) > 0
+            FROM Enrollment e
+            JOIN CourseTime ct ON e.courseTimeId = ct.id AND ct.tenantId = :tenantId
+            JOIN Program p ON ct.program.id = p.id AND p.tenantId = :tenantId
+            JOIN CourseSnapshot cs ON p.snapshot.id = cs.id AND cs.tenantId = :tenantId
+            JOIN SnapshotItem si ON si.snapshot.id = cs.id AND si.tenantId = :tenantId
+            JOIN SnapshotLearningObject slo ON si.snapshotLearningObject.id = slo.id AND slo.tenantId = :tenantId
+            WHERE e.userId = :userId
+            AND e.tenantId = :tenantId
+            AND e.status IN :activeStatuses
+            AND slo.contentId = :contentId
+            """;
+
+        TypedQuery<Boolean> query = entityManager.createQuery(jpql, Boolean.class);
+        query.setParameter("userId", userId);
+        query.setParameter("contentId", contentId);
+        query.setParameter("tenantId", tenantId);
+        query.setParameter("activeStatuses", List.of(EnrollmentStatus.ENROLLED, EnrollmentStatus.COMPLETED));
+
+        return query.getSingleResult();
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/student/controller/EnrollmentControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/student/controller/EnrollmentControllerTest.java
@@ -418,7 +418,7 @@ class EnrollmentControllerTest extends TenantTestSupport {
             CourseTime courseTime = createRecruitingCourseTime();
             Enrollment enrollment = createEnrollment(user.getId(), courseTime.getId());
             String accessToken = loginAndGetAccessToken("user@example.com", "Password123!");
-            UpdateProgressRequest request = new UpdateProgressRequest(50);
+            UpdateProgressRequest request = new UpdateProgressRequest(1L, 50, 0);
 
             // when & then
             mockMvc.perform(patch("/api/enrollments/{enrollmentId}/progress", enrollment.getId())

--- a/src/test/java/com/mzc/lp/domain/student/service/EnrollmentServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/student/service/EnrollmentServiceTest.java
@@ -297,7 +297,7 @@ class EnrollmentServiceTest extends TenantTestSupport {
             Long enrollmentId = 1L;
             Long userId = 1L;
             Enrollment enrollment = createTestEnrollment(userId, 1L, EnrollmentStatus.ENROLLED);
-            UpdateProgressRequest request = new UpdateProgressRequest(50);
+            UpdateProgressRequest request = new UpdateProgressRequest(1L, 50, 0);
 
             given(enrollmentRepository.findByIdAndTenantId(enrollmentId, TENANT_ID))
                     .willReturn(Optional.of(enrollment));
@@ -314,7 +314,7 @@ class EnrollmentServiceTest extends TenantTestSupport {
         void updateProgress_fail_notFound() {
             // given
             Long enrollmentId = 999L;
-            UpdateProgressRequest request = new UpdateProgressRequest(50);
+            UpdateProgressRequest request = new UpdateProgressRequest(1L, 50, 0);
 
             given(enrollmentRepository.findByIdAndTenantId(enrollmentId, TENANT_ID))
                     .willReturn(Optional.empty());


### PR DESCRIPTION
## Summary
- 학습자용 콘텐츠 스트리밍 API 구현
- 스냅샷 생성 시 외부링크 URL 저장 기능 추가
- 스냅샷 생성 시 contentId 저장 버그 수정
- 아이템별 학습 진도 관리 기능 추가
- 학습 진도율 계산을 스냅샷 아이템 기준으로 수정

## Changes
- `SnapshotLearningObject.java`: externalUrl 필드 추가
- `SnapshotLearningObjectResponse.java`: externalUrl 포함
- `SnapshotServiceImpl.java`: Content의 externalUrl 복사

## Test Plan
- [ ] 학습자용 콘텐츠 스트리밍 API 동작 확인
- [ ] 스냅샷 생성 시 externalUrl 저장 확인
- [ ] 학습 진도 저장 및 조회 확인

Closes #303