### PR TITLE
feat: Course API 응답에 생성자/카테고리/차수 정보 추가

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(./gradlew test:*)",
       "Bash(taskkill //F //PID 175528)",
-      "Bash(./gradlew bootRun)"
+      "Bash(./gradlew bootRun)",
+      "Bash(git add:*)"
     ]
   }
 }

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseDetailResponse.java
@@ -28,7 +28,9 @@ public record CourseDetailResponse(
         Double averageRating,
         long reviewCount,
         Instant createdAt,
-        Instant updatedAt
+        Instant updatedAt,
+        Long creatorId,
+        String creatorName
 ) {
     /**
      * 완성도 판단 기준:
@@ -46,15 +48,20 @@ public record CourseDetailResponse(
 
     public static CourseDetailResponse from(Course course, List<CourseItemResponse> items) {
         int count = items != null ? items.size() : 0;
-        return from(course, items, count, null, 0L);
+        return from(course, items, count, null, 0L, null);
     }
 
     public static CourseDetailResponse from(Course course, List<CourseItemResponse> items, int itemCount) {
-        return from(course, items, itemCount, null, 0L);
+        return from(course, items, itemCount, null, 0L, null);
     }
 
     public static CourseDetailResponse from(Course course, List<CourseItemResponse> items, int itemCount,
                                              Double averageRating, long reviewCount) {
+        return from(course, items, itemCount, averageRating, reviewCount, null);
+    }
+
+    public static CourseDetailResponse from(Course course, List<CourseItemResponse> items, int itemCount,
+                                             Double averageRating, long reviewCount, String creatorName) {
         return new CourseDetailResponse(
                 course.getId(),
                 course.getTitle(),
@@ -74,7 +81,9 @@ public record CourseDetailResponse(
                 averageRating != null ? Math.round(averageRating * 10.0) / 10.0 : 0.0,
                 reviewCount,
                 course.getCreatedAt(),
-                course.getUpdatedAt()
+                course.getUpdatedAt(),
+                course.getCreatedBy(),
+                creatorName
         );
     }
 }

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseResponse.java
@@ -25,7 +25,9 @@ public record CourseResponse(
         Instant createdAt,
         Instant updatedAt,
         boolean isComplete,
-        int itemCount
+        int itemCount,
+        Long creatorId,
+        String creatorName
 ) {
     /**
      * 완성도 판단 기준:
@@ -42,10 +44,14 @@ public record CourseResponse(
     }
 
     public static CourseResponse from(Course course) {
-        return from(course, 0);
+        return from(course, 0, null);
     }
 
     public static CourseResponse from(Course course, int itemCount) {
+        return from(course, itemCount, null);
+    }
+
+    public static CourseResponse from(Course course, int itemCount, String creatorName) {
         return new CourseResponse(
                 course.getId(),
                 course.getTitle(),
@@ -62,7 +68,9 @@ public record CourseResponse(
                 course.getCreatedAt(),
                 course.getUpdatedAt(),
                 checkCompleteness(course, itemCount),
-                itemCount
+                itemCount,
+                course.getCreatedBy(),
+                creatorName
         );
     }
 }

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseResponse.java
@@ -19,6 +19,7 @@ public record CourseResponse(
         CourseStatus status,
         Integer estimatedHours,
         Long categoryId,
+        String categoryName,
         LocalDate startDate,
         LocalDate endDate,
         List<String> tags,
@@ -26,6 +27,7 @@ public record CourseResponse(
         Instant updatedAt,
         boolean isComplete,
         int itemCount,
+        int timeCount,
         Long creatorId,
         String creatorName
 ) {
@@ -44,14 +46,19 @@ public record CourseResponse(
     }
 
     public static CourseResponse from(Course course) {
-        return from(course, 0, null);
+        return from(course, 0, null, null, 0);
     }
 
     public static CourseResponse from(Course course, int itemCount) {
-        return from(course, itemCount, null);
+        return from(course, itemCount, null, null, 0);
     }
 
     public static CourseResponse from(Course course, int itemCount, String creatorName) {
+        return from(course, itemCount, creatorName, null, 0);
+    }
+
+    public static CourseResponse from(Course course, int itemCount, String creatorName,
+                                       String categoryName, int timeCount) {
         return new CourseResponse(
                 course.getId(),
                 course.getTitle(),
@@ -62,6 +69,7 @@ public record CourseResponse(
                 course.getStatus(),
                 course.getEstimatedHours(),
                 course.getCategoryId(),
+                categoryName,
                 course.getStartDate(),
                 course.getEndDate(),
                 course.getTags(),
@@ -69,6 +77,7 @@ public record CourseResponse(
                 course.getUpdatedAt(),
                 checkCompleteness(course, itemCount),
                 itemCount,
+                timeCount,
                 course.getCreatedBy(),
                 creatorName
         );

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
@@ -117,8 +117,8 @@ public class CourseServiceImpl implements CourseService {
         return courses.map(course -> CourseResponse.from(
                 course,
                 0,
-                creatorNameMap.get(course.getCreatedBy()),
-                categoryNameMap.get(course.getCategoryId()),
+                course.getCreatedBy() != null ? creatorNameMap.get(course.getCreatedBy()) : null,
+                course.getCategoryId() != null ? categoryNameMap.get(course.getCategoryId()) : null,
                 timeCountMap.getOrDefault(course.getId(), 0)
         ));
     }

--- a/src/main/java/com/mzc/lp/domain/ts/repository/CourseTimeRepository.java
+++ b/src/main/java/com/mzc/lp/domain/ts/repository/CourseTimeRepository.java
@@ -267,4 +267,15 @@ public interface CourseTimeRepository extends JpaRepository<CourseTime, Long>, J
     List<Long> findIdsByCourseIdInAndTenantId(
             @Param("courseIds") List<Long> courseIds,
             @Param("tenantId") Long tenantId);
+
+    /**
+     * Course ID 목록별 차수 카운트 일괄 조회
+     */
+    @Query("SELECT ct.course.id, COUNT(ct) FROM CourseTime ct " +
+            "WHERE ct.course.id IN :courseIds " +
+            "AND ct.tenantId = :tenantId " +
+            "GROUP BY ct.course.id")
+    List<Object[]> countByCourseIds(
+            @Param("courseIds") List<Long> courseIds,
+            @Param("tenantId") Long tenantId);
 }


### PR DESCRIPTION
## Summary

CO(운영자) 페이지에서 과정 목록/상세 조회 시 생성자 정보, 카테고리명, 차수 수를 표시하기 위해 Course API 응답 필드를 확장합니다.

## Related Issue

- Closes #

## Changes

- `CourseResponse`에 `creatorId`, `creatorName`, `categoryName`, `timeCount` 필드 추가
- `CourseDetailResponse`에 `creatorId`, `creatorName` 필드 추가
- `CourseServiceImpl`에서 User, Category, CourseTime 일괄 조회 로직 추가 (N+1 방지)
- `CourseTimeRepository`에 `countByCourseIds` 쿼리 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)