### PR TITLE
feat: Course 시작일/종료일 필드 제거

### DIFF
--- a/src/main/java/com/mzc/lp/domain/course/dto/request/CreateCourseRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/CreateCourseRequest.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
-import java.time.LocalDate;
 import java.util.List;
 
 public record CreateCourseRequest(
@@ -28,10 +27,6 @@ public record CreateCourseRequest(
 
         @Size(max = 500, message = "썸네일 URL은 500자 이하여야 합니다")
         String thumbnailUrl,
-
-        LocalDate startDate,
-
-        LocalDate endDate,
 
         List<String> tags
 ) {

--- a/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateCourseRequest.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/request/UpdateCourseRequest.java
@@ -6,7 +6,6 @@ import com.mzc.lp.domain.course.constant.CourseType;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
-import java.time.LocalDate;
 import java.util.List;
 
 public record UpdateCourseRequest(
@@ -27,10 +26,6 @@ public record UpdateCourseRequest(
 
         @Size(max = 500, message = "썸네일 URL은 500자 이하여야 합니다")
         String thumbnailUrl,
-
-        LocalDate startDate,
-
-        LocalDate endDate,
 
         List<String> tags,
 

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseDetailResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseDetailResponse.java
@@ -6,7 +6,6 @@ import com.mzc.lp.domain.course.constant.CourseType;
 import com.mzc.lp.domain.course.entity.Course;
 
 import java.time.Instant;
-import java.time.LocalDate;
 import java.util.List;
 
 public record CourseDetailResponse(
@@ -19,8 +18,6 @@ public record CourseDetailResponse(
         CourseStatus status,
         Integer estimatedHours,
         Long categoryId,
-        LocalDate startDate,
-        LocalDate endDate,
         List<String> tags,
         List<CourseItemResponse> items,
         int itemCount,
@@ -72,8 +69,6 @@ public record CourseDetailResponse(
                 course.getStatus(),
                 course.getEstimatedHours(),
                 course.getCategoryId(),
-                course.getStartDate(),
-                course.getEndDate(),
                 course.getTags(),
                 items,
                 itemCount,

--- a/src/main/java/com/mzc/lp/domain/course/dto/response/CourseResponse.java
+++ b/src/main/java/com/mzc/lp/domain/course/dto/response/CourseResponse.java
@@ -6,7 +6,6 @@ import com.mzc.lp.domain.course.constant.CourseType;
 import com.mzc.lp.domain.course.entity.Course;
 
 import java.time.Instant;
-import java.time.LocalDate;
 import java.util.List;
 
 public record CourseResponse(
@@ -20,8 +19,6 @@ public record CourseResponse(
         Integer estimatedHours,
         Long categoryId,
         String categoryName,
-        LocalDate startDate,
-        LocalDate endDate,
         List<String> tags,
         Instant createdAt,
         Instant updatedAt,
@@ -70,8 +67,6 @@ public record CourseResponse(
                 course.getEstimatedHours(),
                 course.getCategoryId(),
                 categoryName,
-                course.getStartDate(),
-                course.getEndDate(),
                 course.getTags(),
                 course.getCreatedAt(),
                 course.getUpdatedAt(),

--- a/src/main/java/com/mzc/lp/domain/course/entity/Course.java
+++ b/src/main/java/com/mzc/lp/domain/course/entity/Course.java
@@ -10,7 +10,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -54,12 +53,6 @@ public class Course extends TenantEntity {
     @Column
     private Long createdBy;
 
-    @Column
-    private LocalDate startDate;
-
-    @Column
-    private LocalDate endDate;
-
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "cm_course_tags", joinColumns = @JoinColumn(name = "course_id"))
     @Column(name = "tag", length = 100)
@@ -79,8 +72,7 @@ public class Course extends TenantEntity {
 
     public static Course create(String title, String description, CourseLevel level,
                                 CourseType type, Integer estimatedHours,
-                                Long categoryId, String thumbnailUrl,
-                                LocalDate startDate, LocalDate endDate, List<String> tags,
+                                Long categoryId, String thumbnailUrl, List<String> tags,
                                 Long createdBy) {
         Course course = new Course();
         course.title = title;
@@ -90,8 +82,6 @@ public class Course extends TenantEntity {
         course.estimatedHours = estimatedHours;
         course.categoryId = categoryId;
         course.thumbnailUrl = thumbnailUrl;
-        course.startDate = startDate;
-        course.endDate = endDate;
         course.tags = tags != null ? new ArrayList<>(tags) : new ArrayList<>();
         course.createdBy = createdBy;
         course.status = CourseStatus.DRAFT;
@@ -128,22 +118,13 @@ public class Course extends TenantEntity {
         this.categoryId = categoryId;
     }
 
-    public void updateStartDate(LocalDate startDate) {
-        this.startDate = startDate;
-    }
-
-    public void updateEndDate(LocalDate endDate) {
-        this.endDate = endDate;
-    }
-
     public void updateTags(List<String> tags) {
         this.tags = tags != null ? new ArrayList<>(tags) : new ArrayList<>();
     }
 
     public void update(String title, String description, CourseLevel level,
                        CourseType type, Integer estimatedHours,
-                       Long categoryId, String thumbnailUrl,
-                       LocalDate startDate, LocalDate endDate, List<String> tags) {
+                       Long categoryId, String thumbnailUrl, List<String> tags) {
         if (title != null) {
             updateTitle(title);
         }
@@ -153,8 +134,6 @@ public class Course extends TenantEntity {
         this.estimatedHours = estimatedHours;
         this.categoryId = categoryId;
         this.thumbnailUrl = thumbnailUrl;
-        this.startDate = startDate;
-        this.endDate = endDate;
         this.tags = tags != null ? new ArrayList<>(tags) : new ArrayList<>();
     }
 

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
@@ -56,8 +56,6 @@ public class CourseServiceImpl implements CourseService {
                 request.estimatedHours(),
                 request.categoryId(),
                 request.thumbnailUrl(),
-                request.startDate(),
-                request.endDate(),
                 request.tags(),
                 createdBy
         );
@@ -183,8 +181,6 @@ public class CourseServiceImpl implements CourseService {
                 request.estimatedHours(),
                 request.categoryId(),
                 request.thumbnailUrl(),
-                request.startDate(),
-                request.endDate(),
                 request.tags()
         );
 

--- a/src/main/java/com/mzc/lp/domain/ts/dto/response/CourseTimeFormDataResponse.java
+++ b/src/main/java/com/mzc/lp/domain/ts/dto/response/CourseTimeFormDataResponse.java
@@ -23,16 +23,12 @@ public record CourseTimeFormDataResponse(
 ) {
     public record CourseDefaults(
             CourseType type,
-            Integer estimatedHours,
-            LocalDate startDate,
-            LocalDate endDate
+            Integer estimatedHours
     ) {
         public static CourseDefaults from(Course course) {
             return new CourseDefaults(
                     course.getType(),
-                    course.getEstimatedHours(),
-                    course.getStartDate(),
-                    course.getEndDate()
+                    course.getEstimatedHours()
             );
         }
     }
@@ -41,8 +37,6 @@ public record CourseTimeFormDataResponse(
         DeliveryType suggestedDeliveryType = mapCourseTypeToDeliveryType(course.getType());
         DurationType suggestedDurationType = determineDurationType(course);
         Integer suggestedDurationDays = calculateSuggestedDurationDays(course);
-        LocalDate suggestedClassStartDate = course.getStartDate();
-        LocalDate suggestedClassEndDate = course.getEndDate();
 
         return new CourseTimeFormDataResponse(
                 course.getId(),
@@ -50,8 +44,8 @@ public record CourseTimeFormDataResponse(
                 suggestedDeliveryType,
                 suggestedDurationType,
                 suggestedDurationDays,
-                suggestedClassStartDate,
-                suggestedClassEndDate,
+                null,
+                null,
                 CourseDefaults.from(course)
         );
     }
@@ -68,9 +62,6 @@ public record CourseTimeFormDataResponse(
     }
 
     private static DurationType determineDurationType(Course course) {
-        if (course.getStartDate() != null && course.getEndDate() != null) {
-            return DurationType.FIXED;
-        }
         if (course.getEstimatedHours() != null) {
             return DurationType.RELATIVE;
         }
@@ -78,10 +69,6 @@ public record CourseTimeFormDataResponse(
     }
 
     private static Integer calculateSuggestedDurationDays(Course course) {
-        if (course.getStartDate() != null && course.getEndDate() != null) {
-            return (int) java.time.temporal.ChronoUnit.DAYS.between(
-                    course.getStartDate(), course.getEndDate()) + 1;
-        }
         if (course.getEstimatedHours() != null) {
             return Math.max(1, (int) Math.ceil(course.getEstimatedHours() / 8.0));
         }

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseControllerTest.java
@@ -114,8 +114,6 @@ class CourseControllerTest extends TenantTestSupport {
                 1L,
                 null,
                 null,
-                null,
-                null,
                 null
         );
         return courseRepository.save(course);
@@ -129,8 +127,6 @@ class CourseControllerTest extends TenantTestSupport {
                 CourseType.ONLINE,
                 10,
                 1L,
-                null,
-                null,
                 null,
                 null,
                 createdBy
@@ -164,8 +160,6 @@ class CourseControllerTest extends TenantTestSupport {
                     20,
                     1L,
                     null,
-                    null,
-                    null,
                     null
             );
 
@@ -198,8 +192,6 @@ class CourseControllerTest extends TenantTestSupport {
                     30,
                     2L,
                     null,
-                    null,
-                    null,
                     null
             );
 
@@ -222,8 +214,6 @@ class CourseControllerTest extends TenantTestSupport {
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
             CreateCourseRequest request = new CreateCourseRequest(
                     "최소 강의",
-                    null,
-                    null,
                     null,
                     null,
                     null,
@@ -258,8 +248,6 @@ class CourseControllerTest extends TenantTestSupport {
                     10,
                     1L,
                     null,
-                    null,
-                    null,
                     null
             );
 
@@ -286,8 +274,6 @@ class CourseControllerTest extends TenantTestSupport {
                     CourseType.ONLINE,
                     10,
                     1L,
-                    null,
-                    null,
                     null,
                     null
             );
@@ -317,8 +303,6 @@ class CourseControllerTest extends TenantTestSupport {
                     10,
                     1L,
                     null,
-                    null,
-                    null,
                     null
             );
 
@@ -346,8 +330,6 @@ class CourseControllerTest extends TenantTestSupport {
                     null,
                     null,
                     null,
-                    null,
-                    null,
                     null
             );
 
@@ -366,8 +348,6 @@ class CourseControllerTest extends TenantTestSupport {
             // given
             CreateCourseRequest request = new CreateCourseRequest(
                     "테스트 강의",
-                    null,
-                    null,
                     null,
                     null,
                     null,
@@ -439,9 +419,9 @@ class CourseControllerTest extends TenantTestSupport {
             createOperatorUser();
             String accessToken = loginAndGetAccessToken("operator@example.com", "Password123!");
 
-            Course course1 = Course.create("Spring Boot", "설명", CourseLevel.BEGINNER, CourseType.ONLINE, 10, 1L, null, null, null, null, null);
-            Course course2 = Course.create("React", "설명", CourseLevel.BEGINNER, CourseType.ONLINE, 10, 2L, null, null, null, null, null);
-            Course course3 = Course.create("Docker", "설명", CourseLevel.BEGINNER, CourseType.ONLINE, 10, 1L, null, null, null, null, null);
+            Course course1 = Course.create("Spring Boot", "설명", CourseLevel.BEGINNER, CourseType.ONLINE, 10, 1L, null, null, null);
+            Course course2 = Course.create("React", "설명", CourseLevel.BEGINNER, CourseType.ONLINE, 10, 2L, null, null, null);
+            Course course3 = Course.create("Docker", "설명", CourseLevel.BEGINNER, CourseType.ONLINE, 10, 1L, null, null, null);
             courseRepository.save(course1);
             courseRepository.save(course2);
             courseRepository.save(course3);
@@ -543,8 +523,6 @@ class CourseControllerTest extends TenantTestSupport {
                     1L, // categoryId
                     null,
                     null,
-                    null,
-                    null,
                     null
             );
             courseRepository.save(course);
@@ -582,8 +560,6 @@ class CourseControllerTest extends TenantTestSupport {
                     CourseType.ONLINE,
                     10,
                     1L,
-                    null,
-                    null,
                     null,
                     null,
                     null
@@ -645,8 +621,6 @@ class CourseControllerTest extends TenantTestSupport {
                     2L,
                     null,
                     null,
-                    null,
-                    null,
                     null
             );
 
@@ -674,8 +648,6 @@ class CourseControllerTest extends TenantTestSupport {
             Course course = createTestCourse("원래 제목");
             UpdateCourseRequest request = new UpdateCourseRequest(
                     "수정된 제목만",
-                    null,
-                    null,
                     null,
                     null,
                     null,
@@ -712,8 +684,6 @@ class CourseControllerTest extends TenantTestSupport {
                     null,
                     null,
                     null,
-                    null,
-                    null,
                     null
             );
 
@@ -737,8 +707,6 @@ class CourseControllerTest extends TenantTestSupport {
             Course course = createTestCourse("테스트 강의");
             UpdateCourseRequest request = new UpdateCourseRequest(
                     "수정 시도",
-                    null,
-                    null,
                     null,
                     null,
                     null,
@@ -783,8 +751,6 @@ class CourseControllerTest extends TenantTestSupport {
                     null,
                     null,
                     null,
-                    null,
-                    null,
                     operator.getId()
             );
             courseRepository.save(incompleteCourse);
@@ -797,8 +763,6 @@ class CourseControllerTest extends TenantTestSupport {
                     CourseType.ONLINE,
                     10,
                     1L,
-                    null,
-                    null,
                     null,
                     null,
                     operator.getId()

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseItemControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseItemControllerTest.java
@@ -119,8 +119,6 @@ class CourseItemControllerTest extends TenantTestSupport {
                 1L,
                 null,
                 null,
-                null,
-                null,
                 null
         );
         return courseRepository.save(course);

--- a/src/test/java/com/mzc/lp/domain/course/controller/CourseRelationControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/controller/CourseRelationControllerTest.java
@@ -114,8 +114,6 @@ class CourseRelationControllerTest extends TenantTestSupport {
                 1L,
                 null,
                 null,
-                null,
-                null,
                 null
         );
         return courseRepository.save(course);

--- a/src/test/java/com/mzc/lp/domain/course/service/CourseStatusServiceTest.java
+++ b/src/test/java/com/mzc/lp/domain/course/service/CourseStatusServiceTest.java
@@ -56,8 +56,6 @@ class CourseStatusServiceTest extends TenantTestSupport {
                 1L, // categoryId
                 null,
                 null,
-                null,
-                null,
                 1L // createdBy
         );
         CourseItem item = CourseItem.createFolder(course, "폴더1", null);
@@ -69,8 +67,6 @@ class CourseStatusServiceTest extends TenantTestSupport {
         Course course = Course.create(
                 title,
                 null, // description 없음 -> 미완성
-                null,
-                null,
                 null,
                 null,
                 null,
@@ -250,7 +246,7 @@ class CourseStatusServiceTest extends TenantTestSupport {
                     course.getId(),
                     new com.mzc.lp.domain.course.dto.request.UpdateCourseRequest(
                             "수정 시도",
-                            null, null, null, null, null, null, null, null, null, null
+                            null, null, null, null, null, null, null, null
                     )
             )).isInstanceOf(CourseNotModifiableException.class);
         }

--- a/src/test/java/com/mzc/lp/domain/snapshot/controller/SnapshotControllerTest.java
+++ b/src/test/java/com/mzc/lp/domain/snapshot/controller/SnapshotControllerTest.java
@@ -130,8 +130,6 @@ class SnapshotControllerTest extends TenantTestSupport {
                 1L,
                 null,
                 null,
-                null,
-                null,
                 null
         );
         return courseRepository.save(course);


### PR DESCRIPTION
## Summary
- Course 엔티티에서 startDate/endDate 필드 및 관련 메서드 제거
- Request/Response DTO에서 해당 필드 제거
- CourseTimeFormDataResponse에서 Course 날짜 의존 제거

## Test plan
- [ ] 빌드 성공 확인
- [ ] 강의 생성/수정 API 테스트
- [ ] 차수 생성 폼 데이터 API 테스트

Closes #395