### PR TITLE
feat(course): Course 상태 전환 재설계 (Phase 1)

### DIFF
--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -43,6 +43,8 @@ public enum ErrorCode {
     CM_ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CM015", "Announcement not found"),
     CM_NOT_ANNOUNCEMENT_AUTHOR(HttpStatus.FORBIDDEN, "CM016", "Not authorized to modify this announcement"),
     CM_COURSE_INCOMPLETE(HttpStatus.BAD_REQUEST, "CM017", "Course is incomplete and cannot be published"),
+    CM_COURSE_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST, "CM018", "Course is not modifiable in current status"),
+    CM_INVALID_COURSE_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "CM019", "Invalid course status transition"),
 
     // Content (CMS)
     CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CT001", "Content not found"),

--- a/src/main/java/com/mzc/lp/domain/course/constant/CourseStatus.java
+++ b/src/main/java/com/mzc/lp/domain/course/constant/CourseStatus.java
@@ -8,7 +8,26 @@ import lombok.RequiredArgsConstructor;
 public enum CourseStatus {
 
     DRAFT("작성중"),
-    PUBLISHED("발행됨");
+    READY("작성완료"),
+    REGISTERED("등록됨");
 
     private final String description;
+
+    /**
+     * 해당 상태에서 수정이 가능한지 확인
+     * DRAFT, READY: 수정 가능
+     * REGISTERED: 수정 불가
+     */
+    public boolean isModifiable() {
+        return this == DRAFT || this == READY;
+    }
+
+    /**
+     * 해당 상태에서 차수(CourseTime) 생성이 가능한지 확인
+     * REGISTERED: 차수 생성 가능
+     * DRAFT, READY: 차수 생성 불가
+     */
+    public boolean canCreateCourseTime() {
+        return this == REGISTERED;
+    }
 }

--- a/src/main/java/com/mzc/lp/domain/course/controller/CourseController.java
+++ b/src/main/java/com/mzc/lp/domain/course/controller/CourseController.java
@@ -117,7 +117,9 @@ public class CourseController {
     /**
      * 강의 발행
      * POST /api/courses/{courseId}/publish
+     * @deprecated Use {@link #readyCourse(Long, UserPrincipal)} instead
      */
+    @Deprecated
     @PostMapping("/{courseId:\\d+}/publish")
     @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<CourseResponse>> publishCourse(
@@ -131,7 +133,9 @@ public class CourseController {
     /**
      * 강의 발행 취소
      * POST /api/courses/{courseId}/unpublish
+     * @deprecated Use {@link #unreadyCourse(Long, UserPrincipal)} instead
      */
+    @Deprecated
     @PostMapping("/{courseId:\\d+}/unpublish")
     @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<CourseResponse>> unpublishCourse(
@@ -139,6 +143,48 @@ public class CourseController {
             @AuthenticationPrincipal UserPrincipal principal
     ) {
         CourseResponse response = courseService.unpublishCourse(courseId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 강의 작성완료 (DRAFT -> READY)
+     * POST /api/courses/{courseId}/ready
+     */
+    @PostMapping("/{courseId:\\d+}/ready")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseResponse>> readyCourse(
+            @PathVariable @Positive Long courseId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseResponse response = courseService.readyCourse(courseId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 강의 작성중으로 변경 (READY -> DRAFT)
+     * POST /api/courses/{courseId}/unready
+     */
+    @PostMapping("/{courseId:\\d+}/unready")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseResponse>> unreadyCourse(
+            @PathVariable @Positive Long courseId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseResponse response = courseService.unreadyCourse(courseId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 강의 등록 (READY -> REGISTERED)
+     * POST /api/courses/{courseId}/register
+     */
+    @PostMapping("/{courseId:\\d+}/register")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseResponse>> registerCourse(
+            @PathVariable @Positive Long courseId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        CourseResponse response = courseService.registerCourse(courseId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/course/exception/CourseNotModifiableException.java
+++ b/src/main/java/com/mzc/lp/domain/course/exception/CourseNotModifiableException.java
@@ -1,0 +1,17 @@
+package com.mzc.lp.domain.course.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.domain.course.constant.CourseStatus;
+
+public class CourseNotModifiableException extends BusinessException {
+
+    public CourseNotModifiableException() {
+        super(ErrorCode.CM_COURSE_NOT_MODIFIABLE);
+    }
+
+    public CourseNotModifiableException(Long courseId, CourseStatus status) {
+        super(ErrorCode.CM_COURSE_NOT_MODIFIABLE,
+                String.format("강의(ID: %d)는 현재 상태(%s)에서 수정할 수 없습니다.", courseId, status.getDescription()));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/exception/InvalidCourseStatusTransitionException.java
+++ b/src/main/java/com/mzc/lp/domain/course/exception/InvalidCourseStatusTransitionException.java
@@ -1,0 +1,17 @@
+package com.mzc.lp.domain.course.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.domain.course.constant.CourseStatus;
+
+public class InvalidCourseStatusTransitionException extends BusinessException {
+
+    public InvalidCourseStatusTransitionException() {
+        super(ErrorCode.CM_INVALID_COURSE_STATUS_TRANSITION);
+    }
+
+    public InvalidCourseStatusTransitionException(CourseStatus from, CourseStatus to) {
+        super(ErrorCode.CM_INVALID_COURSE_STATUS_TRANSITION,
+                String.format("강의 상태를 %s에서 %s(으)로 변경할 수 없습니다.", from.getDescription(), to.getDescription()));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseService.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseService.java
@@ -58,17 +58,25 @@ public interface CourseService {
     Page<CourseResponse> getMyCourses(Long creatorId, Pageable pageable);
 
     /**
-     * 강의 발행
-     * @param courseId 강의 ID
-     * @return 발행된 강의 정보
-     * @throws com.mzc.lp.domain.course.exception.CourseIncompleteException 완성되지 않은 강의인 경우
+     * 강의를 READY 상태로 전환
      */
-    CourseResponse publishCourse(Long courseId);
+    CourseResponse readyCourse(Long courseId);
 
     /**
-     * 강의 발행 취소
-     * @param courseId 강의 ID
-     * @return 발행 취소된 강의 정보
+     * 강의를 DRAFT 상태로 전환
      */
+    CourseResponse unreadyCourse(Long courseId);
+
+    /**
+     * 강의를 REGISTERED 상태로 등록 (되돌릴 수 없음)
+     */
+    CourseResponse registerCourse(Long courseId);
+
+    /** @deprecated Use {@link #readyCourse(Long)} instead */
+    @Deprecated
+    CourseResponse publishCourse(Long courseId);
+
+    /** @deprecated Use {@link #unreadyCourse(Long)} instead */
+    @Deprecated
     CourseResponse unpublishCourse(Long courseId);
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -902,19 +902,19 @@ INSERT INTO iis_instructor_assignments (tenant_id, user_key, time_key, assigned_
  (SELECT id FROM users WHERE email = 'designer1@default.com'), NOW(), NOW(), 0);
 
 -- =============================================
--- 13. 사용자 코스 역할 데이터 INSERT (USER → DESIGNER → OWNER 흐름)
+-- 13. 사용자 코스 역할 데이터 INSERT (USER → DESIGNER 흐름)
 -- =============================================
--- creator@default.com: USER + DESIGNER + OWNER (프로그램 승인받음)
+-- creator@default.com: USER + DESIGNER (프로그램 승인받음)
 -- DESIGNER 역할 (courseId = null, 테넌트 레벨)
 INSERT INTO user_course_roles (tenant_id, user_id, course_id, role, revenue_share_percent, created_at, updated_at)
 SELECT 1, (SELECT id FROM users WHERE email = 'creator@default.com'), NULL, 'DESIGNER', NULL, NOW(), NOW();
--- OWNER 역할 (courseId = programId, 프로그램 승인 시 자동 부여)
+-- DESIGNER 역할 (courseId = programId, 프로그램별 설계자)
 INSERT INTO user_course_roles (tenant_id, user_id, course_id, role, revenue_share_percent, created_at, updated_at)
 SELECT 1, (SELECT id FROM users WHERE email = 'creator@default.com'),
- (SELECT id FROM cm_programs WHERE title = 'Spring Boot 기초 과정' AND tenant_id = 1), 'OWNER', 70, NOW(), NOW();
+ (SELECT id FROM cm_programs WHERE title = 'Spring Boot 기초 과정' AND tenant_id = 1), 'DESIGNER', 70, NOW(), NOW();
 INSERT INTO user_course_roles (tenant_id, user_id, course_id, role, revenue_share_percent, created_at, updated_at)
 SELECT 1, (SELECT id FROM users WHERE email = 'creator@default.com'),
- (SELECT id FROM cm_programs WHERE title = 'React & TypeScript 실전' AND tenant_id = 1), 'OWNER', 70, NOW(), NOW();
+ (SELECT id FROM cm_programs WHERE title = 'React & TypeScript 실전' AND tenant_id = 1), 'DESIGNER', 70, NOW(), NOW();
 
 -- designer3@default.com: USER + DESIGNER (프로그램 아직 미승인)
 -- DESIGNER 역할만 (courseId = null, 테넌트 레벨)

--- a/src/main/resources/migration/V20260113__course_status_migration.sql
+++ b/src/main/resources/migration/V20260113__course_status_migration.sql
@@ -1,0 +1,9 @@
+-- ============================================
+-- Course status 마이그레이션: PUBLISHED -> READY
+-- 적용 대상: cm_courses 테이블
+-- 날짜: 2026-01-13
+-- 이슈: #368
+-- ============================================
+
+-- 기존 PUBLISHED 상태를 READY로 변경
+UPDATE cm_courses SET status = 'READY' WHERE status = 'PUBLISHED';

--- a/src/test/java/com/mzc/lp/domain/course/entity/CourseStatusTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/entity/CourseStatusTest.java
@@ -1,0 +1,252 @@
+package com.mzc.lp.domain.course.entity;
+
+import com.mzc.lp.domain.course.constant.CourseStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Course 상태 전환 테스트")
+class CourseStatusTest {
+
+    // ===== 테스트 헬퍼 메서드 =====
+    private Course createDraftCourse() {
+        return Course.create("테스트 강의", 1L);
+    }
+
+    private Course createReadyCourse() {
+        Course course = createDraftCourse();
+        course.markAsReady();
+        return course;
+    }
+
+    private Course createRegisteredCourse() {
+        Course course = createReadyCourse();
+        course.register();
+        return course;
+    }
+
+    // ===== markAsReady 테스트 =====
+    @Nested
+    @DisplayName("markAsReady() - 작성완료 전환")
+    class MarkAsReady {
+
+        @Test
+        @DisplayName("성공 - DRAFT -> READY")
+        void markAsReady_fromDraft_success() {
+            // given
+            Course course = createDraftCourse();
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.DRAFT);
+
+            // when
+            course.markAsReady();
+
+            // then
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.READY);
+            assertThat(course.isReady()).isTrue();
+            assertThat(course.isModifiable()).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공 - READY -> READY (멱등성)")
+        void markAsReady_fromReady_success() {
+            // given
+            Course course = createReadyCourse();
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.READY);
+
+            // when
+            course.markAsReady();
+
+            // then
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.READY);
+        }
+
+        @Test
+        @DisplayName("실패 - REGISTERED 상태에서 호출")
+        void markAsReady_fromRegistered_throwsException() {
+            // given
+            Course course = createRegisteredCourse();
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.REGISTERED);
+
+            // when & then
+            assertThatThrownBy(course::markAsReady)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("수정할 수 없습니다");
+        }
+    }
+
+    // ===== markAsDraft 테스트 =====
+    @Nested
+    @DisplayName("markAsDraft() - 작성중 전환")
+    class MarkAsDraft {
+
+        @Test
+        @DisplayName("성공 - READY -> DRAFT")
+        void markAsDraft_fromReady_success() {
+            // given
+            Course course = createReadyCourse();
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.READY);
+
+            // when
+            course.markAsDraft();
+
+            // then
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.DRAFT);
+            assertThat(course.isDraft()).isTrue();
+            assertThat(course.isModifiable()).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공 - DRAFT -> DRAFT (멱등성)")
+        void markAsDraft_fromDraft_success() {
+            // given
+            Course course = createDraftCourse();
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.DRAFT);
+
+            // when
+            course.markAsDraft();
+
+            // then
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.DRAFT);
+        }
+
+        @Test
+        @DisplayName("실패 - REGISTERED 상태에서 호출")
+        void markAsDraft_fromRegistered_throwsException() {
+            // given
+            Course course = createRegisteredCourse();
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.REGISTERED);
+
+            // when & then
+            assertThatThrownBy(course::markAsDraft)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("수정할 수 없습니다");
+        }
+    }
+
+    // ===== register 테스트 =====
+    @Nested
+    @DisplayName("register() - 등록 전환")
+    class Register {
+
+        @Test
+        @DisplayName("성공 - READY -> REGISTERED")
+        void register_fromReady_success() {
+            // given
+            Course course = createReadyCourse();
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.READY);
+
+            // when
+            course.register();
+
+            // then
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.REGISTERED);
+            assertThat(course.isRegistered()).isTrue();
+            assertThat(course.isModifiable()).isFalse();
+            assertThat(course.canCreateCourseTime()).isTrue();
+        }
+
+        @Test
+        @DisplayName("실패 - DRAFT 상태에서 호출")
+        void register_fromDraft_throwsException() {
+            // given
+            Course course = createDraftCourse();
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.DRAFT);
+
+            // when & then
+            assertThatThrownBy(course::register)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("READY 상태의 강의만 등록");
+        }
+
+        @Test
+        @DisplayName("실패 - REGISTERED 상태에서 재호출")
+        void register_fromRegistered_throwsException() {
+            // given
+            Course course = createRegisteredCourse();
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.REGISTERED);
+
+            // when & then
+            assertThatThrownBy(course::register)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("READY 상태의 강의만 등록");
+        }
+    }
+
+    // ===== 상태 헬퍼 메서드 테스트 =====
+    @Nested
+    @DisplayName("상태 확인 헬퍼 메서드")
+    class StatusHelpers {
+
+        @Test
+        @DisplayName("isModifiable - DRAFT와 READY만 true")
+        void isModifiable_correctness() {
+            assertThat(createDraftCourse().isModifiable()).isTrue();
+            assertThat(createReadyCourse().isModifiable()).isTrue();
+            assertThat(createRegisteredCourse().isModifiable()).isFalse();
+        }
+
+        @Test
+        @DisplayName("canCreateCourseTime - REGISTERED만 true")
+        void canCreateCourseTime_correctness() {
+            assertThat(createDraftCourse().canCreateCourseTime()).isFalse();
+            assertThat(createReadyCourse().canCreateCourseTime()).isFalse();
+            assertThat(createRegisteredCourse().canCreateCourseTime()).isTrue();
+        }
+
+        @Test
+        @DisplayName("isDraft/isReady/isRegistered 정확성")
+        void statusCheckers_correctness() {
+            Course draft = createDraftCourse();
+            assertThat(draft.isDraft()).isTrue();
+            assertThat(draft.isReady()).isFalse();
+            assertThat(draft.isRegistered()).isFalse();
+
+            Course ready = createReadyCourse();
+            assertThat(ready.isDraft()).isFalse();
+            assertThat(ready.isReady()).isTrue();
+            assertThat(ready.isRegistered()).isFalse();
+
+            Course registered = createRegisteredCourse();
+            assertThat(registered.isDraft()).isFalse();
+            assertThat(registered.isReady()).isFalse();
+            assertThat(registered.isRegistered()).isTrue();
+        }
+    }
+
+    // ===== Deprecated 메서드 하위호환성 테스트 =====
+    @Nested
+    @DisplayName("Deprecated 메서드 하위호환성")
+    class DeprecatedMethods {
+
+        @Test
+        @DisplayName("publish() -> markAsReady() 위임")
+        @SuppressWarnings("deprecation")
+        void publish_delegatesToMarkAsReady() {
+            // given
+            Course course = createDraftCourse();
+
+            // when
+            course.publish();
+
+            // then
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.READY);
+        }
+
+        @Test
+        @DisplayName("unpublish() -> markAsDraft() 위임")
+        @SuppressWarnings("deprecation")
+        void unpublish_delegatesToMarkAsDraft() {
+            // given
+            Course course = createReadyCourse();
+
+            // when
+            course.unpublish();
+
+            // then
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.DRAFT);
+        }
+    }
+}

--- a/src/test/java/com/mzc/lp/domain/course/service/CourseStatusServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/service/CourseStatusServiceTest.java
@@ -1,0 +1,250 @@
+package com.mzc.lp.domain.course.service;
+
+import com.mzc.lp.common.support.TenantTestSupport;
+import com.mzc.lp.domain.course.constant.CourseLevel;
+import com.mzc.lp.domain.course.constant.CourseStatus;
+import com.mzc.lp.domain.course.constant.CourseType;
+import com.mzc.lp.domain.course.dto.response.CourseResponse;
+import com.mzc.lp.domain.course.entity.Course;
+import com.mzc.lp.domain.course.entity.CourseItem;
+import com.mzc.lp.domain.course.exception.CourseIncompleteException;
+import com.mzc.lp.domain.course.exception.CourseNotFoundException;
+import com.mzc.lp.domain.course.exception.CourseNotModifiableException;
+import com.mzc.lp.domain.course.exception.InvalidCourseStatusTransitionException;
+import com.mzc.lp.domain.course.repository.CourseRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@DisplayName("Course 상태 전환 서비스 테스트")
+class CourseStatusServiceTest extends TenantTestSupport {
+
+    @Autowired
+    private CourseService courseService;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @BeforeEach
+    void setUp() {
+        courseRepository.deleteAll();
+    }
+
+    // ===== 테스트 헬퍼 메서드 =====
+    private Course createCompleteCourse(String title) {
+        Course course = Course.create(
+                title,
+                "상세한 설명입니다",
+                CourseLevel.BEGINNER,
+                CourseType.ONLINE,
+                10,
+                1L, // categoryId
+                null,
+                null,
+                null,
+                null,
+                1L // createdBy
+        );
+        CourseItem item = CourseItem.createFolder(course, "폴더1", null);
+        course.addItem(item);
+        return courseRepository.save(course);
+    }
+
+    private Course createIncompleteCourse(String title) {
+        Course course = Course.create(
+                title,
+                null, // description 없음 -> 미완성
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                1L
+        );
+        return courseRepository.save(course);
+    }
+
+    // ===== readyCourse 테스트 =====
+    @Nested
+    @DisplayName("readyCourse() - 작성완료 전환")
+    class ReadyCourse {
+
+        @Test
+        @DisplayName("성공 - DRAFT -> READY (완성된 강의)")
+        void readyCourse_fromDraft_success() {
+            // given
+            Course course = createCompleteCourse("완성 강의");
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.DRAFT);
+
+            // when
+            CourseResponse response = courseService.readyCourse(course.getId());
+
+            // then
+            assertThat(response.status()).isEqualTo(CourseStatus.READY);
+
+            Course updated = courseRepository.findById(course.getId()).orElseThrow();
+            assertThat(updated.getStatus()).isEqualTo(CourseStatus.READY);
+        }
+
+        @Test
+        @DisplayName("실패 - 미완성 강의")
+        void readyCourse_incompleteCourse_throwsException() {
+            // given
+            Course course = createIncompleteCourse("미완성 강의");
+
+            // when & then
+            assertThatThrownBy(() -> courseService.readyCourse(course.getId()))
+                    .isInstanceOf(CourseIncompleteException.class);
+        }
+
+        @Test
+        @DisplayName("실패 - REGISTERED 상태")
+        void readyCourse_fromRegistered_throwsException() {
+            // given
+            Course course = createCompleteCourse("등록된 강의");
+            course.markAsReady();
+            course.register();
+            courseRepository.save(course);
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.REGISTERED);
+
+            // when & then
+            assertThatThrownBy(() -> courseService.readyCourse(course.getId()))
+                    .isInstanceOf(CourseNotModifiableException.class);
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 강의")
+        void readyCourse_notFound_throwsException() {
+            // when & then
+            assertThatThrownBy(() -> courseService.readyCourse(99999L))
+                    .isInstanceOf(CourseNotFoundException.class);
+        }
+    }
+
+    // ===== unreadyCourse 테스트 =====
+    @Nested
+    @DisplayName("unreadyCourse() - 작성중 전환")
+    class UnreadyCourse {
+
+        @Test
+        @DisplayName("성공 - READY -> DRAFT")
+        void unreadyCourse_fromReady_success() {
+            // given
+            Course course = createCompleteCourse("완성 강의");
+            course.markAsReady();
+            courseRepository.save(course);
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.READY);
+
+            // when
+            CourseResponse response = courseService.unreadyCourse(course.getId());
+
+            // then
+            assertThat(response.status()).isEqualTo(CourseStatus.DRAFT);
+
+            Course updated = courseRepository.findById(course.getId()).orElseThrow();
+            assertThat(updated.getStatus()).isEqualTo(CourseStatus.DRAFT);
+        }
+
+        @Test
+        @DisplayName("실패 - REGISTERED 상태")
+        void unreadyCourse_fromRegistered_throwsException() {
+            // given
+            Course course = createCompleteCourse("등록된 강의");
+            course.markAsReady();
+            course.register();
+            courseRepository.save(course);
+
+            // when & then
+            assertThatThrownBy(() -> courseService.unreadyCourse(course.getId()))
+                    .isInstanceOf(CourseNotModifiableException.class);
+        }
+    }
+
+    // ===== registerCourse 테스트 =====
+    @Nested
+    @DisplayName("registerCourse() - 등록 전환")
+    class RegisterCourse {
+
+        @Test
+        @DisplayName("성공 - READY -> REGISTERED")
+        void registerCourse_fromReady_success() {
+            // given
+            Course course = createCompleteCourse("READY 강의");
+            course.markAsReady();
+            courseRepository.save(course);
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.READY);
+
+            // when
+            CourseResponse response = courseService.registerCourse(course.getId());
+
+            // then
+            assertThat(response.status()).isEqualTo(CourseStatus.REGISTERED);
+
+            Course updated = courseRepository.findById(course.getId()).orElseThrow();
+            assertThat(updated.getStatus()).isEqualTo(CourseStatus.REGISTERED);
+            assertThat(updated.isModifiable()).isFalse();
+            assertThat(updated.canCreateCourseTime()).isTrue();
+        }
+
+        @Test
+        @DisplayName("실패 - DRAFT 상태에서 호출")
+        void registerCourse_fromDraft_throwsException() {
+            // given
+            Course course = createCompleteCourse("DRAFT 강의");
+            assertThat(course.getStatus()).isEqualTo(CourseStatus.DRAFT);
+
+            // when & then
+            assertThatThrownBy(() -> courseService.registerCourse(course.getId()))
+                    .isInstanceOf(InvalidCourseStatusTransitionException.class);
+        }
+
+        @Test
+        @DisplayName("실패 - REGISTERED 상태에서 재호출")
+        void registerCourse_fromRegistered_throwsException() {
+            // given
+            Course course = createCompleteCourse("등록된 강의");
+            course.markAsReady();
+            course.register();
+            courseRepository.save(course);
+
+            // when & then
+            assertThatThrownBy(() -> courseService.registerCourse(course.getId()))
+                    .isInstanceOf(InvalidCourseStatusTransitionException.class);
+        }
+    }
+
+    // ===== updateCourse 상태 검증 테스트 =====
+    @Nested
+    @DisplayName("updateCourse() - 수정 가능 상태 검증")
+    class UpdateCourseModifiableCheck {
+
+        @Test
+        @DisplayName("실패 - REGISTERED 상태에서 수정 시도")
+        void updateCourse_registeredCourse_throwsException() {
+            // given
+            Course course = createCompleteCourse("등록된 강의");
+            course.markAsReady();
+            course.register();
+            courseRepository.save(course);
+
+            // when & then
+            assertThatThrownBy(() -> courseService.updateCourse(
+                    course.getId(),
+                    new com.mzc.lp.domain.course.dto.request.UpdateCourseRequest(
+                            "수정 시도",
+                            null, null, null, null, null, null, null, null, null, null
+                    )
+            )).isInstanceOf(CourseNotModifiableException.class);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Course 상태를 DRAFT → READY → REGISTERED 3단계로 재설계
- 상태별 수정 가능 여부 및 차수 생성 가능 여부 제어
- 기존 publish/unpublish API는 deprecated 처리 후 신규 API로 위임

## Changes

### 1. CourseStatus enum 재설계
| 상태 | 설명 | 수정 가능 | 차수 생성 |
|------|------|----------|----------|
| DRAFT | 작성중 | ✅ | ❌ |
| READY | 작성완료 | ✅ | ❌ |
| REGISTERED | 등록됨 | ❌ | ✅ |

### 2. 신규 API 엔드포인트
- `POST /api/courses/{id}/ready` - DRAFT → READY
- `POST /api/courses/{id}/unready` - READY → DRAFT
- `POST /api/courses/{id}/register` - READY → REGISTERED (단방향)

### 3. 수정 파일
- `ErrorCode.java` - CM018, CM019 추가
- `CourseStatus.java` - enum 재설계 및 헬퍼 메서드
- `CourseNotModifiableException.java` - 신규
- `InvalidCourseStatusTransitionException.java` - 신규
- `Course.java` - 상태 전환 메서드 추가
- `CourseService.java` / `CourseServiceImpl.java` - 신규 메서드 구현
- `CourseItemServiceImpl.java` - 수정 가능 상태 검증 추가
- `CourseController.java` - 신규 엔드포인트
- `V20260113__course_status_migration.sql` - PUBLISHED → READY 마이그레이션
- `data.sql` - OWNER → DESIGNER 수정

### 4. 테스트
- `CourseStatusTest.java` - 엔티티 단위 테스트
- `CourseStatusServiceTest.java` - 서비스 통합 테스트

## Related
- Closes #368
- Frontend: mzc-lp-frontend#397

## Test plan
- [ ] 상태 전환 테스트 (DRAFT ↔ READY → REGISTERED)
- [ ] REGISTERED 상태에서 수정 불가 확인
- [ ] 기존 publish/unpublish API 하위 호환성 확인
- [ ] CourseItem 수정 시 상태 검증 확인