### PR TITLE
fix(security): 커뮤니티 인증 필요 엔드포인트 permitAll 제외

### DIFF
--- a/src/main/java/com/mzc/lp/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mzc/lp/common/security/JwtAuthenticationFilter.java
@@ -68,7 +68,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 path.equals("/api/tenant/settings/layout/public") ||
                 path.equals("/api/tenant/settings/navigation/public") ||
                 (path.startsWith("/api/courses") && !path.equals("/api/courses/my")) ||
-                path.startsWith("/api/community/posts") ||
+                (path.startsWith("/api/community/posts") && !path.equals("/api/community/posts/my") && !path.equals("/api/community/posts/commented")) ||
                 path.equals("/api/community/categories") ||
                 path.startsWith("/api/public/course-times") ||
                 path.startsWith("/api/banners/public")) {


### PR DESCRIPTION
## Summary

커뮤니티 인증 필요 API(`/my`, `/commented`)가 permitAll로 처리되어 403 에러가 발생하던 문제를 수정했습니다.

## Related Issue

- Closes #

## Changes

- `JwtAuthenticationFilter`의 permitAll 체크에서 인증 필요 엔드포인트 제외
  - `/api/community/posts/my` (내 게시글 조회)
  - `/api/community/posts/commented` (댓글 단 게시글 조회)
- `@PreAuthorize("isAuthenticated()")`가 적용된 엔드포인트는 JWT 토큰 검증이 필요하므로 permitAll에서 제외

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

**문제 원인:**
`path.startsWith("/api/community/posts")`가 `/api/community/posts/my`와 `/api/community/posts/commented`도 포함하여 토큰 검증을 건너뛰었음. 이로 인해 `@PreAuthorize`에서 인증 정보가 없어 403 Access Denied 발생.

**수정 내용:**
```java
// Before
path.startsWith("/api/community/posts")

// After
(path.startsWith("/api/community/posts") && !path.equals("/api/community/posts/my") && !path.equals("/api/community/posts/commented"))

