### PR TITLE
[Fix] 파일 교체 시 contentType 자동 업데이트

### DIFF
--- a/src/main/java/com/mzc/lp/domain/content/entity/Content.java
+++ b/src/main/java/com/mzc/lp/domain/content/entity/Content.java
@@ -193,11 +193,14 @@ public class Content extends TenantEntity {
 
     // 비즈니스 메서드 - 파일 교체 (콘텐츠 이름은 유지, 파일 정보만 교체)
     public void replaceFile(String uploadedFileName, String storedFileName,
-                           Long fileSize, String filePath) {
+                           Long fileSize, String filePath, ContentType contentType) {
         this.uploadedFileName = uploadedFileName;
         this.storedFileName = storedFileName;
         this.fileSize = fileSize;
         this.filePath = filePath;
+        if (contentType != null) {
+            this.contentType = contentType;
+        }
     }
 
     // 비즈니스 메서드 - 버전 복원 (모든 정보 복원)


### PR DESCRIPTION
## Summary
- 파일 교체 시 새 파일의 확장자로 contentType 자동 감지
- 동영상→문서 등 파일 교체 시 타입이 올바르게 변경됨

## Changes
- `Content.replaceFile()`: contentType 파라미터 추가
- `ContentServiceImpl.replaceFile()`: 확장자 기반 contentType 감지 로직 추가

## Test plan
- [x] 동영상 콘텐츠를 문서 파일로 교체 후 contentType이 DOCUMENT로 변경되는지 확인
- [x] 문서 콘텐츠를 이미지로 교체 후 contentType이 IMAGE로 변경되는지 확인

Fixes #386