### PR TITLE
Feature/notice target audience expansion

### DIFF
--- a/src/main/java/com/mzc/lp/domain/tenantnotice/constant/NoticeTargetAudience.java
+++ b/src/main/java/com/mzc/lp/domain/tenantnotice/constant/NoticeTargetAudience.java
@@ -2,9 +2,13 @@ package com.mzc.lp.domain.tenantnotice.constant;
 
 /**
  * 공지사항 대상자
+ * TA가 CO, TU, DESIGNER, INSTRUCTOR에게 공지 가능
+ * CO가 TU에게 공지 가능
  */
 public enum NoticeTargetAudience {
-    ALL,         // 전체 대상 (운영자 + 사용자)
+    ALL,         // 전체 대상 (모든 역할)
     OPERATOR,    // 운영자 대상 (TA → CO)
-    USER         // 사용자 대상 (TA → TU, CO → TU)
+    USER,        // 일반 사용자 대상 (TA/CO → TU)
+    DESIGNER,    // 설계자 대상 (TA → DESIGNER)
+    INSTRUCTOR   // 강사 대상 (TA → INSTRUCTOR)
 }

--- a/src/main/java/com/mzc/lp/domain/tenantnotice/service/TenantNoticeService.java
+++ b/src/main/java/com/mzc/lp/domain/tenantnotice/service/TenantNoticeService.java
@@ -8,6 +8,8 @@ import com.mzc.lp.domain.tenantnotice.dto.response.TenantNoticeResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Set;
+
 /**
  * 테넌트 공지사항 서비스 인터페이스
  */
@@ -75,4 +77,24 @@ public interface TenantNoticeService {
      * 발행된 공지 수 조회
      */
     long countVisibleNotices(Long tenantId, NoticeTargetAudience targetAudience);
+
+    // ============================================
+    // TU/CO 다중 역할 지원 API
+    // ============================================
+
+    /**
+     * 발행된 공지사항 목록 조회 (다중 역할 지원)
+     * 사용자의 모든 역할에 해당하는 공지 조회
+     */
+    Page<TenantNoticeResponse> getVisibleNoticesForMultipleAudiences(Long tenantId, Set<NoticeTargetAudience> targetAudiences, Pageable pageable);
+
+    /**
+     * 발행된 공지사항 상세 조회 (다중 역할 지원, 조회수 증가)
+     */
+    TenantNoticeResponse getVisibleNoticeForMultipleAudiences(Long tenantId, Long noticeId, Set<NoticeTargetAudience> targetAudiences);
+
+    /**
+     * 발행된 공지 수 조회 (다중 역할 지원)
+     */
+    long countVisibleNoticesForMultipleAudiences(Long tenantId, Set<NoticeTargetAudience> targetAudiences);
 }

--- a/src/main/java/com/mzc/lp/domain/user/dto/response/UserDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/response/UserDetailResponse.java
@@ -1,10 +1,13 @@
 package com.mzc.lp.domain.user.dto.response;
 
+import com.mzc.lp.domain.user.constant.TenantRole;
 import com.mzc.lp.domain.user.entity.User;
 
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public record UserDetailResponse(
         Long userId,
@@ -15,6 +18,7 @@ public record UserDetailResponse(
         String department,
         String position,
         String role,
+        Set<String> roles,  // 다중 역할 (1:N)
         String status,
         Long tenantId,
         String tenantSubdomain,
@@ -62,6 +66,7 @@ public record UserDetailResponse(
                 user.getDepartment(),
                 user.getPosition(),
                 user.getRole().name(),
+                user.getRoles().stream().map(TenantRole::name).collect(Collectors.toSet()),
                 user.getStatus().name(),
                 user.getTenantId(),
                 null,
@@ -83,6 +88,7 @@ public record UserDetailResponse(
                 user.getDepartment(),
                 user.getPosition(),
                 user.getRole().name(),
+                user.getRoles().stream().map(TenantRole::name).collect(Collectors.toSet()),
                 user.getStatus().name(),
                 user.getTenantId(),
                 null,
@@ -104,6 +110,7 @@ public record UserDetailResponse(
                 user.getDepartment(),
                 user.getPosition(),
                 user.getRole().name(),
+                user.getRoles().stream().map(TenantRole::name).collect(Collectors.toSet()),
                 user.getStatus().name(),
                 user.getTenantId(),
                 tenantSubdomain,

--- a/src/main/java/com/mzc/lp/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/mzc/lp/domain/user/repository/UserRepository.java
@@ -121,6 +121,28 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
             "AND u.status = 'ACTIVE'")
     List<Long> findActiveUserIdsByTenantId(@Param("tenantId") Long tenantId);
 
+    /**
+     * 테넌트별 특정 역할의 활성 사용자 ID 목록 조회 (공지 알림 발송용)
+     */
+    @Query("SELECT u.id FROM User u " +
+            "WHERE u.tenantId = :tenantId " +
+            "AND u.status = 'ACTIVE' " +
+            "AND u.role = :role")
+    List<Long> findActiveUserIdsByTenantIdAndRole(
+            @Param("tenantId") Long tenantId,
+            @Param("role") com.mzc.lp.domain.user.constant.TenantRole role);
+
+    /**
+     * 테넌트별 여러 역할의 활성 사용자 ID 목록 조회 (공지 알림 발송용)
+     */
+    @Query("SELECT u.id FROM User u " +
+            "WHERE u.tenantId = :tenantId " +
+            "AND u.status = 'ACTIVE' " +
+            "AND u.role IN :roles")
+    List<Long> findActiveUserIdsByTenantIdAndRoles(
+            @Param("tenantId") Long tenantId,
+            @Param("roles") java.util.Collection<com.mzc.lp.domain.user.constant.TenantRole> roles);
+
     // ===== 기간 필터 통계 쿼리 (SA 대시보드) - 전체 사용자 =====
 
     /**

--- a/src/main/java/com/mzc/lp/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/mzc/lp/domain/user/repository/UserRepository.java
@@ -143,6 +143,31 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
             @Param("tenantId") Long tenantId,
             @Param("roles") java.util.Collection<com.mzc.lp.domain.user.constant.TenantRole> roles);
 
+    /**
+     * 테넌트별 특정 역할을 가진 활성 사용자 ID 목록 조회 (userRoles 테이블 기준 - 다중 역할 지원)
+     * 사용자의 기본 역할(u.role) 또는 추가 역할(userRoles)에 해당 역할이 있으면 포함
+     */
+    @Query("SELECT DISTINCT u.id FROM User u " +
+            "LEFT JOIN u.userRoles ur " +
+            "WHERE u.tenantId = :tenantId " +
+            "AND u.status = 'ACTIVE' " +
+            "AND (u.role = :role OR ur.role = :role)")
+    List<Long> findActiveUserIdsByTenantIdHavingRole(
+            @Param("tenantId") Long tenantId,
+            @Param("role") com.mzc.lp.domain.user.constant.TenantRole role);
+
+    /**
+     * 테넌트별 여러 역할 중 하나를 가진 활성 사용자 ID 목록 조회 (userRoles 테이블 기준 - 다중 역할 지원)
+     */
+    @Query("SELECT DISTINCT u.id FROM User u " +
+            "LEFT JOIN u.userRoles ur " +
+            "WHERE u.tenantId = :tenantId " +
+            "AND u.status = 'ACTIVE' " +
+            "AND (u.role IN :roles OR ur.role IN :roles)")
+    List<Long> findActiveUserIdsByTenantIdHavingAnyRole(
+            @Param("tenantId") Long tenantId,
+            @Param("roles") java.util.Collection<com.mzc.lp.domain.user.constant.TenantRole> roles);
+
     // ===== 기간 필터 통계 쿼리 (SA 대시보드) - 전체 사용자 =====
 
     /**


### PR DESCRIPTION
## Summary

공지사항 다중 역할 지원 및 알림 템플릿 자동 초기화 기능을 구현했습니다. 사용자가 여러 역할을 가질 때 모든 역할에 해당하는 공지사항을 볼 수 있으며, 알림 템플릿이 없어도 자동으로 생성되어 수강신청 완료 알림이 즉시 발송됩니다.

## Related Issue

- Closes #

## Changes

### 공지사항 다중 역할 지원
- TU/CO 사용자가 여러 역할(USER, INSTRUCTOR 등)을 동시에 가질 때 모든 역할에 해당하는 공지 조회 가능
- `TuTenantNoticeController`에서 사용자의 모든 역할(`roles`, `courseRoles`)을 기반으로 대상 Set 생성
- `TenantNoticeRepository`에 IN 절 사용하는 쿼리 추가 (`findVisibleNoticesForMultipleAudiences`)
- `TenantNoticeService`에 다중 역할 지원 메서드 추가

### 알림 발송 대상 선정 개선
- `UserRepository`에 `userRoles` 테이블 조인하는 쿼리 추가
- `findActiveUserIdsByTenantIdHavingRole`: 기본 역할(`u.role`) 또는 추가 역할(`user_roles`) 확인
- 공지사항 발행 시 USER+INSTRUCTOR 역할을 가진 사용자도 USER 대상 공지 수신 가능

### 알림 템플릿 자동 초기화
- `NotificationTemplateServiceImpl.sendNotificationByTrigger()`에서 템플릿 없을 시 자동 생성
- 기본 템플릿이 활성화 상태로 생성되어 별도 설정 없이 즉시 알림 발송 가능
- 템플릿이 비활성화 상태일 경우에만 알림 발송 건너뜀

### 수강신청 완료 알림
- `ENROLLMENT_COMPLETE` 트리거로 COURSE 타입 알림 자동 발송
- 기본 메시지: "{유저명}님, {강좌명} 강좌 수강신청이 완료되었습니다."
- 알림 클릭 시 `/my-courses/{courseTimeId}`로 이동

### 기타 개선
- 공지사항 발행 알림 링크를 `/tu/b2c/notifications?tab=SYSTEM`으로 변경

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### 주요 파일 변경사항
- `TuTenantNoticeController.java`: 다중 역할 처리 로직 추가
- `TenantNoticeRepository.java`: IN 절 쿼리 추가
- `TenantNoticeServiceImpl.java`: 다중 역할 지원 메서드 구현 + 알림 발송 개선
- `UserRepository.java`: `userRoles` 조인 쿼리 추가
- `NotificationTemplateServiceImpl.java`: 템플릿 자동 생성 로직 추가

### 테스트 시나리오
1. USER+INSTRUCTOR 역할을 가진 사용자가 USER 대상 공지를 볼 수 있는지 확인
2. 템플릿이 없는 상태에서 수강신청 시 알림이 자동 발송되는지 확인
3. 템플릿을 비활성화하면 알림이 발송되지 않는지 확인
