### PR TITLE
feat: 콘텐츠 다운로드 권한 체크 제거

### DIFF
--- a/src/main/java/com/mzc/lp/domain/content/service/ContentServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/content/service/ContentServiceImpl.java
@@ -10,7 +10,6 @@ import com.mzc.lp.domain.content.dto.response.ContentListResponse;
 import com.mzc.lp.domain.content.dto.response.ContentResponse;
 import com.mzc.lp.domain.content.entity.Content;
 import com.mzc.lp.domain.content.event.ContentCreatedEvent;
-import com.mzc.lp.domain.content.exception.ContentDownloadNotAllowedException;
 import com.mzc.lp.domain.content.exception.ContentInUseException;
 import com.mzc.lp.domain.content.exception.ContentNotFoundException;
 import com.mzc.lp.domain.content.exception.FileStorageException;
@@ -281,11 +280,6 @@ public class ContentServiceImpl implements ContentService {
     @Override
     public ContentDownloadInfo getFileForDownload(Long contentId, Long tenantId) {
         Content content = findContentOrThrow(contentId, tenantId);
-
-        // 다운로드 허용 여부 체크
-        if (content.getDownloadable() != null && !content.getDownloadable()) {
-            throw new ContentDownloadNotAllowedException(contentId);
-        }
 
         if (content.getFilePath() == null) {
             throw new FileStorageException(ErrorCode.FILE_NOT_FOUND,

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -911,10 +911,10 @@ SELECT 1, (SELECT id FROM users WHERE email = 'creator@default.com'), NULL, 'DES
 -- OWNER 역할 (courseId = programId, 프로그램 승인 시 자동 부여)
 INSERT INTO user_course_roles (tenant_id, user_id, course_id, role, revenue_share_percent, created_at, updated_at)
 SELECT 1, (SELECT id FROM users WHERE email = 'creator@default.com'),
- (SELECT id FROM cm_programs WHERE title = 'Spring Boot 기초 과정' AND tenant_id = 1), 'OWNER', 70, NOW(), NOW();
+ (SELECT id FROM cm_programs WHERE title = 'Spring Boot 기초 과정' AND tenant_id = 1), 'DESIGNER', 70, NOW(), NOW();
 INSERT INTO user_course_roles (tenant_id, user_id, course_id, role, revenue_share_percent, created_at, updated_at)
 SELECT 1, (SELECT id FROM users WHERE email = 'creator@default.com'),
- (SELECT id FROM cm_programs WHERE title = 'React & TypeScript 실전' AND tenant_id = 1), 'OWNER', 70, NOW(), NOW();
+ (SELECT id FROM cm_programs WHERE title = 'React & TypeScript 실전' AND tenant_id = 1), 'DESIGNER', 70, NOW(), NOW();
 
 -- designer3@default.com: USER + DESIGNER (프로그램 아직 미승인)
 -- DESIGNER 역할만 (courseId = null, 테넌트 레벨)

--- a/src/test/java/com/mzc/lp/domain/content/controller/ContentControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/content/controller/ContentControllerTest.java
@@ -1010,8 +1010,8 @@ class ContentControllerTest extends TenantTestSupport {
         }
 
         @Test
-        @DisplayName("실패 - downloadable=false인 콘텐츠 다운로드 거부")
-        void download_fail_downloadableDisabled() throws Exception {
+        @DisplayName("성공 - downloadable=false여도 다운로드 허용")
+        void download_success_evenIfDownloadableDisabled() throws Exception {
             // given
             createDesignerUser();
             String accessToken = loginAndGetAccessToken("designer@example.com", "Password123!");
@@ -1031,12 +1031,11 @@ class ContentControllerTest extends TenantTestSupport {
             Long contentId = objectMapper.readTree(uploadResult.getResponse().getContentAsString())
                     .get("data").get("id").asLong();
 
-            // when & then - 다운로드 시도
+            // when & then - downloadable=false여도 다운로드 성공
             mockMvc.perform(get("/api/contents/{contentId}/download", contentId)
                             .header("Authorization", "Bearer " + accessToken))
                     .andDo(print())
-                    .andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.error.code").value("CT011"));
+                    .andExpect(status().isOk());
         }
 
         @Test


### PR DESCRIPTION
## Summary
- 콘텐츠 다운로드 시 `downloadable` 필드 체크 로직 제거
- 모든 콘텐츠 다운로드 허용

Related to: mzcATU/mzc-lp-frontend#391