### PR TITLE
feat: 공지사항 배포 통계 API 구현

### DIFF
--- a/src/main/java/com/mzc/lp/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/mzc/lp/domain/notice/controller/NoticeController.java
@@ -6,6 +6,8 @@ import com.mzc.lp.domain.notice.constant.NoticeType;
 import com.mzc.lp.domain.notice.dto.request.CreateNoticeRequest;
 import com.mzc.lp.domain.notice.dto.request.DistributeNoticeRequest;
 import com.mzc.lp.domain.notice.dto.request.UpdateNoticeRequest;
+import com.mzc.lp.domain.notice.dto.response.NoticeDistributionStatsResponse;
+import com.mzc.lp.domain.notice.dto.response.NoticeDistributionSummaryResponse;
 import com.mzc.lp.domain.notice.dto.response.NoticeResponse;
 import com.mzc.lp.domain.notice.service.NoticeService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -134,5 +136,34 @@ public class NoticeController {
     ) {
         List<Long> tenantIds = noticeService.getDistributedTenantIds(noticeId);
         return ResponseEntity.ok(ApiResponse.success(tenantIds));
+    }
+
+    // ============================================
+    // 배포 통계 API
+    // ============================================
+
+    @Operation(summary = "배포 통계 목록 조회", description = "발행된 공지사항들의 배포 통계를 조회합니다")
+    @GetMapping("/distributions")
+    public ResponseEntity<ApiResponse<Page<NoticeDistributionStatsResponse>>> getDistributionStats(
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<NoticeDistributionStatsResponse> response = noticeService.getDistributionStats(pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "배포 통계 요약 조회", description = "전체 배포 통계 요약을 조회합니다")
+    @GetMapping("/distributions/summary")
+    public ResponseEntity<ApiResponse<NoticeDistributionSummaryResponse>> getDistributionSummary() {
+        NoticeDistributionSummaryResponse response = noticeService.getDistributionSummary();
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "특정 공지 배포 상세 조회", description = "특정 공지사항의 테넌트별 배포 현황을 조회합니다")
+    @GetMapping("/{noticeId}/distributions")
+    public ResponseEntity<ApiResponse<NoticeDistributionStatsResponse>> getDistributionStatsForNotice(
+            @PathVariable Long noticeId
+    ) {
+        NoticeDistributionStatsResponse response = noticeService.getDistributionStatsForNotice(noticeId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/notice/dto/response/NoticeDistributionStatsResponse.java
+++ b/src/main/java/com/mzc/lp/domain/notice/dto/response/NoticeDistributionStatsResponse.java
@@ -1,0 +1,58 @@
+package com.mzc.lp.domain.notice.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * 공지사항 배포 통계 응답 DTO
+ */
+public record NoticeDistributionStatsResponse(
+        Long noticeId,
+        String noticeTitle,
+        String noticeType,
+        String noticeStatus,
+        Boolean isPinned,
+        Integer totalTenants,
+        Integer sentCount,
+        Integer readCount,
+        Instant publishedAt,
+        Instant createdAt,
+        List<TenantDistributionInfo> tenantDistributions
+) {
+    public record TenantDistributionInfo(
+            Long tenantId,
+            String tenantName,
+            String tenantCode,
+            Boolean isRead,
+            Instant distributedAt,
+            Instant readAt
+    ) {}
+
+    public static NoticeDistributionStatsResponse of(
+            Long noticeId,
+            String noticeTitle,
+            String noticeType,
+            String noticeStatus,
+            Boolean isPinned,
+            Integer totalTenants,
+            Integer sentCount,
+            Integer readCount,
+            Instant publishedAt,
+            Instant createdAt,
+            List<TenantDistributionInfo> tenantDistributions
+    ) {
+        return new NoticeDistributionStatsResponse(
+                noticeId,
+                noticeTitle,
+                noticeType,
+                noticeStatus,
+                isPinned,
+                totalTenants,
+                sentCount,
+                readCount,
+                publishedAt,
+                createdAt,
+                tenantDistributions
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notice/dto/response/NoticeDistributionSummaryResponse.java
+++ b/src/main/java/com/mzc/lp/domain/notice/dto/response/NoticeDistributionSummaryResponse.java
@@ -1,0 +1,31 @@
+package com.mzc.lp.domain.notice.dto.response;
+
+/**
+ * 공지사항 배포 요약 통계 응답 DTO
+ */
+public record NoticeDistributionSummaryResponse(
+        Integer totalDistributions,
+        Integer completedCount,
+        Integer inProgressCount,
+        Integer totalTenants,
+        Integer totalReadCount,
+        Double averageReadRate
+) {
+    public static NoticeDistributionSummaryResponse of(
+            Integer totalDistributions,
+            Integer completedCount,
+            Integer inProgressCount,
+            Integer totalTenants,
+            Integer totalReadCount,
+            Double averageReadRate
+    ) {
+        return new NoticeDistributionSummaryResponse(
+                totalDistributions,
+                completedCount,
+                inProgressCount,
+                totalTenants,
+                totalReadCount,
+                averageReadRate
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notice/repository/NoticeDistributionRepository.java
+++ b/src/main/java/com/mzc/lp/domain/notice/repository/NoticeDistributionRepository.java
@@ -41,4 +41,13 @@ public interface NoticeDistributionRepository extends JpaRepository<NoticeDistri
     @Modifying
     @Query("DELETE FROM NoticeDistribution nd WHERE nd.notice.id = :noticeId")
     void deleteByNoticeId(@Param("noticeId") Long noticeId);
+
+    @Query("SELECT COUNT(nd) FROM NoticeDistribution nd WHERE nd.notice.id = :noticeId AND nd.isRead = true")
+    long countReadByNoticeId(@Param("noticeId") Long noticeId);
+
+    @Query("SELECT nd FROM NoticeDistribution nd JOIN FETCH nd.notice WHERE nd.notice.id = :noticeId")
+    List<NoticeDistribution> findByNoticeIdWithNotice(@Param("noticeId") Long noticeId);
+
+    @Query("SELECT DISTINCT nd.notice.id FROM NoticeDistribution nd WHERE nd.notice.status = 'PUBLISHED'")
+    List<Long> findDistributedNoticeIds();
 }

--- a/src/main/java/com/mzc/lp/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/mzc/lp/domain/notice/repository/NoticeRepository.java
@@ -35,4 +35,6 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     Page<Notice> searchByKeywordAndStatus(@Param("keyword") String keyword,
                                           @Param("status") NoticeStatus status,
                                           Pageable pageable);
+
+    long countByStatus(NoticeStatus status);
 }

--- a/src/main/java/com/mzc/lp/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/mzc/lp/domain/notice/service/NoticeService.java
@@ -5,6 +5,8 @@ import com.mzc.lp.domain.notice.constant.NoticeType;
 import com.mzc.lp.domain.notice.dto.request.CreateNoticeRequest;
 import com.mzc.lp.domain.notice.dto.request.DistributeNoticeRequest;
 import com.mzc.lp.domain.notice.dto.request.UpdateNoticeRequest;
+import com.mzc.lp.domain.notice.dto.response.NoticeDistributionStatsResponse;
+import com.mzc.lp.domain.notice.dto.response.NoticeDistributionSummaryResponse;
 import com.mzc.lp.domain.notice.dto.response.NoticeResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -42,4 +44,11 @@ public interface NoticeService {
     NoticeResponse getNoticeForTenant(Long noticeId, Long tenantId);
 
     void markNoticeAsRead(Long noticeId, Long tenantId);
+
+    // 배포 통계 (SA용)
+    Page<NoticeDistributionStatsResponse> getDistributionStats(Pageable pageable);
+
+    NoticeDistributionStatsResponse getDistributionStatsForNotice(Long noticeId);
+
+    NoticeDistributionSummaryResponse getDistributionSummary();
 }


### PR DESCRIPTION
## Summary

확장 브랜딩 설정 API를 추가했습니다. TA에서 배너, 랜딩페이지, 사이드바 설정을 저장하고 TU/TO에서 조회할 수 있습니다.

## Related Issue

- Closes #

## Changes

- TenantSettings 엔티티에 확장 브랜딩 필드 추가
  - companyName, bannerSettings, landingPageSettings
  - sidebarTUSettings, sidebarTOSettings
- UpdateExtendedBrandingRequest DTO 추가
- PUT /api/tenant/settings/branding/extended 엔드포인트 추가
- PublicLayoutResponse에 확장 브랜딩 필드 포함
- X-Subdomain 헤더 기반 테넌트 식별 지원

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)



## Additional Notes

- DB 컬럼이 자동 생성됩니다 (JPA ddl-auto: update)
- 프론트엔드 PR과 함께 머지되어야 합니다
