### PR TITLE
[과정관리] Course 등록 API에 DESIGNER 권한 추가

### DIFF
--- a/src/main/java/com/mzc/lp/domain/course/controller/CourseController.java
+++ b/src/main/java/com/mzc/lp/domain/course/controller/CourseController.java
@@ -179,7 +179,7 @@ public class CourseController {
      * POST /api/courses/{courseId}/register
      */
     @PostMapping("/{courseId:\\d+}/register")
-    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<CourseResponse>> registerCourse(
             @PathVariable @Positive Long courseId,
             @AuthenticationPrincipal UserPrincipal principal


### PR DESCRIPTION
## Summary

- Course 등록 API (`POST /api/courses/{id}/register`)에 DESIGNER 권한 추가
- DESIGNER(TU) 역할 사용자가 직접 과정 등록 가능 (READY → REGISTERED)

## Changes

- `CourseController.registerCourse()` 메서드의 `@PreAuthorize` 수정
  - Before: `hasAnyRole('OPERATOR', 'TENANT_ADMIN')`
  - After: `hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')`

## Test plan

- [ ] DESIGNER 역할로 로그인
- [ ] READY 상태의 과정에 대해 `/api/courses/{id}/register` API 호출
- [ ] 200 OK 응답 및 상태가 REGISTERED로 변경되는지 확인
- [ ] OPERATOR, TENANT_ADMIN 역할도 정상 작동하는지 확인

## Related Issues

- Closes #390
- 관련 프론트엔드 이슈: mzc-lp-frontend#456, mzc-lp-frontend#457