### PR TITLE
feat: 확장 브랜딩 설정 추가 (배너, 랜딩페이지, 사이드바)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/controller/TenantSettingsController.java
@@ -4,6 +4,7 @@ import com.mzc.lp.common.context.TenantContext;
 import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.domain.tenant.dto.request.NavigationItemRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateDesignSettingsRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateExtendedBrandingRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateLayoutSettingsRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateTenantFeaturesRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateTenantSettingsRequest;
@@ -102,6 +103,17 @@ public class TenantSettingsController {
                 null, null, null, null, null, null, null
         );
         TenantSettingsResponse response = tenantSettingsService.updateSettings(tenantId, brandingRequest);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "확장 브랜딩 설정 업데이트", description = "배너, 랜딩페이지, 사이드바 등 확장 브랜딩 설정을 업데이트합니다")
+    @PutMapping("/branding/extended")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<TenantSettingsResponse>> updateExtendedBrandingSettings(
+            @Valid @RequestBody UpdateExtendedBrandingRequest request
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        TenantSettingsResponse response = tenantSettingsService.updateExtendedBrandingSettings(tenantId, request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateExtendedBrandingRequest.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateExtendedBrandingRequest.java
@@ -1,0 +1,23 @@
+package com.mzc.lp.domain.tenant.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+import java.util.Map;
+
+/**
+ * 확장 브랜딩 설정 업데이트 요청 DTO
+ * 배너, 랜딩페이지, 사이드바 설정 등
+ */
+public record UpdateExtendedBrandingRequest(
+        @Size(max = 200)
+        String companyName,
+
+        Map<String, Object> bannerSettings,
+
+        Map<String, Object> landingPageSettings,
+
+        Map<String, Object> sidebarTUSettings,
+
+        Map<String, Object> sidebarCOSettings
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/response/PublicLayoutResponse.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/response/PublicLayoutResponse.java
@@ -13,7 +13,13 @@ public record PublicLayoutResponse(
         Map<String, Object> headerSettings,
         Map<String, Object> footerSettings,
         Map<String, Object> contentSettings,
-        List<NavigationItemResponse> navigationItems
+        List<NavigationItemResponse> navigationItems,
+        // 확장 브랜딩 설정
+        String companyName,
+        Map<String, Object> bannerSettings,
+        Map<String, Object> landingPageSettings,
+        Map<String, Object> sidebarTUSettings,
+        Map<String, Object> sidebarCOSettings
 ) {
     public static PublicLayoutResponse from(
             TenantSettings settings,
@@ -23,7 +29,12 @@ public record PublicLayoutResponse(
                 settings.getHeaderSettings(),
                 settings.getFooterSettings(),
                 settings.getContentSettings(),
-                navigationItems
+                navigationItems,
+                settings.getCompanyName(),
+                settings.getBannerSettings(),
+                settings.getLandingPageSettings(),
+                settings.getSidebarTUSettings(),
+                settings.getSidebarCOSettings()
         );
     }
 
@@ -49,7 +60,12 @@ public record PublicLayoutResponse(
                         "maxWidth", "xl",
                         "padding", "normal"
                 ),
-                List.of()
+                List.of(),
+                null,
+                null,
+                null,
+                null,
+                null
         );
     }
 }

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/response/TenantSettingsResponse.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/response/TenantSettingsResponse.java
@@ -29,6 +29,13 @@ public record TenantSettingsResponse(
         Map<String, Object> footerSettings,
         Map<String, Object> contentSettings,
 
+        // 확장 브랜딩 설정
+        String companyName,
+        Map<String, Object> bannerSettings,
+        Map<String, Object> landingPageSettings,
+        Map<String, Object> sidebarTUSettings,
+        Map<String, Object> sidebarCOSettings,
+
         // 일반 설정
         String defaultLanguage,
         String timezone,
@@ -70,6 +77,11 @@ public record TenantSettingsResponse(
                 settings.getSidebarSettings(),
                 settings.getFooterSettings(),
                 settings.getContentSettings(),
+                settings.getCompanyName(),
+                settings.getBannerSettings(),
+                settings.getLandingPageSettings(),
+                settings.getSidebarTUSettings(),
+                settings.getSidebarCOSettings(),
                 settings.getDefaultLanguage(),
                 settings.getTimezone(),
                 settings.getAllowSelfRegistration(),

--- a/src/main/java/com/mzc/lp/domain/tenant/entity/TenantSettings.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/entity/TenantSettings.java
@@ -57,6 +57,29 @@ public class TenantSettings extends BaseTimeEntity {
     private String bodyFont;
 
     // ============================================
+    // 확장 브랜딩 설정
+    // ============================================
+
+    @Column(length = 200)
+    private String companyName;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json")
+    private Map<String, Object> bannerSettings = new HashMap<>();
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json")
+    private Map<String, Object> landingPageSettings = new HashMap<>();
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json")
+    private Map<String, Object> sidebarTUSettings = new HashMap<>();
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json")
+    private Map<String, Object> sidebarCOSettings = new HashMap<>();
+
+    // ============================================
     // 레이아웃 설정 (JSON)
     // ============================================
 
@@ -255,5 +278,18 @@ public class TenantSettings extends BaseTimeEntity {
         if (cartEnabled != null) this.cartEnabled = cartEnabled;
         if (wishlistEnabled != null) this.wishlistEnabled = wishlistEnabled;
         if (instructorTabEnabled != null) this.instructorTabEnabled = instructorTabEnabled;
+    }
+
+    // 확장 브랜딩 설정 업데이트
+    public void updateExtendedBranding(String companyName,
+                                       Map<String, Object> bannerSettings,
+                                       Map<String, Object> landingPageSettings,
+                                       Map<String, Object> sidebarTUSettings,
+                                       Map<String, Object> sidebarCOSettings) {
+        if (companyName != null) this.companyName = companyName;
+        if (bannerSettings != null) this.bannerSettings = bannerSettings;
+        if (landingPageSettings != null) this.landingPageSettings = landingPageSettings;
+        if (sidebarTUSettings != null) this.sidebarTUSettings = sidebarTUSettings;
+        if (sidebarCOSettings != null) this.sidebarCOSettings = sidebarCOSettings;
     }
 }

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsService.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsService.java
@@ -2,6 +2,7 @@ package com.mzc.lp.domain.tenant.service;
 
 import com.mzc.lp.domain.tenant.dto.request.NavigationItemRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateDesignSettingsRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateExtendedBrandingRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateLayoutSettingsRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateTenantFeaturesRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateTenantSettingsRequest;
@@ -48,6 +49,14 @@ public interface TenantSettingsService {
      * @return 업데이트된 설정
      */
     TenantSettingsResponse updateLayoutSettings(Long tenantId, UpdateLayoutSettingsRequest request);
+
+    /**
+     * 확장 브랜딩 설정 업데이트 (배너, 랜딩페이지, 사이드바 등)
+     * @param tenantId 테넌트 ID
+     * @param request 확장 브랜딩 설정 요청
+     * @return 업데이트된 설정
+     */
+    TenantSettingsResponse updateExtendedBrandingSettings(Long tenantId, UpdateExtendedBrandingRequest request);
 
     /**
      * 테넌트 설정 초기화 (기본값으로 생성)

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsServiceImpl.java
@@ -2,6 +2,7 @@ package com.mzc.lp.domain.tenant.service;
 
 import com.mzc.lp.domain.tenant.dto.request.NavigationItemRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateDesignSettingsRequest;
+import com.mzc.lp.domain.tenant.dto.request.UpdateExtendedBrandingRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateLayoutSettingsRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateTenantFeaturesRequest;
 import com.mzc.lp.domain.tenant.dto.request.UpdateTenantSettingsRequest;
@@ -128,6 +129,23 @@ public class TenantSettingsServiceImpl implements TenantSettingsService {
                 request.sidebarSettings(),
                 request.footerSettings(),
                 request.contentSettings()
+        );
+
+        return TenantSettingsResponse.from(settings);
+    }
+
+    @Override
+    @Transactional
+    public TenantSettingsResponse updateExtendedBrandingSettings(Long tenantId, UpdateExtendedBrandingRequest request) {
+        TenantSettings settings = tenantSettingsRepository.findByTenantId(tenantId)
+                .orElseGet(() -> initializeAndGet(tenantId));
+
+        settings.updateExtendedBranding(
+                request.companyName(),
+                request.bannerSettings(),
+                request.landingPageSettings(),
+                request.sidebarTUSettings(),
+                request.sidebarCOSettings()
         );
 
         return TenantSettingsResponse.from(settings);


### PR DESCRIPTION
## Summary

TA에서 TU B2C 페이지의 배너, 랜딩페이지, 사이드바 설정을 관리할 수 있는 확장 브랜딩 API 추가

## Related Issue

- Closes #

## Changes

- TenantSettings 엔티티에 확장 브랜딩 필드 추가 (bannerSettings, landingPageSettings, sidebarTUSettings, sidebarCOSettings)
- UpdateExtendedBrandingRequest DTO 추가
- TenantSettingsService에 updateExtendedBrandingSettings 메서드 추가
- TenantSettingsController에 확장 브랜딩 업데이트 엔드포인트 추가
- PublicLayoutResponse에 확장 브랜딩 필드 포함
- sidebarTO → sidebarCO 네이밍 변경

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

- 프론트엔드 PR: https://github.com/mzcATU/mzc-lp-frontend/pull/394