### PR TITLE
feat: 단체 계정 파일 업로드 검증 개선

### DIFF
--- a/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
@@ -199,12 +199,12 @@ public class TenantSettingsController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @Operation(summary = "네비게이션 초기화", description = "네비게이션 메뉴를 기본값으로 초기화합니다")
+    @Operation(summary = "네비게이션 초기화", description = "네비게이션 메뉴를 기본값으로 리셋합니다 (기존 항목 삭제 후 재생성)")
     @PostMapping("/navigation/reset")
     @PreAuthorize("hasRole('TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<List<NavigationItemResponse>>> resetNavigationItems() {
         Long tenantId = TenantContext.getCurrentTenantId();
-        List<NavigationItemResponse> response = tenantSettingsService.initializeDefaultNavigationItems(tenantId);
+        List<NavigationItemResponse> response = tenantSettingsService.resetNavigationItems(tenantId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsService.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsService.java
@@ -106,6 +106,13 @@ public interface TenantSettingsService {
      */
     List<NavigationItemResponse> initializeDefaultNavigationItems(Long tenantId);
 
+    /**
+     * 네비게이션 항목을 기본값으로 리셋 (기존 항목 삭제 후 재생성)
+     * @param tenantId 테넌트 ID
+     * @return 리셋된 항목 목록
+     */
+    List<NavigationItemResponse> resetNavigationItems(Long tenantId);
+
     // ============================================
     // 공개 브랜딩 정보 (인증 불필요)
     // ============================================

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsServiceImpl.java
@@ -259,12 +259,11 @@ public class TenantSettingsServiceImpl implements TenantSettingsService {
                     .toList();
         }
 
-        // 기본 네비게이션 항목 생성
+        // 기본 네비게이션 항목 생성 (TU 홈페이지 기본 메뉴와 일치)
         List<NavigationItem> defaultItems = new ArrayList<>();
-        defaultItems.add(NavigationItem.createDefault(tenant, "홈", "Home", "/", 1));
-        defaultItems.add(NavigationItem.createDefault(tenant, "강좌", "BookOpen", "/courses", 2));
-        defaultItems.add(NavigationItem.createDefault(tenant, "내 학습", "Award", "/my-learning", 3));
-        defaultItems.add(NavigationItem.createDefault(tenant, "도움말", "HelpCircle", "/help", 4));
+        defaultItems.add(NavigationItem.createDefault(tenant, "강의 탐색", "BookOpen", "/tu/b2c/courses", 1));
+        defaultItems.add(NavigationItem.createDefault(tenant, "로드맵", "Map", "/tu/b2c/roadmaps", 2));
+        defaultItems.add(NavigationItem.createDefault(tenant, "커뮤니티", "Users", "/tu/b2c/community", 3));
 
         try {
             List<NavigationItem> saved = navigationItemRepository.saveAll(defaultItems);
@@ -279,6 +278,28 @@ public class TenantSettingsServiceImpl implements TenantSettingsService {
                     .map(NavigationItemResponse::from)
                     .toList();
         }
+    }
+
+    @Override
+    @Transactional
+    public List<NavigationItemResponse> resetNavigationItems(Long tenantId) {
+        Tenant tenant = tenantRepository.findById(tenantId)
+                .orElseThrow(() -> new TenantDomainNotFoundException("Tenant not found: " + tenantId));
+
+        // 기존 네비게이션 항목 모두 삭제
+        navigationItemRepository.deleteAllByTenantId(tenantId);
+        navigationItemRepository.flush();
+
+        // 기본 네비게이션 항목 생성 (TU 홈페이지 기본 메뉴와 일치)
+        List<NavigationItem> defaultItems = new ArrayList<>();
+        defaultItems.add(NavigationItem.createDefault(tenant, "강의 탐색", "BookOpen", "/tu/b2c/courses", 1));
+        defaultItems.add(NavigationItem.createDefault(tenant, "로드맵", "Map", "/tu/b2c/roadmaps", 2));
+        defaultItems.add(NavigationItem.createDefault(tenant, "커뮤니티", "Users", "/tu/b2c/community", 3));
+
+        List<NavigationItem> saved = navigationItemRepository.saveAll(defaultItems);
+        return saved.stream()
+                .map(NavigationItemResponse::from)
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/FileParseResult.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/FileParseResult.java
@@ -1,0 +1,39 @@
+package com.mzc.lp.domain.user.dto.request;
+
+import java.util.List;
+
+/**
+ * 파일 파싱 결과를 담는 DTO
+ */
+public record FileParseResult(
+        List<FileUserRow> users,
+        List<ParseError> errors,
+        boolean hasHeaderError
+) {
+    public record ParseError(
+            int rowNumber,
+            String field,
+            String value,
+            String message
+    ) {}
+
+    public static FileParseResult success(List<FileUserRow> users) {
+        return new FileParseResult(users, List.of(), false);
+    }
+
+    public static FileParseResult withErrors(List<FileUserRow> users, List<ParseError> errors) {
+        return new FileParseResult(users, errors, false);
+    }
+
+    public static FileParseResult headerError(String message) {
+        return new FileParseResult(
+                List.of(),
+                List.of(new ParseError(1, "header", "", message)),
+                true
+        );
+    }
+
+    public boolean hasErrors() {
+        return !errors.isEmpty();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/dto/response/BulkCreateUsersResponse.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/response/BulkCreateUsersResponse.java
@@ -25,8 +25,13 @@ public record BulkCreateUsersResponse(
 
     public record FailedUserInfo(
             String email,
-            String reason
-    ) {}
+            String reason,
+            Integer rowNumber  // 파일에서 실패한 행 번호 (nullable)
+    ) {
+        public FailedUserInfo(String email, String reason) {
+            this(email, reason, null);
+        }
+    }
 
     public record AutoLinkedUserInfo(
             Long userId,

--- a/src/main/java/com/mzc/lp/domain/user/util/UserExcelParser.java
+++ b/src/main/java/com/mzc/lp/domain/user/util/UserExcelParser.java
@@ -1,5 +1,7 @@
 package com.mzc.lp.domain.user.util;
 
+import com.mzc.lp.domain.user.dto.request.FileParseResult;
+import com.mzc.lp.domain.user.dto.request.FileParseResult.ParseError;
 import com.mzc.lp.domain.user.dto.request.FileUserRow;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.*;
@@ -12,15 +14,124 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Component
 public class UserExcelParser {
 
     private static final int MAX_ROWS = 500;
+    private static final Pattern EMAIL_PATTERN = Pattern.compile(
+            "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+    );
 
+    // 허용되는 헤더명 (대소문자 무시, 한글/영문 모두 지원)
+    private static final Set<String> EMAIL_HEADERS = Set.of("email", "이메일", "e-mail", "메일");
+    private static final Set<String> NAME_HEADERS = Set.of("name", "이름", "성명", "사용자명");
+    private static final Set<String> PASSWORD_HEADERS = Set.of("password", "비밀번호", "패스워드", "pw");
+    private static final Set<String> PHONE_HEADERS = Set.of("phone", "전화번호", "휴대폰", "연락처", "tel");
+
+    /**
+     * Excel 파일 파싱 (헤더 기반 매핑, 검증 포함)
+     */
+    public FileParseResult parseExcelWithValidation(MultipartFile file) throws IOException {
+        List<FileUserRow> users = new ArrayList<>();
+        List<ParseError> errors = new ArrayList<>();
+
+        try (InputStream is = file.getInputStream();
+             Workbook workbook = new XSSFWorkbook(is)) {
+
+            Sheet sheet = workbook.getSheetAt(0);
+            Iterator<Row> rowIterator = sheet.iterator();
+
+            // 헤더 행 파싱
+            if (!rowIterator.hasNext()) {
+                return FileParseResult.headerError("파일이 비어있습니다");
+            }
+
+            Row headerRow = rowIterator.next();
+            Map<String, Integer> columnMap = parseHeaderRow(headerRow);
+
+            // 필수 컬럼 검증
+            if (!columnMap.containsKey("email")) {
+                return FileParseResult.headerError("필수 컬럼 'email'이 없습니다. 헤더에 'email' 또는 '이메일' 컬럼을 추가해주세요.");
+            }
+
+            int rowCount = 0;
+            while (rowIterator.hasNext()) {
+                Row row = rowIterator.next();
+                int rowNum = row.getRowNum() + 1; // 1-based for user display
+
+                if (rowCount >= MAX_ROWS) {
+                    log.warn("Maximum row limit ({}) exceeded, stopping parsing", MAX_ROWS);
+                    errors.add(new ParseError(rowNum, "system", "",
+                            String.format("최대 %d개 행까지만 처리됩니다", MAX_ROWS)));
+                    break;
+                }
+
+                FileUserRow userRow = parseDataRow(row, columnMap, rowNum, errors);
+                if (userRow != null) {
+                    users.add(userRow);
+                    rowCount++;
+                }
+            }
+        }
+
+        return FileParseResult.withErrors(users, errors);
+    }
+
+    /**
+     * CSV 파일 파싱 (헤더 기반 매핑, 검증 포함)
+     */
+    public FileParseResult parseCsvWithValidation(MultipartFile file) throws IOException {
+        List<FileUserRow> users = new ArrayList<>();
+        List<ParseError> errors = new ArrayList<>();
+
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8))) {
+
+            // 헤더 행 읽기
+            String headerLine = reader.readLine();
+            if (headerLine == null || headerLine.isBlank()) {
+                return FileParseResult.headerError("파일이 비어있습니다");
+            }
+
+            Map<String, Integer> columnMap = parseCsvHeader(headerLine);
+
+            // 필수 컬럼 검증
+            if (!columnMap.containsKey("email")) {
+                return FileParseResult.headerError("필수 컬럼 'email'이 없습니다. 헤더에 'email' 또는 '이메일' 컬럼을 추가해주세요.");
+            }
+
+            String line;
+            int lineNum = 1; // 헤더가 1, 데이터는 2부터
+            int rowCount = 0;
+
+            while ((line = reader.readLine()) != null) {
+                lineNum++;
+
+                if (rowCount >= MAX_ROWS) {
+                    log.warn("Maximum row limit ({}) exceeded, stopping parsing", MAX_ROWS);
+                    errors.add(new ParseError(lineNum, "system", "",
+                            String.format("최대 %d개 행까지만 처리됩니다", MAX_ROWS)));
+                    break;
+                }
+
+                FileUserRow userRow = parseCsvDataLine(line, columnMap, lineNum, errors);
+                if (userRow != null) {
+                    users.add(userRow);
+                    rowCount++;
+                }
+            }
+        }
+
+        return FileParseResult.withErrors(users, errors);
+    }
+
+    /**
+     * 기존 Excel 파싱 메서드 (하위 호환 - 고정 컬럼 순서)
+     */
     public List<FileUserRow> parseExcel(MultipartFile file) throws IOException {
         List<FileUserRow> users = new ArrayList<>();
 
@@ -41,7 +152,7 @@ public class UserExcelParser {
                     break;
                 }
 
-                FileUserRow userRow = parseRow(row);
+                FileUserRow userRow = parseRowLegacy(row);
                 if (userRow != null && userRow.email() != null && !userRow.email().isBlank()) {
                     users.add(userRow);
                     rowCount++;
@@ -52,6 +163,9 @@ public class UserExcelParser {
         return users;
     }
 
+    /**
+     * 기존 CSV 파싱 메서드 (하위 호환 - 고정 컬럼 순서)
+     */
     public List<FileUserRow> parseCsv(MultipartFile file) throws IOException {
         List<FileUserRow> users = new ArrayList<>();
 
@@ -75,7 +189,7 @@ public class UserExcelParser {
                     break;
                 }
 
-                FileUserRow userRow = parseCsvLine(line);
+                FileUserRow userRow = parseCsvLineLegacy(line);
                 if (userRow != null && userRow.email() != null && !userRow.email().isBlank()) {
                     users.add(userRow);
                     rowCount++;
@@ -86,7 +200,162 @@ public class UserExcelParser {
         return users;
     }
 
-    private FileUserRow parseRow(Row row) {
+    // ========== Private Helper Methods ==========
+
+    private Map<String, Integer> parseHeaderRow(Row headerRow) {
+        Map<String, Integer> columnMap = new HashMap<>();
+
+        for (Cell cell : headerRow) {
+            String headerValue = getCellValueAsString(cell);
+            if (headerValue == null || headerValue.isBlank()) {
+                continue;
+            }
+
+            String normalizedHeader = headerValue.trim().toLowerCase();
+            int colIndex = cell.getColumnIndex();
+
+            if (matchesAny(normalizedHeader, EMAIL_HEADERS)) {
+                columnMap.put("email", colIndex);
+            } else if (matchesAny(normalizedHeader, NAME_HEADERS)) {
+                columnMap.put("name", colIndex);
+            } else if (matchesAny(normalizedHeader, PASSWORD_HEADERS)) {
+                columnMap.put("password", colIndex);
+            } else if (matchesAny(normalizedHeader, PHONE_HEADERS)) {
+                columnMap.put("phone", colIndex);
+            }
+        }
+
+        log.debug("Parsed header columns: {}", columnMap);
+        return columnMap;
+    }
+
+    private Map<String, Integer> parseCsvHeader(String headerLine) {
+        Map<String, Integer> columnMap = new HashMap<>();
+        String[] headers = headerLine.split(",", -1);
+
+        for (int i = 0; i < headers.length; i++) {
+            String normalizedHeader = headers[i].trim().toLowerCase();
+
+            if (matchesAny(normalizedHeader, EMAIL_HEADERS)) {
+                columnMap.put("email", i);
+            } else if (matchesAny(normalizedHeader, NAME_HEADERS)) {
+                columnMap.put("name", i);
+            } else if (matchesAny(normalizedHeader, PASSWORD_HEADERS)) {
+                columnMap.put("password", i);
+            } else if (matchesAny(normalizedHeader, PHONE_HEADERS)) {
+                columnMap.put("phone", i);
+            }
+        }
+
+        log.debug("Parsed CSV header columns: {}", columnMap);
+        return columnMap;
+    }
+
+    private boolean matchesAny(String value, Set<String> candidates) {
+        return candidates.contains(value);
+    }
+
+    private FileUserRow parseDataRow(Row row, Map<String, Integer> columnMap, int rowNum, List<ParseError> errors) {
+        try {
+            String email = getColumnValue(row, columnMap, "email");
+            String name = getColumnValue(row, columnMap, "name");
+            String password = getColumnValue(row, columnMap, "password");
+            String phone = getColumnValue(row, columnMap, "phone");
+
+            // 빈 행 스킵
+            if ((email == null || email.isBlank()) && (name == null || name.isBlank())) {
+                return null;
+            }
+
+            // 이메일 필수 검증
+            if (email == null || email.isBlank()) {
+                errors.add(new ParseError(rowNum, "email", "", "이메일이 비어있습니다"));
+                return null;
+            }
+
+            // 이메일 형식 검증
+            email = email.trim().toLowerCase();
+            if (!isValidEmail(email)) {
+                errors.add(new ParseError(rowNum, "email", email, "이메일 형식이 올바르지 않습니다"));
+                return null;
+            }
+
+            return new FileUserRow(
+                    email,
+                    name != null ? name.trim() : null,
+                    password != null ? password.trim() : null,
+                    phone != null ? phone.trim() : null
+            );
+        } catch (Exception e) {
+            log.warn("Failed to parse row {}: {}", rowNum, e.getMessage());
+            errors.add(new ParseError(rowNum, "row", "", "행 파싱 실패: " + e.getMessage()));
+            return null;
+        }
+    }
+
+    private FileUserRow parseCsvDataLine(String line, Map<String, Integer> columnMap, int rowNum, List<ParseError> errors) {
+        try {
+            String[] parts = line.split(",", -1);
+
+            String email = getColumnValue(parts, columnMap, "email");
+            String name = getColumnValue(parts, columnMap, "name");
+            String password = getColumnValue(parts, columnMap, "password");
+            String phone = getColumnValue(parts, columnMap, "phone");
+
+            // 빈 행 스킵
+            if ((email == null || email.isBlank()) && (name == null || name.isBlank())) {
+                return null;
+            }
+
+            // 이메일 필수 검증
+            if (email == null || email.isBlank()) {
+                errors.add(new ParseError(rowNum, "email", "", "이메일이 비어있습니다"));
+                return null;
+            }
+
+            // 이메일 형식 검증
+            email = email.trim().toLowerCase();
+            if (!isValidEmail(email)) {
+                errors.add(new ParseError(rowNum, "email", email, "이메일 형식이 올바르지 않습니다"));
+                return null;
+            }
+
+            return new FileUserRow(
+                    email,
+                    name != null ? name.trim() : null,
+                    password != null ? password.trim() : null,
+                    phone != null ? phone.trim() : null
+            );
+        } catch (Exception e) {
+            log.warn("Failed to parse CSV line {}: {}", rowNum, e.getMessage());
+            errors.add(new ParseError(rowNum, "row", "", "행 파싱 실패: " + e.getMessage()));
+            return null;
+        }
+    }
+
+    private String getColumnValue(Row row, Map<String, Integer> columnMap, String columnName) {
+        Integer colIndex = columnMap.get(columnName);
+        if (colIndex == null) {
+            return null;
+        }
+        return getCellValueAsString(row.getCell(colIndex));
+    }
+
+    private String getColumnValue(String[] parts, Map<String, Integer> columnMap, String columnName) {
+        Integer colIndex = columnMap.get(columnName);
+        if (colIndex == null || colIndex >= parts.length) {
+            return null;
+        }
+        String value = parts[colIndex].trim();
+        return value.isEmpty() ? null : value;
+    }
+
+    private boolean isValidEmail(String email) {
+        return email != null && EMAIL_PATTERN.matcher(email).matches();
+    }
+
+    // Legacy methods (고정 컬럼 순서)
+    private FileUserRow parseRowLegacy(Row row) {
         try {
             String email = getCellValueAsString(row.getCell(0));
             String name = getCellValueAsString(row.getCell(1));
@@ -109,7 +378,7 @@ public class UserExcelParser {
         }
     }
 
-    private FileUserRow parseCsvLine(String line) {
+    private FileUserRow parseCsvLineLegacy(String line) {
         try {
             String[] parts = line.split(",", -1);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,10 +3,12 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local}
 
   datasource:
-    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:mza_newlp}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:mza_newlp}?useSSL=false&serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=UTF-8&connectionCollation=utf8mb4_unicode_ci&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD:mzanewlp123}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      connection-init-sql: "SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci"
 
   jpa:
     hibernate:
@@ -53,10 +55,10 @@ spring.h2.console:
 file:
   upload-dir: ${FILE_UPLOAD_DIR:./uploads}
   max-size:
-    video: ${FILE_MAX_SIZE_VIDEO:2147483648}      # 2GB
-    audio: ${FILE_MAX_SIZE_AUDIO:524288000}       # 500MB
+    video: ${FILE_MAX_SIZE_VIDEO:2147483648} # 2GB
+    audio: ${FILE_MAX_SIZE_AUDIO:524288000} # 500MB
     document: ${FILE_MAX_SIZE_DOCUMENT:104857600} # 100MB
-    image: ${FILE_MAX_SIZE_IMAGE:52428800}        # 50MB
+    image: ${FILE_MAX_SIZE_IMAGE:52428800} # 50MB
 
 # Spring Servlet Multipart
 spring.servlet.multipart:


### PR DESCRIPTION
## Summary

단체 계정 파일 업로드(Excel/CSV) 시 컬럼 검증 및 에러 처리를 개선했습니다.

## Related Issue

- Closes #

## Changes

- 헤더 기반 컬럼 매핑 구현 (컬럼 순서 무관)
- 한글/영문 헤더 모두 지원 (email/이메일, name/이름 등)
- 이메일 형식 검증 추가 (정규식)
- 필수 컬럼(email) 존재 여부 검증
- 파싱 에러 상세 정보 반환 (행 번호, 에러 메시지)
- FileParseResult DTO 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

기존 parseExcel/parseCsv 메서드는 하위 호환을 위해 유지하고, 새로운 parseExcelWithValidation/parseCsvWithValidation 메서드를 추가했습니다.
