### PR TITLE
Add notification template management with auto-initialization

### DIFF
--- a/src/main/java/com/mzc/lp/domain/notification/constant/NotificationCategory.java
+++ b/src/main/java/com/mzc/lp/domain/notification/constant/NotificationCategory.java
@@ -1,0 +1,21 @@
+package com.mzc.lp.domain.notification.constant;
+
+/**
+ * 알림 템플릿 카테고리
+ */
+public enum NotificationCategory {
+    AUTH("인증"),
+    NOTIFICATION("알림"),
+    MARKETING("마케팅"),
+    SYSTEM("시스템");
+
+    private final String displayName;
+
+    NotificationCategory(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notification/constant/NotificationTrigger.java
+++ b/src/main/java/com/mzc/lp/domain/notification/constant/NotificationTrigger.java
@@ -1,0 +1,30 @@
+package com.mzc.lp.domain.notification.constant;
+
+/**
+ * 알림 트리거 타입
+ * 특정 이벤트 발생 시 자동으로 알림을 생성하는 트리거 종류
+ */
+public enum NotificationTrigger {
+    // 인증 관련
+    WELCOME("회원가입 환영", NotificationCategory.AUTH),
+
+    // 알림 관련
+    ENROLLMENT_COMPLETE("수강신청 완료", NotificationCategory.NOTIFICATION),
+    COURSE_COMPLETE("과정 완료 축하", NotificationCategory.NOTIFICATION);
+
+    private final String displayName;
+    private final NotificationCategory category;
+
+    NotificationTrigger(String displayName, NotificationCategory category) {
+        this.displayName = displayName;
+        this.category = category;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public NotificationCategory getCategory() {
+        return category;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notification/controller/NotificationTemplateController.java
+++ b/src/main/java/com/mzc/lp/domain/notification/controller/NotificationTemplateController.java
@@ -1,0 +1,141 @@
+package com.mzc.lp.domain.notification.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.domain.notification.constant.NotificationCategory;
+import com.mzc.lp.domain.notification.constant.NotificationTrigger;
+import com.mzc.lp.domain.notification.dto.request.CreateNotificationTemplateRequest;
+import com.mzc.lp.domain.notification.dto.request.UpdateNotificationTemplateRequest;
+import com.mzc.lp.domain.notification.dto.response.NotificationTemplateResponse;
+import com.mzc.lp.domain.notification.service.NotificationTemplateService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 알림 템플릿 관리 API (TA - Tenant Admin)
+ */
+@RestController
+@RequestMapping("/api/ta/notification-templates")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('TENANT_ADMIN')")
+public class NotificationTemplateController {
+
+    private final NotificationTemplateService templateService;
+
+    /**
+     * 템플릿 목록 조회
+     */
+    @GetMapping
+    public ApiResponse<List<NotificationTemplateResponse>> getTemplates(
+            @RequestParam(required = false) NotificationCategory category
+    ) {
+        List<NotificationTemplateResponse> templates = templateService.getTemplates(category);
+        return ApiResponse.success(templates);
+    }
+
+    /**
+     * 템플릿 상세 조회
+     */
+    @GetMapping("/{id}")
+    public ApiResponse<NotificationTemplateResponse> getTemplate(@PathVariable Long id) {
+        NotificationTemplateResponse template = templateService.getTemplate(id);
+        return ApiResponse.success(template);
+    }
+
+    /**
+     * 템플릿 생성
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<NotificationTemplateResponse> createTemplate(
+            @Valid @RequestBody CreateNotificationTemplateRequest request
+    ) {
+        NotificationTemplateResponse template = templateService.createTemplate(request);
+        return ApiResponse.success(template);
+    }
+
+    /**
+     * 기본 템플릿 초기화
+     */
+    @PostMapping("/initialize")
+    public ApiResponse<Void> initializeDefaultTemplates() {
+        templateService.initializeDefaultTemplates();
+        return ApiResponse.success(null);
+    }
+
+    /**
+     * 템플릿 수정
+     */
+    @PutMapping("/{id}")
+    public ApiResponse<NotificationTemplateResponse> updateTemplate(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateNotificationTemplateRequest request
+    ) {
+        NotificationTemplateResponse template = templateService.updateTemplate(id, request);
+        return ApiResponse.success(template);
+    }
+
+    /**
+     * 템플릿 활성화
+     */
+    @PostMapping("/{id}/activate")
+    public ApiResponse<Void> activateTemplate(@PathVariable Long id) {
+        templateService.activateTemplate(id);
+        return ApiResponse.success(null);
+    }
+
+    /**
+     * 템플릿 비활성화
+     */
+    @PostMapping("/{id}/deactivate")
+    public ApiResponse<Void> deactivateTemplate(@PathVariable Long id) {
+        templateService.deactivateTemplate(id);
+        return ApiResponse.success(null);
+    }
+
+    /**
+     * 템플릿 삭제
+     */
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public ApiResponse<Void> deleteTemplate(@PathVariable Long id) {
+        templateService.deleteTemplate(id);
+        return ApiResponse.success(null);
+    }
+
+    /**
+     * 사용 가능한 트리거 타입 목록 조회
+     */
+    @GetMapping("/triggers")
+    public ApiResponse<List<Map<String, String>>> getTriggerTypes() {
+        List<Map<String, String>> triggers = Arrays.stream(NotificationTrigger.values())
+                .map(t -> Map.of(
+                        "value", t.name(),
+                        "label", t.getDisplayName(),
+                        "category", t.getCategory().name(),
+                        "categoryLabel", t.getCategory().getDisplayName()
+                ))
+                .toList();
+        return ApiResponse.success(triggers);
+    }
+
+    /**
+     * 사용 가능한 카테고리 목록 조회
+     */
+    @GetMapping("/categories")
+    public ApiResponse<List<Map<String, String>>> getCategories() {
+        List<Map<String, String>> categories = Arrays.stream(NotificationCategory.values())
+                .map(c -> Map.of(
+                        "value", c.name(),
+                        "label", c.getDisplayName()
+                ))
+                .toList();
+        return ApiResponse.success(categories);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notification/dto/request/CreateNotificationTemplateRequest.java
+++ b/src/main/java/com/mzc/lp/domain/notification/dto/request/CreateNotificationTemplateRequest.java
@@ -1,0 +1,25 @@
+package com.mzc.lp.domain.notification.dto.request;
+
+import com.mzc.lp.domain.notification.constant.NotificationTrigger;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateNotificationTemplateRequest(
+        @NotNull(message = "트리거 타입은 필수입니다")
+        NotificationTrigger triggerType,
+
+        @NotBlank(message = "템플릿 이름은 필수입니다")
+        @Size(max = 100, message = "템플릿 이름은 100자 이내여야 합니다")
+        String name,
+
+        @NotBlank(message = "제목 템플릿은 필수입니다")
+        @Size(max = 200, message = "제목 템플릿은 200자 이내여야 합니다")
+        String titleTemplate,
+
+        @NotBlank(message = "메시지 템플릿은 필수입니다")
+        String messageTemplate,
+
+        @Size(max = 500, message = "설명은 500자 이내여야 합니다")
+        String description
+) {}

--- a/src/main/java/com/mzc/lp/domain/notification/dto/request/UpdateNotificationTemplateRequest.java
+++ b/src/main/java/com/mzc/lp/domain/notification/dto/request/UpdateNotificationTemplateRequest.java
@@ -1,0 +1,20 @@
+package com.mzc.lp.domain.notification.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateNotificationTemplateRequest(
+        @NotBlank(message = "템플릿 이름은 필수입니다")
+        @Size(max = 100, message = "템플릿 이름은 100자 이내여야 합니다")
+        String name,
+
+        @NotBlank(message = "제목 템플릿은 필수입니다")
+        @Size(max = 200, message = "제목 템플릿은 200자 이내여야 합니다")
+        String titleTemplate,
+
+        @NotBlank(message = "메시지 템플릿은 필수입니다")
+        String messageTemplate,
+
+        @Size(max = 500, message = "설명은 500자 이내여야 합니다")
+        String description
+) {}

--- a/src/main/java/com/mzc/lp/domain/notification/dto/response/NotificationTemplateResponse.java
+++ b/src/main/java/com/mzc/lp/domain/notification/dto/response/NotificationTemplateResponse.java
@@ -1,0 +1,39 @@
+package com.mzc.lp.domain.notification.dto.response;
+
+import com.mzc.lp.domain.notification.constant.NotificationCategory;
+import com.mzc.lp.domain.notification.constant.NotificationTrigger;
+import com.mzc.lp.domain.notification.entity.NotificationTemplate;
+
+import java.time.Instant;
+
+public record NotificationTemplateResponse(
+        Long id,
+        NotificationTrigger triggerType,
+        String triggerDisplayName,
+        NotificationCategory category,
+        String categoryDisplayName,
+        String name,
+        String titleTemplate,
+        String messageTemplate,
+        String description,
+        Boolean isActive,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static NotificationTemplateResponse from(NotificationTemplate template) {
+        return new NotificationTemplateResponse(
+                template.getId(),
+                template.getTriggerType(),
+                template.getTriggerType().getDisplayName(),
+                template.getCategory(),
+                template.getCategory().getDisplayName(),
+                template.getName(),
+                template.getTitleTemplate(),
+                template.getMessageTemplate(),
+                template.getDescription(),
+                template.getIsActive(),
+                template.getCreatedAt(),
+                template.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notification/entity/NotificationTemplate.java
+++ b/src/main/java/com/mzc/lp/domain/notification/entity/NotificationTemplate.java
@@ -1,0 +1,145 @@
+package com.mzc.lp.domain.notification.entity;
+
+import com.mzc.lp.common.entity.TenantEntity;
+import com.mzc.lp.domain.notification.constant.NotificationCategory;
+import com.mzc.lp.domain.notification.constant.NotificationTrigger;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 알림 템플릿 엔티티
+ * 테넌트별로 알림 메시지 템플릿을 관리
+ */
+@Entity
+@Table(
+    name = "notification_templates",
+    indexes = {
+        @Index(name = "idx_notification_template_tenant", columnList = "tenant_id"),
+        @Index(name = "idx_notification_template_trigger", columnList = "tenant_id, trigger_type"),
+        @Index(name = "idx_notification_template_category", columnList = "tenant_id, category"),
+        @Index(name = "idx_notification_template_active", columnList = "tenant_id, is_active")
+    },
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_notification_template_trigger", columnNames = {"tenant_id", "trigger_type"})
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationTemplate extends TenantEntity {
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "trigger_type", nullable = false, length = 50)
+    private NotificationTrigger triggerType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 20)
+    private NotificationCategory category;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "title_template", nullable = false, length = 200)
+    private String titleTemplate;
+
+    @Column(name = "message_template", nullable = false, columnDefinition = "TEXT")
+    private String messageTemplate;
+
+    @Column(name = "description", length = 500)
+    private String description;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
+    @Version
+    private Long version;
+
+    // ===== 정적 팩토리 메서드 =====
+    public static NotificationTemplate create(
+            NotificationTrigger triggerType,
+            String name,
+            String titleTemplate,
+            String messageTemplate,
+            String description
+    ) {
+        NotificationTemplate template = new NotificationTemplate();
+        template.triggerType = triggerType;
+        template.category = triggerType.getCategory();
+        template.name = name;
+        template.titleTemplate = titleTemplate;
+        template.messageTemplate = messageTemplate;
+        template.description = description;
+        template.isActive = true;
+        return template;
+    }
+
+    /**
+     * 기본 템플릿 생성 (트리거 타입 기반)
+     */
+    public static NotificationTemplate createDefault(NotificationTrigger triggerType) {
+        NotificationTemplate template = new NotificationTemplate();
+        template.triggerType = triggerType;
+        template.category = triggerType.getCategory();
+        template.name = triggerType.getDisplayName();
+        template.titleTemplate = getDefaultTitle(triggerType);
+        template.messageTemplate = getDefaultMessage(triggerType);
+        template.description = triggerType.getDisplayName() + " 시 발송";
+        template.isActive = true;
+        return template;
+    }
+
+    private static String getDefaultTitle(NotificationTrigger trigger) {
+        return switch (trigger) {
+            case WELCOME -> "회원가입을 환영합니다!";
+            case ENROLLMENT_COMPLETE -> "수강신청이 완료되었습니다";
+            case COURSE_COMPLETE -> "축하합니다! 과정을 완료하셨습니다";
+        };
+    }
+
+    private static String getDefaultMessage(NotificationTrigger trigger) {
+        return switch (trigger) {
+            case WELCOME -> "{{userName}}님, 가입을 환영합니다! 다양한 강좌를 둘러보세요.";
+            case ENROLLMENT_COMPLETE -> "{{userName}}님, {{courseName}} 강좌 수강신청이 완료되었습니다.";
+            case COURSE_COMPLETE -> "{{userName}}님, {{courseName}} 과정을 성공적으로 완료하셨습니다!";
+        };
+    }
+
+    // ===== 비즈니스 메서드 =====
+    public void update(String name, String titleTemplate, String messageTemplate, String description) {
+        this.name = name;
+        this.titleTemplate = titleTemplate;
+        this.messageTemplate = messageTemplate;
+        this.description = description;
+    }
+
+    public void activate() {
+        this.isActive = true;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    /**
+     * 템플릿 변수를 치환하여 실제 제목 생성
+     */
+    public String renderTitle(java.util.Map<String, String> variables) {
+        return renderTemplate(this.titleTemplate, variables);
+    }
+
+    /**
+     * 템플릿 변수를 치환하여 실제 메시지 생성
+     */
+    public String renderMessage(java.util.Map<String, String> variables) {
+        return renderTemplate(this.messageTemplate, variables);
+    }
+
+    private String renderTemplate(String template, java.util.Map<String, String> variables) {
+        String result = template;
+        for (java.util.Map.Entry<String, String> entry : variables.entrySet()) {
+            result = result.replace("{{" + entry.getKey() + "}}", entry.getValue());
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notification/event/NotificationEvent.java
+++ b/src/main/java/com/mzc/lp/domain/notification/event/NotificationEvent.java
@@ -1,0 +1,65 @@
+package com.mzc.lp.domain.notification.event;
+
+import com.mzc.lp.domain.notification.constant.NotificationTrigger;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+import java.util.Map;
+
+/**
+ * 알림 발송을 위한 이벤트
+ */
+@Getter
+public class NotificationEvent extends ApplicationEvent {
+
+    private final NotificationTrigger trigger;
+    private final Long tenantId;
+    private final Long userId;
+    private final Map<String, String> variables;
+    private final String link;
+    private final Long referenceId;
+    private final String referenceType;
+
+    public NotificationEvent(
+            Object source,
+            NotificationTrigger trigger,
+            Long tenantId,
+            Long userId,
+            Map<String, String> variables,
+            String link,
+            Long referenceId,
+            String referenceType
+    ) {
+        super(source);
+        this.trigger = trigger;
+        this.tenantId = tenantId;
+        this.userId = userId;
+        this.variables = variables;
+        this.link = link;
+        this.referenceId = referenceId;
+        this.referenceType = referenceType;
+    }
+
+    public static NotificationEvent of(
+            Object source,
+            NotificationTrigger trigger,
+            Long tenantId,
+            Long userId,
+            Map<String, String> variables
+    ) {
+        return new NotificationEvent(source, trigger, tenantId, userId, variables, null, null, null);
+    }
+
+    public static NotificationEvent of(
+            Object source,
+            NotificationTrigger trigger,
+            Long tenantId,
+            Long userId,
+            Map<String, String> variables,
+            String link,
+            Long referenceId,
+            String referenceType
+    ) {
+        return new NotificationEvent(source, trigger, tenantId, userId, variables, link, referenceId, referenceType);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notification/event/NotificationEventListener.java
+++ b/src/main/java/com/mzc/lp/domain/notification/event/NotificationEventListener.java
@@ -1,0 +1,52 @@
+package com.mzc.lp.domain.notification.event;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.domain.notification.service.NotificationTemplateService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 알림 이벤트 리스너
+ * 비동기로 알림을 발송하여 메인 트랜잭션에 영향을 주지 않음
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationEventListener {
+
+    private final NotificationTemplateService templateService;
+
+    @Async
+    @EventListener
+    @Transactional
+    public void handleNotificationEvent(NotificationEvent event) {
+        try {
+            // TenantContext 설정
+            TenantContext.setTenantId(event.getTenantId());
+
+            log.debug("Processing notification event: trigger={}, userId={}, tenantId={}",
+                    event.getTrigger(), event.getUserId(), event.getTenantId());
+
+            templateService.sendNotificationByTrigger(
+                    event.getTrigger(),
+                    event.getUserId(),
+                    event.getVariables(),
+                    event.getLink(),
+                    event.getReferenceId(),
+                    event.getReferenceType()
+            );
+
+            log.info("Notification sent: trigger={}, userId={}", event.getTrigger(), event.getUserId());
+        } catch (Exception e) {
+            // 알림 발송 실패는 메인 비즈니스 로직에 영향을 주지 않도록 로그만 남김
+            log.error("Failed to send notification: trigger={}, userId={}, error={}",
+                    event.getTrigger(), event.getUserId(), e.getMessage(), e);
+        } finally {
+            TenantContext.clear();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notification/event/NotificationEventPublisher.java
+++ b/src/main/java/com/mzc/lp/domain/notification/event/NotificationEventPublisher.java
@@ -1,0 +1,92 @@
+package com.mzc.lp.domain.notification.event;
+
+import com.mzc.lp.domain.notification.constant.NotificationTrigger;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/**
+ * 알림 이벤트 퍼블리셔
+ * 각 서비스에서 알림을 발송할 때 사용
+ */
+@Component
+@RequiredArgsConstructor
+public class NotificationEventPublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    /**
+     * 알림 이벤트 발행
+     */
+    public void publish(
+            NotificationTrigger trigger,
+            Long tenantId,
+            Long userId,
+            Map<String, String> variables
+    ) {
+        eventPublisher.publishEvent(
+                NotificationEvent.of(this, trigger, tenantId, userId, variables)
+        );
+    }
+
+    /**
+     * 알림 이벤트 발행 (링크 및 참조 정보 포함)
+     */
+    public void publish(
+            NotificationTrigger trigger,
+            Long tenantId,
+            Long userId,
+            Map<String, String> variables,
+            String link,
+            Long referenceId,
+            String referenceType
+    ) {
+        eventPublisher.publishEvent(
+                NotificationEvent.of(this, trigger, tenantId, userId, variables, link, referenceId, referenceType)
+        );
+    }
+
+    /**
+     * 회원가입 환영 알림
+     */
+    public void publishWelcome(Long tenantId, Long userId, String userName) {
+        publish(
+                NotificationTrigger.WELCOME,
+                tenantId,
+                userId,
+                Map.of("userName", userName)
+        );
+    }
+
+    /**
+     * 수강신청 완료 알림
+     */
+    public void publishEnrollmentComplete(Long tenantId, Long userId, String userName, String courseName, Long courseTimeId) {
+        publish(
+                NotificationTrigger.ENROLLMENT_COMPLETE,
+                tenantId,
+                userId,
+                Map.of("userName", userName, "courseName", courseName),
+                "/my-courses/" + courseTimeId,
+                courseTimeId,
+                "COURSE_TIME"
+        );
+    }
+
+    /**
+     * 과정 완료 축하 알림
+     */
+    public void publishCourseComplete(Long tenantId, Long userId, String userName, String courseName, Long courseTimeId) {
+        publish(
+                NotificationTrigger.COURSE_COMPLETE,
+                tenantId,
+                userId,
+                Map.of("userName", userName, "courseName", courseName),
+                "/my-courses/" + courseTimeId,
+                courseTimeId,
+                "COURSE_TIME"
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notification/exception/DuplicateNotificationTemplateException.java
+++ b/src/main/java/com/mzc/lp/domain/notification/exception/DuplicateNotificationTemplateException.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.notification.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+import com.mzc.lp.domain.notification.constant.NotificationTrigger;
+
+public class DuplicateNotificationTemplateException extends BusinessException {
+    public DuplicateNotificationTemplateException(NotificationTrigger triggerType) {
+        super(ErrorCode.INVALID_INPUT_VALUE, "이미 동일한 트리거 타입의 템플릿이 존재합니다: " + triggerType.getDisplayName());
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notification/exception/NotificationTemplateNotFoundException.java
+++ b/src/main/java/com/mzc/lp/domain/notification/exception/NotificationTemplateNotFoundException.java
@@ -1,0 +1,10 @@
+package com.mzc.lp.domain.notification.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class NotificationTemplateNotFoundException extends BusinessException {
+    public NotificationTemplateNotFoundException(Long id) {
+        super(ErrorCode.NOTIFICATION_NOT_FOUND, "알림 템플릿을 찾을 수 없습니다. ID: " + id);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/notification/repository/NotificationTemplateRepository.java
+++ b/src/main/java/com/mzc/lp/domain/notification/repository/NotificationTemplateRepository.java
@@ -1,0 +1,62 @@
+package com.mzc.lp.domain.notification.repository;
+
+import com.mzc.lp.domain.notification.constant.NotificationCategory;
+import com.mzc.lp.domain.notification.constant.NotificationTrigger;
+import com.mzc.lp.domain.notification.entity.NotificationTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationTemplateRepository extends JpaRepository<NotificationTemplate, Long> {
+
+    /**
+     * 테넌트별 전체 템플릿 조회
+     */
+    List<NotificationTemplate> findByTenantIdOrderByCreatedAtDesc(Long tenantId);
+
+    /**
+     * 테넌트별 카테고리별 템플릿 조회
+     */
+    List<NotificationTemplate> findByTenantIdAndCategoryOrderByCreatedAtDesc(Long tenantId, NotificationCategory category);
+
+    /**
+     * 테넌트별 활성 템플릿 조회
+     */
+    List<NotificationTemplate> findByTenantIdAndIsActiveTrueOrderByCreatedAtDesc(Long tenantId);
+
+    /**
+     * 테넌트별 트리거 타입으로 템플릿 조회
+     */
+    Optional<NotificationTemplate> findByTenantIdAndTriggerType(Long tenantId, NotificationTrigger triggerType);
+
+    /**
+     * 테넌트별 활성화된 트리거 타입 템플릿 조회
+     */
+    Optional<NotificationTemplate> findByTenantIdAndTriggerTypeAndIsActiveTrue(Long tenantId, NotificationTrigger triggerType);
+
+    /**
+     * 테넌트별 트리거 타입 존재 여부 확인
+     */
+    boolean existsByTenantIdAndTriggerType(Long tenantId, NotificationTrigger triggerType);
+
+    /**
+     * 테넌트별 템플릿 개수
+     */
+    long countByTenantId(Long tenantId);
+
+    /**
+     * 테넌트별 카테고리별 템플릿 개수
+     */
+    long countByTenantIdAndCategory(Long tenantId, NotificationCategory category);
+
+    /**
+     * 키워드 검색 (이름, 제목 템플릿)
+     */
+    @Query("SELECT t FROM NotificationTemplate t WHERE t.tenantId = :tenantId " +
+            "AND (LOWER(t.name) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(t.titleTemplate) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+    List<NotificationTemplate> searchByKeyword(@Param("tenantId") Long tenantId, @Param("keyword") String keyword);
+}

--- a/src/main/java/com/mzc/lp/domain/notification/service/NotificationTemplateService.java
+++ b/src/main/java/com/mzc/lp/domain/notification/service/NotificationTemplateService.java
@@ -1,0 +1,75 @@
+package com.mzc.lp.domain.notification.service;
+
+import com.mzc.lp.domain.notification.constant.NotificationCategory;
+import com.mzc.lp.domain.notification.constant.NotificationTrigger;
+import com.mzc.lp.domain.notification.dto.request.CreateNotificationTemplateRequest;
+import com.mzc.lp.domain.notification.dto.request.UpdateNotificationTemplateRequest;
+import com.mzc.lp.domain.notification.dto.response.NotificationTemplateResponse;
+
+import java.util.List;
+import java.util.Map;
+
+public interface NotificationTemplateService {
+
+    /**
+     * 템플릿 생성
+     */
+    NotificationTemplateResponse createTemplate(CreateNotificationTemplateRequest request);
+
+    /**
+     * 기본 템플릿 초기화 (테넌트 첫 설정 시)
+     */
+    void initializeDefaultTemplates();
+
+    /**
+     * 템플릿 목록 조회
+     */
+    List<NotificationTemplateResponse> getTemplates(NotificationCategory category);
+
+    /**
+     * 템플릿 상세 조회
+     */
+    NotificationTemplateResponse getTemplate(Long id);
+
+    /**
+     * 트리거 타입으로 템플릿 조회
+     */
+    NotificationTemplateResponse getTemplateByTrigger(NotificationTrigger triggerType);
+
+    /**
+     * 템플릿 수정
+     */
+    NotificationTemplateResponse updateTemplate(Long id, UpdateNotificationTemplateRequest request);
+
+    /**
+     * 템플릿 활성화
+     */
+    void activateTemplate(Long id);
+
+    /**
+     * 템플릿 비활성화
+     */
+    void deactivateTemplate(Long id);
+
+    /**
+     * 템플릿 삭제
+     */
+    void deleteTemplate(Long id);
+
+    /**
+     * 템플릿 복제
+     */
+    NotificationTemplateResponse duplicateTemplate(Long id);
+
+    /**
+     * 트리거에 따른 알림 발송 (템플릿 변수 치환)
+     */
+    void sendNotificationByTrigger(
+            NotificationTrigger trigger,
+            Long userId,
+            Map<String, String> variables,
+            String link,
+            Long referenceId,
+            String referenceType
+    );
+}

--- a/src/main/java/com/mzc/lp/domain/notification/service/NotificationTemplateServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/notification/service/NotificationTemplateServiceImpl.java
@@ -1,0 +1,223 @@
+package com.mzc.lp.domain.notification.service;
+
+import com.mzc.lp.common.context.TenantContext;
+import com.mzc.lp.domain.notification.constant.NotificationCategory;
+import com.mzc.lp.domain.notification.constant.NotificationTrigger;
+import com.mzc.lp.domain.notification.constant.NotificationType;
+import com.mzc.lp.domain.notification.dto.request.CreateNotificationTemplateRequest;
+import com.mzc.lp.domain.notification.dto.request.UpdateNotificationTemplateRequest;
+import com.mzc.lp.domain.notification.dto.response.NotificationTemplateResponse;
+import com.mzc.lp.domain.notification.entity.NotificationTemplate;
+import com.mzc.lp.domain.notification.exception.DuplicateNotificationTemplateException;
+import com.mzc.lp.domain.notification.exception.NotificationTemplateNotFoundException;
+import com.mzc.lp.domain.notification.repository.NotificationTemplateRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class NotificationTemplateServiceImpl implements NotificationTemplateService {
+
+    private final NotificationTemplateRepository templateRepository;
+    private final NotificationService notificationService;
+
+    @Override
+    @Transactional
+    public NotificationTemplateResponse createTemplate(CreateNotificationTemplateRequest request) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 중복 체크
+        if (templateRepository.existsByTenantIdAndTriggerType(tenantId, request.triggerType())) {
+            throw new DuplicateNotificationTemplateException(request.triggerType());
+        }
+
+        NotificationTemplate template = NotificationTemplate.create(
+                request.triggerType(),
+                request.name(),
+                request.titleTemplate(),
+                request.messageTemplate(),
+                request.description()
+        );
+
+        templateRepository.save(template);
+        log.info("Created notification template: {} for tenant: {}", request.triggerType(), tenantId);
+
+        return NotificationTemplateResponse.from(template);
+    }
+
+    @Override
+    @Transactional
+    public void initializeDefaultTemplates() {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        log.info("Initializing default notification templates for tenant: {}", tenantId);
+
+        for (NotificationTrigger trigger : NotificationTrigger.values()) {
+            if (!templateRepository.existsByTenantIdAndTriggerType(tenantId, trigger)) {
+                NotificationTemplate template = NotificationTemplate.createDefault(trigger);
+                templateRepository.save(template);
+                log.debug("Created default template: {} for tenant: {}", trigger, tenantId);
+            }
+        }
+    }
+
+    @Override
+    @Transactional
+    public List<NotificationTemplateResponse> getTemplates(NotificationCategory category) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 템플릿이 하나도 없으면 기본 템플릿 자동 생성
+        long templateCount = templateRepository.countByTenantId(tenantId);
+        if (templateCount == 0) {
+            log.info("No templates found for tenant: {}. Initializing default templates.", tenantId);
+
+            // 기본 템플릿 생성
+            for (NotificationTrigger trigger : NotificationTrigger.values()) {
+                if (!templateRepository.existsByTenantIdAndTriggerType(tenantId, trigger)) {
+                    NotificationTemplate template = NotificationTemplate.createDefault(trigger);
+                    templateRepository.save(template);
+                    log.debug("Created default template: {} for tenant: {}", trigger, tenantId);
+                }
+            }
+        }
+
+        List<NotificationTemplate> templates;
+        if (category != null) {
+            templates = templateRepository.findByTenantIdAndCategoryOrderByCreatedAtDesc(tenantId, category);
+        } else {
+            templates = templateRepository.findByTenantIdOrderByCreatedAtDesc(tenantId);
+        }
+
+        return templates.stream()
+                .map(NotificationTemplateResponse::from)
+                .toList();
+    }
+
+    @Override
+    public NotificationTemplateResponse getTemplate(Long id) {
+        NotificationTemplate template = findTemplate(id);
+        return NotificationTemplateResponse.from(template);
+    }
+
+    @Override
+    public NotificationTemplateResponse getTemplateByTrigger(NotificationTrigger triggerType) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        NotificationTemplate template = templateRepository.findByTenantIdAndTriggerType(tenantId, triggerType)
+                .orElseThrow(() -> new NotificationTemplateNotFoundException(0L));
+        return NotificationTemplateResponse.from(template);
+    }
+
+    @Override
+    @Transactional
+    public NotificationTemplateResponse updateTemplate(Long id, UpdateNotificationTemplateRequest request) {
+        NotificationTemplate template = findTemplate(id);
+        template.update(
+                request.name(),
+                request.titleTemplate(),
+                request.messageTemplate(),
+                request.description()
+        );
+
+        log.info("Updated notification template: {}", id);
+        return NotificationTemplateResponse.from(template);
+    }
+
+    @Override
+    @Transactional
+    public void activateTemplate(Long id) {
+        NotificationTemplate template = findTemplate(id);
+        template.activate();
+        log.info("Activated notification template: {}", id);
+    }
+
+    @Override
+    @Transactional
+    public void deactivateTemplate(Long id) {
+        NotificationTemplate template = findTemplate(id);
+        template.deactivate();
+        log.info("Deactivated notification template: {}", id);
+    }
+
+    @Override
+    @Transactional
+    public void deleteTemplate(Long id) {
+        NotificationTemplate template = findTemplate(id);
+        templateRepository.delete(template);
+        log.info("Deleted notification template: {}", id);
+    }
+
+    @Override
+    @Transactional
+    public NotificationTemplateResponse duplicateTemplate(Long id) {
+        NotificationTemplate original = findTemplate(id);
+
+        // 복제된 템플릿은 다른 트리거 타입을 가질 수 없으므로, 이름만 변경하여 저장
+        // 실제로는 같은 트리거 타입으로 복제 불가
+        throw new UnsupportedOperationException("트리거 타입이 동일한 템플릿은 복제할 수 없습니다. 다른 트리거 타입으로 새 템플릿을 생성해주세요.");
+    }
+
+    @Override
+    @Transactional
+    public void sendNotificationByTrigger(
+            NotificationTrigger trigger,
+            Long userId,
+            Map<String, String> variables,
+            String link,
+            Long referenceId,
+            String referenceType
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+
+        // 활성화된 템플릿 조회
+        Optional<NotificationTemplate> templateOpt = templateRepository
+                .findByTenantIdAndTriggerTypeAndIsActiveTrue(tenantId, trigger);
+
+        if (templateOpt.isEmpty()) {
+            log.debug("No active template found for trigger: {} in tenant: {}", trigger, tenantId);
+            return;
+        }
+
+        NotificationTemplate template = templateOpt.get();
+
+        // 템플릿 변수 치환
+        String title = template.renderTitle(variables);
+        String message = template.renderMessage(variables);
+
+        // 알림 타입 매핑
+        NotificationType notificationType = mapTriggerToNotificationType(trigger);
+
+        // 알림 생성
+        notificationService.createNotification(
+                userId,
+                notificationType,
+                title,
+                message,
+                link,
+                referenceId,
+                referenceType,
+                null,  // actorId
+                null   // actorName
+        );
+
+        log.info("Sent notification for trigger: {} to user: {}", trigger, userId);
+    }
+
+    private NotificationTemplate findTemplate(Long id) {
+        return templateRepository.findById(id)
+                .orElseThrow(() -> new NotificationTemplateNotFoundException(id));
+    }
+
+    private NotificationType mapTriggerToNotificationType(NotificationTrigger trigger) {
+        return switch (trigger) {
+            case WELCOME -> NotificationType.SYSTEM;
+            case ENROLLMENT_COMPLETE, COURSE_COMPLETE -> NotificationType.COURSE;
+        };
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/AuthServiceImpl.java
@@ -1,6 +1,7 @@
 package com.mzc.lp.domain.user.service;
 
 import com.mzc.lp.common.security.JwtProvider;
+import com.mzc.lp.domain.notification.event.NotificationEventPublisher;
 import com.mzc.lp.domain.user.constant.TenantRole;
 import com.mzc.lp.domain.user.dto.request.LoginRequest;
 import com.mzc.lp.domain.user.dto.request.RefreshTokenRequest;
@@ -37,6 +38,7 @@ public class AuthServiceImpl implements AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+    private final NotificationEventPublisher notificationEventPublisher;
 
     @Value("${jwt.access-expiration}")
     private long accessTokenExpiry;
@@ -61,6 +63,13 @@ public class AuthServiceImpl implements AuthService {
         // 저장
         User savedUser = userRepository.save(user);
         log.info("User registered: userId={}", savedUser.getId());
+
+        // 회원가입 환영 알림 발송
+        notificationEventPublisher.publishWelcome(
+                savedUser.getTenantId(),
+                savedUser.getId(),
+                savedUser.getName()
+        );
 
         return UserResponse.from(savedUser);
     }

--- a/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
@@ -40,6 +40,7 @@ import com.mzc.lp.domain.tenant.repository.TenantRepository;
 
 import com.mzc.lp.domain.user.dto.request.UpdateUserRolesRequest;
 import com.mzc.lp.domain.user.dto.response.UserRolesResponse;
+import com.mzc.lp.domain.notification.event.NotificationEventPublisher;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -69,6 +70,7 @@ public class UserServiceImpl implements UserService {
     private final UserExcelParser userExcelParser;
     private final EmployeeRepository employeeRepository;
     private final TenantRepository tenantRepository;
+    private final NotificationEventPublisher notificationEventPublisher;
 
     @Override
     public UserDetailResponse getMe(Long userId) {
@@ -361,6 +363,13 @@ public class UserServiceImpl implements UserService {
                             savedUser.getEmail(),
                             savedUser.getName()
                     ));
+
+                    // 회원가입 환영 알림 발송
+                    notificationEventPublisher.publishWelcome(
+                            tenantId,
+                            savedUser.getId(),
+                            savedUser.getName()
+                    );
                 } catch (Exception e) {
                     log.warn("Failed to create user: email={}, error={}", email, e.getMessage());
                     failedUsers.add(new BulkCreateUsersResponse.FailedUserInfo(email, e.getMessage()));
@@ -491,6 +500,13 @@ public class UserServiceImpl implements UserService {
                             employeeLinked,
                             employeeId
                     ));
+
+                    // 회원가입 환영 알림 발송
+                    notificationEventPublisher.publishWelcome(
+                            tenantId,
+                            savedUser.getId(),
+                            savedUser.getName()
+                    );
 
                     // 자동 연동된 임직원 정보 추가
                     if (employeeLinked) {

--- a/src/main/resources/migration/V20260114_2__add_notification_templates_table.sql
+++ b/src/main/resources/migration/V20260114_2__add_notification_templates_table.sql
@@ -1,0 +1,24 @@
+-- 알림 템플릿 테이블 생성
+CREATE TABLE notification_templates (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    tenant_id BIGINT NOT NULL,
+    trigger_type VARCHAR(50) NOT NULL,
+    category VARCHAR(20) NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    title_template VARCHAR(200) NOT NULL,
+    message_template TEXT NOT NULL,
+    description VARCHAR(500),
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    version BIGINT DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    CONSTRAINT uk_notification_template_trigger UNIQUE (tenant_id, trigger_type),
+    CONSTRAINT fk_notification_template_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id)
+);
+
+-- 인덱스 추가
+CREATE INDEX idx_notification_template_tenant ON notification_templates(tenant_id);
+CREATE INDEX idx_notification_template_trigger ON notification_templates(tenant_id, trigger_type);
+CREATE INDEX idx_notification_template_category ON notification_templates(tenant_id, category);
+CREATE INDEX idx_notification_template_active ON notification_templates(tenant_id, is_active);

--- a/src/main/resources/migration/V20260114_3__cleanup_notification_templates.sql
+++ b/src/main/resources/migration/V20260114_3__cleanup_notification_templates.sql
@@ -1,0 +1,3 @@
+-- 작동하지 않는 트리거 타입의 알림 템플릿 삭제
+DELETE FROM notification_templates
+WHERE trigger_type NOT IN ('WELCOME', 'ENROLLMENT_COMPLETE', 'COURSE_COMPLETE');


### PR DESCRIPTION
## Summary

알림 템플릿 관리 시스템을 추가하여 TA가 회원가입, 수강신청 완료, 강의 완료 시 발송되는 알림을 커스터마이징할 수 있도록 합니다. 최초 접근 시 자동으로 기본 템플릿이 생성되어 즉시 사용 가능합니다.

## Related Issue

- N/A

## Changes

- `NotificationTemplate` 엔티티 및 리포지토리 추가
- `NotificationTemplateService` 및 컨트롤러 추가 (TA 전용 CRUD 엔드포인트)
- 알림 트리거 3종 추가: `WELCOME` (회원가입), `ENROLLMENT_COMPLETE` (수강신청 완료), `COURSE_COMPLETE` (강의 완료)
- 알림 이벤트 시스템 구현 (`@Async`를 통한 비동기 처리)
- 최초 접근 시 기본 템플릿 자동 초기화 로직 추가
- `AuthServiceImpl` 및 `EnrollmentServiceImpl`에 알림 이벤트 발행 통합
- DB 마이그레이션 추가 (`notification_templates` 테이블)

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

- 템플릿은 테넌트별로 격리되어 저장됩니다
- 기본 템플릿은 최초 `/api/admin/notification-templates` 조회 시 자동 생성됩니다
- 알림 발송은 비동기로 처리되어 메인 플로우에 영향을 주지 않습니다
