### PR TITLE
feat: 진도율 100% 달성 시 자동 수료 처리 (#353)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/student/service/ItemProgressServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/student/service/ItemProgressServiceImpl.java
@@ -186,6 +186,13 @@ public class ItemProgressServiceImpl implements ItemProgressService {
 
         // 5. 진도율 업데이트
         enrollment.updateProgress(progressPercent);
+
+        // 6. 진도율 100% 달성 시 자동 수료 처리
+        if (progressPercent == 100 && !enrollment.isCompleted()) {
+            enrollment.complete(null); // 점수 없이 수료 처리
+            log.info("Auto-completed enrollment: enrollmentId={}", enrollmentId);
+        }
+
         enrollmentRepository.save(enrollment);
 
         log.info("Updated enrollment progress: enrollmentId={}, completedItems={}/{}, progressPercent={}",


### PR DESCRIPTION
## Summary
- 학습 진도율이 100%에 도달하면 자동으로 수료 처리되도록 구현

## Changes
- `ItemProgressServiceImpl.updateProgress()`: 진도율 100% 달성 시 enrollment.complete() 호출
- enrollment의 status가 COMPLETED로 변경되고, completedAt 타임스탬프 기록

## Test Plan
- [x] 진도율 100% 달성 시 자동 수료 처리 확인
- [x] 기존 진도 업데이트 로직 정상 동작 확인

Closes #353