### PR TITLE
feat: 스냅샷 LO에 downloadable, description, pageCount 필드 추가 (#341)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/snapshot/dto/response/SnapshotLearningObjectResponse.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/dto/response/SnapshotLearningObjectResponse.java
@@ -11,6 +11,9 @@ public record SnapshotLearningObjectResponse(
         String thumbnailUrl,
         String resolution,
         String externalUrl,
+        String description,
+        Boolean downloadable,
+        Integer pageCount,
         Boolean isCustomized
 ) {
     public static SnapshotLearningObjectResponse from(SnapshotLearningObject slo) {
@@ -26,6 +29,9 @@ public record SnapshotLearningObjectResponse(
                 slo.getThumbnailUrl(),
                 slo.getResolution(),
                 slo.getExternalUrl(),
+                slo.getDescription(),
+                slo.getDownloadable(),
+                slo.getPageCount(),
                 slo.getIsCustomized()
         );
     }

--- a/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotLearningObject.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/entity/SnapshotLearningObject.java
@@ -50,6 +50,12 @@ public class SnapshotLearningObject extends TenantEntity {
     @Column(name = "external_url", length = 2000)
     private String externalUrl;
 
+    @Column(name = "description", length = 500)
+    private String description;
+
+    @Column(name = "downloadable")
+    private Boolean downloadable;
+
     @Column(name = "is_customized", nullable = false)
     private Boolean isCustomized;
 
@@ -66,7 +72,8 @@ public class SnapshotLearningObject extends TenantEntity {
                                                        String displayName, Integer duration,
                                                        String thumbnailUrl, String resolution,
                                                        String codec, Long bitrate, Integer pageCount,
-                                                       String externalUrl) {
+                                                       String externalUrl, String description,
+                                                       Boolean downloadable) {
         SnapshotLearningObject slo = new SnapshotLearningObject();
         slo.sourceLoId = sourceLoId;
         slo.contentId = contentId;
@@ -78,6 +85,8 @@ public class SnapshotLearningObject extends TenantEntity {
         slo.bitrate = bitrate;
         slo.pageCount = pageCount;
         slo.externalUrl = externalUrl;
+        slo.description = description;
+        slo.downloadable = downloadable;
         slo.isCustomized = false;
         return slo;
     }

--- a/src/main/java/com/mzc/lp/domain/snapshot/service/SnapshotServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/snapshot/service/SnapshotServiceImpl.java
@@ -271,6 +271,7 @@ public class SnapshotServiceImpl implements SnapshotService {
                             : courseItem.getItemName();
 
                     // createFromLo를 사용하여 올바른 contentId와 sourceLoId 설정
+                    // description은 CourseItem에서 가져옴 (강의 디자인 시 설정한 값)
                     snapshotLo = SnapshotLearningObject.createFromLo(
                             courseItem.getLearningObjectId(),  // sourceLoId
                             content.getId(),                   // 실제 contentId
@@ -281,7 +282,9 @@ public class SnapshotServiceImpl implements SnapshotService {
                             null,  // codec - Content에 없음
                             null,  // bitrate - Content에 없음
                             content.getPageCount(),
-                            content.getExternalUrl()           // 외부링크 URL
+                            content.getExternalUrl(),          // 외부링크 URL
+                            courseItem.getDescription(),       // 강의 디자인 시 설정한 설명
+                            content.getDownloadable()          // 다운로드 허용 여부
                     );
                     snapshotLo = snapshotLoRepository.save(snapshotLo);
 


### PR DESCRIPTION
## Summary
- SnapshotLearningObject 엔티티에 downloadable, description 필드 추가
- SnapshotLearningObjectResponse DTO에 pageCount 필드 추가
- 스냅샷 생성 시 Content에서 downloadable, pageCount 값 복사
- CourseItem의 description 값을 스냅샷으로 복사 (강의 설계 시 설정한 설명)

## Test plan
- [ ] 차수 생성 오류 해결 후 테스트 예정
- [ ] 강의 발행 시 스냅샷 생성 확인
- [ ] 스냅샷 아이템 조회 시 downloadable, description, pageCount 필드 반환 확인

Closes #341