### PR TITLE
fix: 알림 참조를 courseTimeId에서 enrollmentId로 변경

### DIFF
--- a/src/main/java/com/mzc/lp/domain/notification/event/NotificationEventPublisher.java
+++ b/src/main/java/com/mzc/lp/domain/notification/event/NotificationEventPublisher.java
@@ -63,30 +63,30 @@ public class NotificationEventPublisher {
     /**
      * 수강신청 완료 알림
      */
-    public void publishEnrollmentComplete(Long tenantId, Long userId, String userName, String courseName, Long courseTimeId) {
+    public void publishEnrollmentComplete(Long tenantId, Long userId, String userName, String courseName, Long enrollmentId) {
         publish(
                 NotificationTrigger.ENROLLMENT_COMPLETE,
                 tenantId,
                 userId,
                 Map.of("userName", userName, "courseName", courseName),
-                "/my-courses/" + courseTimeId,
-                courseTimeId,
-                "COURSE_TIME"
+                "/my-courses/" + enrollmentId,
+                enrollmentId,
+                "ENROLLMENT"
         );
     }
 
     /**
      * 과정 완료 축하 알림
      */
-    public void publishCourseComplete(Long tenantId, Long userId, String userName, String courseName, Long courseTimeId) {
+    public void publishCourseComplete(Long tenantId, Long userId, String userName, String courseName, Long enrollmentId) {
         publish(
                 NotificationTrigger.COURSE_COMPLETE,
                 tenantId,
                 userId,
                 Map.of("userName", userName, "courseName", courseName),
-                "/my-courses/" + courseTimeId,
-                courseTimeId,
-                "COURSE_TIME"
+                "/my-courses/" + enrollmentId,
+                enrollmentId,
+                "ENROLLMENT"
         );
     }
 }

--- a/src/main/java/com/mzc/lp/domain/student/repository/EnrollmentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/student/repository/EnrollmentRepository.java
@@ -333,4 +333,13 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
             "WHERE e.courseTimeId = :courseTimeId " +
             "AND e.status != 'DROPPED'")
     List<Long> findUserIdsByCourseTimeId(@Param("courseTimeId") Long courseTimeId);
+
+    /**
+     * 차수별 수강 목록 조회 (알림 발송용 - enrollmentId 필요)
+     * DROPPED 상태 제외
+     */
+    @Query("SELECT e FROM Enrollment e " +
+            "WHERE e.courseTimeId = :courseTimeId " +
+            "AND e.status != 'DROPPED'")
+    List<Enrollment> findAllByCourseTimeId(@Param("courseTimeId") Long courseTimeId);
 }

--- a/src/main/java/com/mzc/lp/domain/ts/scheduler/CourseTimeScheduler.java
+++ b/src/main/java/com/mzc/lp/domain/ts/scheduler/CourseTimeScheduler.java
@@ -2,6 +2,7 @@ package com.mzc.lp.domain.ts.scheduler;
 
 import com.mzc.lp.domain.notification.constant.NotificationType;
 import com.mzc.lp.domain.notification.service.NotificationService;
+import com.mzc.lp.domain.student.entity.Enrollment;
 import com.mzc.lp.domain.student.repository.EnrollmentRepository;
 import com.mzc.lp.domain.ts.constant.CourseTimeStatus;
 import com.mzc.lp.domain.ts.entity.CourseTime;
@@ -72,30 +73,30 @@ public class CourseTimeScheduler {
      */
     private void sendCourseStartNotifications(CourseTime courseTime) {
         try {
-            List<Long> userIds = enrollmentRepository.findUserIdsByCourseTimeId(courseTime.getId());
+            List<Enrollment> enrollments = enrollmentRepository.findAllByCourseTimeId(courseTime.getId());
             log.info("[Batch] Sending course start notification to {} users for courseTime: {}",
-                    userIds.size(), courseTime.getId());
+                    enrollments.size(), courseTime.getId());
 
             String title = "강의 시작 안내";
             String message = String.format("[%s] 강의가 시작되었습니다.", courseTime.getTitle());
-            String link = "/my-courses/" + courseTime.getId();
 
-            for (Long userId : userIds) {
+            for (Enrollment enrollment : enrollments) {
                 try {
+                    String link = "/my-courses/" + enrollment.getId();
                     notificationService.createNotification(
-                            userId,
+                            enrollment.getUserId(),
                             NotificationType.COURSE,
                             title,
                             message,
                             link,
-                            courseTime.getId(),
-                            "COURSE_TIME",
+                            enrollment.getId(),
+                            "ENROLLMENT",
                             null,
                             null
                     );
                 } catch (Exception e) {
                     log.warn("[Batch] Failed to send course start notification to user {}: {}",
-                            userId, e.getMessage());
+                            enrollment.getUserId(), e.getMessage());
                 }
             }
         } catch (Exception e) {
@@ -152,30 +153,30 @@ public class CourseTimeScheduler {
      */
     private void sendCourseEndNotifications(CourseTime courseTime) {
         try {
-            List<Long> userIds = enrollmentRepository.findUserIdsByCourseTimeId(courseTime.getId());
+            List<Enrollment> enrollments = enrollmentRepository.findAllByCourseTimeId(courseTime.getId());
             log.info("[Batch] Sending course end notification to {} users for courseTime: {}",
-                    userIds.size(), courseTime.getId());
+                    enrollments.size(), courseTime.getId());
 
             String title = "강의 종료 안내";
             String message = String.format("[%s] 강의가 종료되었습니다.", courseTime.getTitle());
-            String link = "/my-courses/" + courseTime.getId();
 
-            for (Long userId : userIds) {
+            for (Enrollment enrollment : enrollments) {
                 try {
+                    String link = "/my-courses/" + enrollment.getId();
                     notificationService.createNotification(
-                            userId,
+                            enrollment.getUserId(),
                             NotificationType.COURSE,
                             title,
                             message,
                             link,
-                            courseTime.getId(),
-                            "COURSE_TIME",
+                            enrollment.getId(),
+                            "ENROLLMENT",
                             null,
                             null
                     );
                 } catch (Exception e) {
                     log.warn("[Batch] Failed to send course end notification to user {}: {}",
-                            userId, e.getMessage());
+                            enrollment.getUserId(), e.getMessage());
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
## Summary

알림 시스템의 참조 ID를 `courseTimeId`에서 `enrollmentId`로 변경하여 사용자별 수강 내역을 정확히 참조하도록 개선

## Related Issue

- Closes #

## Changes

- `NotificationEventPublisher`: 수강신청/과정완료 알림의 `referenceId`를 `courseTimeId`에서 `enrollmentId`로 변경
- `EnrollmentRepository`: `findAllByCourseTimeId()` 메서드 추가
- `EnrollmentServiceImpl`: 알림 발송 시 `enrollmentId` 전달하도록 수정
- `CourseTimeScheduler`: 강의 시작/종료 알림에서 `enrollmentId` 사용
- `data.sql`: Program 엔티티 제거로 `roadmap_programs`, `cm_programs` INSERT 문 주석 처리

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [x] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

**변경 이유:**
- 알림 링크(`/my-courses/{id}`)가 사용자별 수강 내역을 참조해야 함
- `courseTimeId`는 차수 정보로, 개별 사용자의 수강 내역을 식별할 수 없음
- `enrollmentId`로 변경하여 사용자가 알림 클릭 시 본인의 수강 상세 페이지로 이동 가능

**영향 범위:**
- 수강신청 완료 알림
- 과정 완료 알림
- 강의 시작/종료 알림 (스케줄러)