### PR TITLE
feat: 테넌트 기능 설정에 유료 모드(paidModeEnabled) 필드 추가

### DIFF
--- a/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateTenantFeaturesRequest.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateTenantFeaturesRequest.java
@@ -8,6 +8,7 @@ public record UpdateTenantFeaturesRequest(
         Boolean userCourseCreationEnabled,
         Boolean cartEnabled,
         Boolean wishlistEnabled,
-        Boolean instructorTabEnabled
+        Boolean instructorTabEnabled,
+        Boolean paidModeEnabled // 유료 모드 (false면 무료 모드 - 가격 숨김)
 ) {
 }

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/response/TenantFeaturesResponse.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/response/TenantFeaturesResponse.java
@@ -10,7 +10,8 @@ public record TenantFeaturesResponse(
         Boolean userCourseCreationEnabled,
         Boolean cartEnabled,
         Boolean wishlistEnabled,
-        Boolean instructorTabEnabled
+        Boolean instructorTabEnabled,
+        Boolean paidModeEnabled // 유료 모드 (false면 무료 모드 - 가격 숨김)
 ) {
     public static TenantFeaturesResponse from(TenantSettings settings) {
         return new TenantFeaturesResponse(
@@ -18,7 +19,8 @@ public record TenantFeaturesResponse(
                 settings.getUserCourseCreationEnabled(),
                 settings.getCartEnabled(),
                 settings.getWishlistEnabled(),
-                settings.getInstructorTabEnabled()
+                settings.getInstructorTabEnabled(),
+                settings.getPaidModeEnabled()
         );
     }
 
@@ -31,7 +33,8 @@ public record TenantFeaturesResponse(
                 false,  // userCourseCreationEnabled
                 true,   // cartEnabled
                 true,   // wishlistEnabled
-                true    // instructorTabEnabled
+                true,   // instructorTabEnabled
+                true    // paidModeEnabled (기본값: 유료 모드)
         );
     }
 }

--- a/src/main/java/com/mzc/lp/domain/tenant/entity/TenantSettings.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/entity/TenantSettings.java
@@ -173,6 +173,9 @@ public class TenantSettings extends BaseTimeEntity {
     @Column(nullable = false)
     private Boolean instructorTabEnabled = true;
 
+    @Column(nullable = false)
+    private Boolean paidModeEnabled = true; // 유료 모드 (false면 무료 모드 - 가격 숨김)
+
     // 정적 팩토리 메서드
     public static TenantSettings createDefault(Tenant tenant) {
         TenantSettings settings = new TenantSettings();
@@ -272,12 +275,13 @@ public class TenantSettings extends BaseTimeEntity {
     // 테넌트 기능 On/Off 설정 업데이트
     public void updateTenantFeatures(Boolean communityEnabled, Boolean userCourseCreationEnabled,
                                      Boolean cartEnabled, Boolean wishlistEnabled,
-                                     Boolean instructorTabEnabled) {
+                                     Boolean instructorTabEnabled, Boolean paidModeEnabled) {
         if (communityEnabled != null) this.communityEnabled = communityEnabled;
         if (userCourseCreationEnabled != null) this.userCourseCreationEnabled = userCourseCreationEnabled;
         if (cartEnabled != null) this.cartEnabled = cartEnabled;
         if (wishlistEnabled != null) this.wishlistEnabled = wishlistEnabled;
         if (instructorTabEnabled != null) this.instructorTabEnabled = instructorTabEnabled;
+        if (paidModeEnabled != null) this.paidModeEnabled = paidModeEnabled;
     }
 
     // 확장 브랜딩 설정 업데이트

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantSettingsServiceImpl.java
@@ -469,7 +469,8 @@ public class TenantSettingsServiceImpl implements TenantSettingsService {
                 request.userCourseCreationEnabled(),
                 request.cartEnabled(),
                 request.wishlistEnabled(),
-                request.instructorTabEnabled()
+                request.instructorTabEnabled(),
+                request.paidModeEnabled()
         );
 
         return TenantFeaturesResponse.from(settings);

--- a/src/main/resources/migration/V20260113__add_paid_mode_enabled.sql
+++ b/src/main/resources/migration/V20260113__add_paid_mode_enabled.sql
@@ -1,0 +1,6 @@
+-- 테넌트 설정에 유료 모드 필드 추가
+ALTER TABLE tenant_settings
+ADD COLUMN paid_mode_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- 기존 테넌트는 기본값 유료 모드로 설정
+UPDATE tenant_settings SET paid_mode_enabled = TRUE WHERE paid_mode_enabled IS NULL;


### PR DESCRIPTION
## Summary

테넌트 기능 설정에 유료 모드(paidModeEnabled) 필드를 추가했습니다.

## Related Issue

- 유료/무료 모드 토글 기능 추가

## Changes

- **TenantSettings Entity**: `paidModeEnabled` 필드 추가 (기본값: true)
- **TenantFeaturesResponse DTO**: `paidModeEnabled` 필드 추가
- **UpdateTenantFeaturesRequest DTO**: `paidModeEnabled` 필드 추가
- **TenantSettingsServiceImpl**: `updateTenantFeatures`에 `paidModeEnabled` 처리
- **DB 마이그레이션**: `V20260113__add_paid_mode_enabled.sql` 추가

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 로컬에서 테스트가 통과합니다

## Additional Notes

- 프론트엔드 PR과 함께 배포되어야 합니다 (frontend: feature/paid-mode-toggle)
- 유료 모드가 false면 프론트엔드에서 가격 숨김 및 장바구니 비활성화
