### PR TITLE
feat: 회원 풀 및 자동입과 규칙 API 응답 개선 (#348, #349)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/memberpool/dto/response/MemberPoolConditionResponse.java
+++ b/src/main/java/com/mzc/lp/domain/memberpool/dto/response/MemberPoolConditionResponse.java
@@ -5,7 +5,7 @@ import com.mzc.lp.domain.memberpool.entity.MemberPoolCondition;
 import java.util.List;
 
 public record MemberPoolConditionResponse(
-        List<Long> departments,
+        List<Long> departmentIds,
         List<String> positions,
         List<String> jobTitles,
         List<String> employeeStatuses


### PR DESCRIPTION
## Summary

회원 풀 API 응답 DTO 필드명을 프론트엔드 타입 정의와 일치하도록 수정하고, 자동입과 규칙 API 응답에 관계 데이터(부서명, 차수명)를 포함하도록 개선

## Related Issue

- Closes #348
- Closes #349

## Changes

- `MemberPoolConditionResponse`: `departments` → `departmentIds` 필드명 변경
- `AutoEnrollmentRuleServiceImpl`: `departmentName`, `courseTimeTitle` 조회 로직 추가
  - `DepartmentRepository`, `CourseTimeRepository` 의존성 주입
  - `toResponseWithRelations()` 헬퍼 메서드 추가

## Type of Change

- [x] Fix: 버그 수정

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- #349의 N+1 문제: 현재 구현은 규칙별로 개별 조회하는 방식이나, 규칙 수가 적어 성능 이슈는 없을 것으로 예상됨
- 대량 조회 시 성능 이슈가 발생하면 배치 조회 또는 JOIN FETCH 최적화 검토 필요