### PR TITLE
feat: OPERATOR 권한으로 회원 풀 및 자동입과 규칙 관리 가능하도록 수정 (#346, #347)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/enrollment/controller/AutoEnrollmentRuleController.java
+++ b/src/main/java/com/mzc/lp/domain/enrollment/controller/AutoEnrollmentRuleController.java
@@ -64,7 +64,7 @@ public class AutoEnrollmentRuleController {
     }
 
     @PostMapping
-    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<AutoEnrollmentRuleResponse>> create(
             @AuthenticationPrincipal UserPrincipal principal,
             @Valid @RequestBody CreateAutoEnrollmentRuleRequest request
@@ -74,7 +74,7 @@ public class AutoEnrollmentRuleController {
     }
 
     @PutMapping("/{ruleId}")
-    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<AutoEnrollmentRuleResponse>> update(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long ruleId,
@@ -85,7 +85,7 @@ public class AutoEnrollmentRuleController {
     }
 
     @DeleteMapping("/{ruleId}")
-    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<Void> delete(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long ruleId
@@ -95,7 +95,7 @@ public class AutoEnrollmentRuleController {
     }
 
     @PostMapping("/{ruleId}/activate")
-    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<AutoEnrollmentRuleResponse>> activate(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long ruleId
@@ -105,7 +105,7 @@ public class AutoEnrollmentRuleController {
     }
 
     @PostMapping("/{ruleId}/deactivate")
-    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<AutoEnrollmentRuleResponse>> deactivate(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long ruleId

--- a/src/main/java/com/mzc/lp/domain/memberpool/controller/MemberPoolController.java
+++ b/src/main/java/com/mzc/lp/domain/memberpool/controller/MemberPoolController.java
@@ -80,7 +80,7 @@ public class MemberPoolController {
     }
 
     @PostMapping
-    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<MemberPoolResponse>> create(
             @AuthenticationPrincipal UserPrincipal principal,
             @Valid @RequestBody CreateMemberPoolRequest request
@@ -90,7 +90,7 @@ public class MemberPoolController {
     }
 
     @PutMapping("/{poolId}")
-    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<MemberPoolResponse>> update(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long poolId,
@@ -101,7 +101,7 @@ public class MemberPoolController {
     }
 
     @DeleteMapping("/{poolId}")
-    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<Void> delete(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long poolId
@@ -111,7 +111,7 @@ public class MemberPoolController {
     }
 
     @PostMapping("/{poolId}/activate")
-    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<MemberPoolResponse>> activate(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long poolId
@@ -121,7 +121,7 @@ public class MemberPoolController {
     }
 
     @PostMapping("/{poolId}/deactivate")
-    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<MemberPoolResponse>> deactivate(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long poolId


### PR DESCRIPTION
## Summary

OPERATOR 권한으로 회원 풀 및 자동입과 규칙을 관리할 수 있도록 권한을 확장했습니다.

기획 문서에 따르면 TO(Tenant Operator)는 일상적인 학습 운영 관리를 자율적으로 수행하고, TA(Tenant Admin)는 브랜딩/정책 설정 및 감독 역할만 수행합니다. 이에 맞춰 회원 풀과 자동입과 규칙의 CRUD 권한을 OPERATOR에게도 부여했습니다.

## Related Issue

- Closes #346
- Closes #347

## Changes

### MemberPoolController
- `POST /api/member-pools` - 회원 풀 생성 권한 추가
- `PUT /api/member-pools/{poolId}` - 회원 풀 수정 권한 추가
- `DELETE /api/member-pools/{poolId}` - 회원 풀 삭제 권한 추가
- `POST /api/member-pools/{poolId}/activate` - 회원 풀 활성화 권한 추가
- `POST /api/member-pools/{poolId}/deactivate` - 회원 풀 비활성화 권한 추가

### AutoEnrollmentRuleController
- `POST /api/auto-enrollment-rules` - 자동입과 규칙 생성 권한 추가
- `PUT /api/auto-enrollment-rules/{ruleId}` - 자동입과 규칙 수정 권한 추가
- `DELETE /api/auto-enrollment-rules/{ruleId}` - 자동입과 규칙 삭제 권한 추가
- `POST /api/auto-enrollment-rules/{ruleId}/activate` - 자동입과 규칙 활성화 권한 추가
- `POST /api/auto-enrollment-rules/{ruleId}/deactivate` - 자동입과 규칙 비활성화 권한 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Test Plan

### 테스트 방법
1. OPERATOR 권한 계정으로 로그인
2. 회원 풀 생성/수정/삭제 API 호출
3. 자동입과 규칙 생성/수정/삭제 API 호출
4. 모든 API가 정상 작동하는지 확인

### 테스트 결과
- ✅ 전체 테스트 통과 (719개)
- ✅ 컴파일 성공
- ✅ 권한 변경으로 인한 부작용 없음

## Additional Notes

- 기존에 TENANT_ADMIN만 가능했던 작업이 OPERATOR도 가능하도록 변경
- 조회 API는 이미 두 권한 모두 가능했으므로 변경 없음
- 프론트엔드에서 TO 페이지 구현 시 이 API를 사용할 수 있음