### PR TITLE
feat: 콘텐츠 일괄 업로드 API (#377)

### DIFF
--- a/src/main/java/com/mzc/lp/domain/content/controller/ContentController.java
+++ b/src/main/java/com/mzc/lp/domain/content/controller/ContentController.java
@@ -7,6 +7,7 @@ import com.mzc.lp.domain.content.constant.ContentStatus;
 import com.mzc.lp.domain.content.constant.ContentType;
 import com.mzc.lp.domain.content.dto.request.CreateExternalLinkRequest;
 import com.mzc.lp.domain.content.dto.request.UpdateContentRequest;
+import com.mzc.lp.domain.content.dto.response.BulkUploadResponse;
 import com.mzc.lp.domain.content.dto.response.ContentListResponse;
 import com.mzc.lp.domain.content.dto.response.ContentResponse;
 import com.mzc.lp.domain.content.service.ContentService;
@@ -67,6 +68,22 @@ public class ContentController {
         Long tenantId = TenantContext.getCurrentTenantId();
         Long userId = principal.id();
         ContentResponse response = contentService.createExternalLink(request, tenantId, userId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    @PostMapping("/bulk-upload")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<BulkUploadResponse>> bulkUploadFiles(
+            @RequestParam("files") MultipartFile[] files,
+            @RequestParam(value = "folderId", required = false) Long folderId,
+            @RequestParam(value = "completionCriteria", required = false) CompletionCriteria completionCriteria,
+            @RequestParam(value = "downloadable", required = false) Boolean downloadable,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        Long userId = principal.id();
+        BulkUploadResponse response = contentService.bulkUploadFiles(
+                files, folderId, completionCriteria, downloadable, tenantId, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/mzc/lp/domain/content/dto/response/BulkUploadResponse.java
+++ b/src/main/java/com/mzc/lp/domain/content/dto/response/BulkUploadResponse.java
@@ -1,0 +1,32 @@
+package com.mzc.lp.domain.content.dto.response;
+
+import java.util.List;
+
+/**
+ * 일괄 업로드 응답 DTO
+ */
+public record BulkUploadResponse(
+        int totalCount,
+        int successCount,
+        int failCount,
+        List<ContentResponse> successItems,
+        List<FailedItem> failedItems
+) {
+    public record FailedItem(
+            String fileName,
+            String errorMessage
+    ) {}
+
+    public static BulkUploadResponse of(
+            List<ContentResponse> successItems,
+            List<FailedItem> failedItems
+    ) {
+        return new BulkUploadResponse(
+                successItems.size() + failedItems.size(),
+                successItems.size(),
+                failedItems.size(),
+                successItems,
+                failedItems
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/content/service/ContentService.java
+++ b/src/main/java/com/mzc/lp/domain/content/service/ContentService.java
@@ -4,6 +4,7 @@ import com.mzc.lp.domain.content.constant.ContentStatus;
 import com.mzc.lp.domain.content.constant.ContentType;
 import com.mzc.lp.domain.content.dto.request.CreateExternalLinkRequest;
 import com.mzc.lp.domain.content.dto.request.UpdateContentRequest;
+import com.mzc.lp.domain.content.dto.response.BulkUploadResponse;
 import com.mzc.lp.domain.content.dto.response.ContentListResponse;
 import com.mzc.lp.domain.content.dto.response.ContentResponse;
 import com.mzc.lp.domain.learning.constant.CompletionCriteria;
@@ -33,6 +34,14 @@ public interface ContentService {
      * 외부 링크 등록
      */
     ContentResponse createExternalLink(CreateExternalLinkRequest request, Long tenantId, Long userId);
+
+    /**
+     * 다중 파일 일괄 업로드
+     * @param files 업로드할 파일 배열 (최대 10개)
+     */
+    BulkUploadResponse bulkUploadFiles(MultipartFile[] files, Long folderId,
+                                       CompletionCriteria completionCriteria, Boolean downloadable,
+                                       Long tenantId, Long userId);
 
     /**
      * 콘텐츠 목록 조회


### PR DESCRIPTION
## Summary
- POST /contents/bulk-upload 엔드포인트 추가
- MultipartFile[] 배열로 최대 10개 파일 동시 업로드 지원
- BulkUploadResponse DTO 추가 (성공/실패 건수 및 상세 정보)

Closes #377

## Test plan
- [x] 다중 파일 업로드 API 호출 테스트
- [x] 10개 초과 파일 업로드 시 에러 응답 확인
- [x] 부분 실패 시 성공/실패 항목 구분 응답 확인