### PR TITLE
[Feat] 역할 전환 API 및 보안 기능 구현

### DIFF
--- a/src/main/java/com/mzc/lp/common/config/SecurityConfig.java
+++ b/src/main/java/com/mzc/lp/common/config/SecurityConfig.java
@@ -43,7 +43,9 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> {
-                    auth.requestMatchers("/api/auth/**").permitAll()
+                    // switch-role은 인증 필요 (auth/** 패턴보다 먼저 정의)
+                    auth.requestMatchers("/api/auth/switch-role").authenticated()
+                        .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/uploads/**").permitAll()
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()

--- a/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
+++ b/src/main/java/com/mzc/lp/common/constant/ErrorCode.java
@@ -91,6 +91,9 @@ public enum ErrorCode {
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "A002", "Access denied"),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "A003", "Invalid email or password"),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "Invalid or expired token"),
+    ROLE_NOT_ASSIGNED(HttpStatus.FORBIDDEN, "A005", "User does not have the requested role"),
+    LAST_TENANT_ADMIN_CANNOT_BE_REMOVED(HttpStatus.BAD_REQUEST, "A006", "Cannot remove the last tenant admin"),
+    CANNOT_ASSIGN_HIGHER_ROLE(HttpStatus.FORBIDDEN, "A007", "Cannot assign role higher than your own"),
 
     // Instructor (IIS)
     INSTRUCTOR_ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "IIS001", "Instructor assignment not found"),

--- a/src/main/java/com/mzc/lp/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mzc/lp/common/security/JwtAuthenticationFilter.java
@@ -53,6 +53,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String path = request.getRequestURI();
         String method = request.getMethod();
 
+        // /api/auth/switch-role은 인증 필요
+        if (path.equals("/api/auth/switch-role")) {
+            return false;
+        }
+
         // 정적 경로 체크
         for (String permitPath : PERMIT_ALL_PATHS) {
             if (path.startsWith(permitPath)) {

--- a/src/main/java/com/mzc/lp/common/security/JwtProvider.java
+++ b/src/main/java/com/mzc/lp/common/security/JwtProvider.java
@@ -56,6 +56,13 @@ public class JwtProvider {
      * 다중 역할을 포함한 AccessToken 생성
      */
     public String createAccessToken(Long userId, String email, String role, Set<String> roles, Long tenantId) {
+        return createAccessToken(userId, email, role, roles, role, tenantId);
+    }
+
+    /**
+     * 다중 역할 + 현재 선택된 역할을 포함한 AccessToken 생성
+     */
+    public String createAccessToken(Long userId, String email, String role, Set<String> roles, String currentRole, Long tenantId) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + accessTokenExpiry);
 
@@ -64,6 +71,7 @@ public class JwtProvider {
                 .claim("email", email)
                 .claim("role", role)
                 .claim("roles", new ArrayList<>(roles))  // 다중 역할
+                .claim("currentRole", currentRole)       // 현재 선택된 역할
                 .claim("tenantId", tenantId)
                 .issuedAt(now)
                 .expiration(expiry)
@@ -156,6 +164,16 @@ public class JwtProvider {
         // 하위 호환성: roles가 없으면 role 하나만 반환
         String role = claims.get("role", String.class);
         return role != null ? Set.of(role) : Set.of();
+    }
+
+    /**
+     * 현재 선택된 역할 조회
+     */
+    public String getCurrentRole(String token) {
+        Claims claims = getClaims(token);
+        String currentRole = claims.get("currentRole", String.class);
+        // 하위 호환성: currentRole이 없으면 role 반환
+        return currentRole != null ? currentRole : claims.get("role", String.class);
     }
 
     /**

--- a/src/main/java/com/mzc/lp/domain/user/controller/AuthController.java
+++ b/src/main/java/com/mzc/lp/domain/user/controller/AuthController.java
@@ -1,9 +1,11 @@
 package com.mzc.lp.domain.user.controller;
 
 import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
 import com.mzc.lp.domain.user.dto.request.LoginRequest;
 import com.mzc.lp.domain.user.dto.request.RefreshTokenRequest;
 import com.mzc.lp.domain.user.dto.request.RegisterRequest;
+import com.mzc.lp.domain.user.dto.request.SwitchRoleRequest;
 import com.mzc.lp.domain.user.dto.response.TokenResponse;
 import com.mzc.lp.domain.user.dto.response.UserResponse;
 import com.mzc.lp.domain.user.service.AuthService;
@@ -11,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -57,5 +60,14 @@ public class AuthController {
     ) {
         authService.logout(request.refreshToken());
         return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @PostMapping("/switch-role")
+    public ResponseEntity<ApiResponse<TokenResponse>> switchRole(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody SwitchRoleRequest request
+    ) {
+        TokenResponse response = authService.switchRole(principal.id(), request);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/user/dto/request/SwitchRoleRequest.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/request/SwitchRoleRequest.java
@@ -1,0 +1,13 @@
+package com.mzc.lp.domain.user.dto.request;
+
+import com.mzc.lp.domain.user.constant.TenantRole;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 역할 전환 요청 DTO
+ * 사용자가 보유한 여러 역할 중 하나를 선택하여 전환할 때 사용
+ */
+public record SwitchRoleRequest(
+        @NotNull(message = "전환할 역할은 필수입니다")
+        TenantRole targetRole
+) {}

--- a/src/main/java/com/mzc/lp/domain/user/exception/LastTenantAdminException.java
+++ b/src/main/java/com/mzc/lp/domain/user/exception/LastTenantAdminException.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.user.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class LastTenantAdminException extends BusinessException {
+
+    public LastTenantAdminException() {
+        super(ErrorCode.LAST_TENANT_ADMIN_CANNOT_BE_REMOVED);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/exception/RoleNotAssignedException.java
+++ b/src/main/java/com/mzc/lp/domain/user/exception/RoleNotAssignedException.java
@@ -1,0 +1,11 @@
+package com.mzc.lp.domain.user.exception;
+
+import com.mzc.lp.common.constant.ErrorCode;
+import com.mzc.lp.common.exception.BusinessException;
+
+public class RoleNotAssignedException extends BusinessException {
+
+    public RoleNotAssignedException() {
+        super(ErrorCode.ROLE_NOT_ASSIGNED);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/user/service/AuthService.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/AuthService.java
@@ -3,6 +3,7 @@ package com.mzc.lp.domain.user.service;
 import com.mzc.lp.domain.user.dto.request.LoginRequest;
 import com.mzc.lp.domain.user.dto.request.RefreshTokenRequest;
 import com.mzc.lp.domain.user.dto.request.RegisterRequest;
+import com.mzc.lp.domain.user.dto.request.SwitchRoleRequest;
 import com.mzc.lp.domain.user.dto.response.TokenResponse;
 import com.mzc.lp.domain.user.dto.response.UserResponse;
 
@@ -27,4 +28,13 @@ public interface AuthService {
      * 로그아웃
      */
     void logout(String refreshToken);
+
+    /**
+     * 역할 전환
+     * 사용자가 보유한 여러 역할 중 하나를 선택하여 현재 활동 역할을 변경
+     * @param userId 사용자 ID
+     * @param request 전환할 역할 정보
+     * @return 새로운 토큰 (currentRole이 변경됨)
+     */
+    TokenResponse switchRole(Long userId, SwitchRoleRequest request);
 }


### PR DESCRIPTION
## Summary

다중 역할 사용자의 역할 전환 시 서버 측 검증 및 새 토큰 발급 기능을 구현합니다.

## Related Issue

- Closes #400

## Changes

- JwtProvider에 currentRole 클레임 추가
- POST /api/auth/switch-role API 구현
- 역할 전환 시 DB에서 사용자 역할 재검증
- 역할 변경 시 감사 로그 기록 (ActivityLogService)
- 최소 1명 TENANT_ADMIN 유지 검증 로직
- SecurityConfig에서 switch-role 인증 요구 설정
- JwtAuthenticationFilter에서 switch-role 인증 처리
- SwitchRoleRequest DTO 추가
- RoleNotAssignedException, LastTenantAdminException 예외 클래스 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 프론트엔드 PR과 함께 배포 필요: mzcATU/mzc-lp-frontend#482