### PR TITLE
fix: 리뷰 수정 API에 PATCH 메서드 지원 추가

### DIFF
--- a/src/main/java/com/mzc/lp/domain/course/controller/CourseReviewController.java
+++ b/src/main/java/com/mzc/lp/domain/course/controller/CourseReviewController.java
@@ -86,9 +86,9 @@ public class CourseReviewController {
 
     /**
      * 리뷰 수정
-     * PUT /api/times/{timeId}/reviews/{reviewId}
+     * PUT/PATCH /api/times/{timeId}/reviews/{reviewId}
      */
-    @PutMapping("/{reviewId}")
+    @RequestMapping(value = "/{reviewId}", method = {RequestMethod.PUT, RequestMethod.PATCH})
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<CourseReviewResponse>> updateReview(
             @PathVariable Long timeId,


### PR DESCRIPTION
## Summary
- 리뷰 수정 API(`/api/times/{timeId}/reviews/{reviewId}`)에 PATCH 메서드 지원 추가
- 기존 PUT 메서드와 함께 PATCH 메서드도 사용 가능하도록 변경

## Changes
- `@PutMapping` → `@RequestMapping(method = {PUT, PATCH})` 변경

## Why
- 프론트엔드에서 리뷰 수정 시 PATCH 메서드 사용
- PUT만 지원하여 500 Internal Server Error 발생
- RESTful API 관례상 부분 수정은 PATCH 사용이 일반적

## Test
- [x] PATCH `/api/times/{timeId}/reviews/{reviewId}` 정상 동작 확인
- [x] PUT `/api/times/{timeId}/reviews/{reviewId}` 기존 동작 유지 확인

## Related
- 프론트엔드 리뷰 수정 기능 호환성 개선