### PR TITLE
Feat : 활동 로그 검색/내보내기 API 추가 및 회원가입 시 서브도메인 기반 테넌트 연결 지원

### DIFF
--- a/src/main/java/com/mzc/lp/common/filter/TenantFilter.java
+++ b/src/main/java/com/mzc/lp/common/filter/TenantFilter.java
@@ -73,11 +73,16 @@ public class TenantFilter implements Filter {
                     log.debug("TenantId set in context: {} for request: {} {}",
                             tenantId, httpRequest.getMethod(), httpRequest.getRequestURI());
                 } else {
-                    // 로그인/회원가입 API는 테넌트 필터 없이 전체 사용자 대상 조회해야 함
                     String requestUri = httpRequest.getRequestURI();
-                    if (requestUri.startsWith("/api/auth/")) {
+                    // 로그인 API는 테넌트 필터 없이 전체 사용자 대상 조회해야 함
+                    if (requestUri.equals("/api/auth/login") || requestUri.equals("/api/auth/refresh")) {
                         log.debug("Auth API - TenantContext not set for request: {} {}",
                                 httpRequest.getMethod(), requestUri);
+                    } else if (requestUri.equals("/api/auth/register")) {
+                        // 회원가입 시에는 X-Subdomain 헤더가 없으면 기본 테넌트로 가입
+                        TenantContext.setTenantId(defaultTenantId);
+                        log.debug("Register API - Default TenantId ({}) set for request: {} {}",
+                                defaultTenantId, httpRequest.getMethod(), requestUri);
                     } else {
                         // 그 외 Public API는 기본 테넌트 사용
                         TenantContext.setTenantId(defaultTenantId);

--- a/src/main/java/com/mzc/lp/domain/analytics/controller/AdminAnalyticsController.java
+++ b/src/main/java/com/mzc/lp/domain/analytics/controller/AdminAnalyticsController.java
@@ -5,16 +5,25 @@ import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.domain.analytics.constant.ActivityType;
 import com.mzc.lp.domain.analytics.dto.response.ActivityLogResponse;
 import com.mzc.lp.domain.analytics.dto.response.ActivityStatsResponse;
+import com.mzc.lp.domain.analytics.entity.ActivityLog;
 import com.mzc.lp.domain.analytics.service.ActivityLogService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -26,6 +35,8 @@ import java.util.List;
 public class AdminAnalyticsController {
 
     private final ActivityLogService activityLogService;
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+            .withZone(ZoneId.systemDefault());
 
     /**
      * 활동 로그 목록 조회
@@ -67,4 +78,149 @@ public class AdminAnalyticsController {
         List<ActivityLogResponse> activities = activityLogService.getRecentActivities(tenantId);
         return ResponseEntity.ok(ApiResponse.success(activities));
     }
+
+    /**
+     * 활동 로그 검색 (유저별, 유형별, 기간별 필터)
+     * GET /api/admin/analytics/logs/search
+     */
+    @GetMapping("/logs/search")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<Page<ActivityLogResponse>>> searchLogs(
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) ActivityType type,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant endDate,
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        Page<ActivityLogResponse> logs = activityLogService.searchLogs(
+                tenantId, userId, type, startDate, endDate, keyword, pageable
+        );
+        return ResponseEntity.ok(ApiResponse.success(logs));
+    }
+
+    /**
+     * 특정 사용자의 활동 로그 조회
+     * GET /api/admin/analytics/logs/users/{userId}
+     */
+    @GetMapping("/logs/users/{userId}")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<Page<ActivityLogResponse>>> getLogsByUser(
+            @PathVariable Long userId,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        Page<ActivityLogResponse> logs = activityLogService.getActivityLogsByUser(tenantId, userId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(logs));
+    }
+
+    /**
+     * 활동 유형 목록 조회
+     * GET /api/admin/analytics/types
+     */
+    @GetMapping("/types")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<ActivityTypeInfo>>> getActivityTypes() {
+        List<ActivityTypeInfo> types = Arrays.stream(ActivityType.values())
+                .map(type -> new ActivityTypeInfo(type.name(), getActivityTypeDescription(type)))
+                .toList();
+        return ResponseEntity.ok(ApiResponse.success(types));
+    }
+
+    /**
+     * 활동 로그 CSV 내보내기
+     * GET /api/admin/analytics/logs/export
+     */
+    @GetMapping("/logs/export")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public void exportLogs(
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) ActivityType type,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant endDate,
+            HttpServletResponse response
+    ) throws IOException {
+        Long tenantId = TenantContext.getCurrentTenantId();
+        List<ActivityLog> logs = activityLogService.getLogsForExport(tenantId, userId, type, startDate, endDate);
+
+        // CSV 응답 설정
+        response.setContentType("text/csv; charset=UTF-8");
+        response.setCharacterEncoding("UTF-8");
+        String filename = "activity_logs_" + Instant.now().toEpochMilli() + ".csv";
+        response.setHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
+
+        // BOM for Excel UTF-8 support
+        response.getOutputStream().write(0xEF);
+        response.getOutputStream().write(0xBB);
+        response.getOutputStream().write(0xBF);
+
+        PrintWriter writer = response.getWriter();
+
+        // CSV 헤더
+        writer.println("일시,사용자ID,사용자이메일,사용자명,활동유형,상세내용,대상유형,대상ID,대상명,IP주소");
+
+        // CSV 데이터
+        for (ActivityLog log : logs) {
+            writer.println(String.join(",",
+                    escapeCSV(log.getCreatedAt() != null ? DATE_FORMATTER.format(log.getCreatedAt()) : ""),
+                    escapeCSV(log.getUserId() != null ? log.getUserId().toString() : ""),
+                    escapeCSV(log.getUserEmail()),
+                    escapeCSV(log.getUserName()),
+                    escapeCSV(log.getActivityType() != null ? log.getActivityType().name() : ""),
+                    escapeCSV(log.getDescription()),
+                    escapeCSV(log.getTargetType()),
+                    escapeCSV(log.getTargetId() != null ? log.getTargetId().toString() : ""),
+                    escapeCSV(log.getTargetName()),
+                    escapeCSV(log.getIpAddress())
+            ));
+        }
+
+        writer.flush();
+    }
+
+    // CSV 값 이스케이프
+    private String escapeCSV(String value) {
+        if (value == null) {
+            return "";
+        }
+        if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+            return "\"" + value.replace("\"", "\"\"") + "\"";
+        }
+        return value;
+    }
+
+    // 활동 유형 설명 (한국어)
+    private String getActivityTypeDescription(ActivityType type) {
+        return switch (type) {
+            case LOGIN -> "로그인";
+            case LOGOUT -> "로그아웃";
+            case LOGIN_FAILED -> "로그인 실패";
+            case PASSWORD_CHANGE -> "비밀번호 변경";
+            case USER_CREATE -> "사용자 생성";
+            case USER_UPDATE -> "사용자 수정";
+            case USER_DELETE -> "사용자 삭제";
+            case ROLE_CHANGE -> "역할 변경";
+            case COURSE_VIEW -> "과정 조회";
+            case COURSE_CREATE -> "과정 생성";
+            case COURSE_UPDATE -> "과정 수정";
+            case COURSE_DELETE -> "과정 삭제";
+            case PROGRAM_CREATE -> "프로그램 생성";
+            case PROGRAM_UPDATE -> "프로그램 수정";
+            case PROGRAM_APPROVE -> "프로그램 승인";
+            case PROGRAM_REJECT -> "프로그램 거절";
+            case ENROLLMENT_CREATE -> "수강 신청";
+            case ENROLLMENT_COMPLETE -> "수강 완료";
+            case ENROLLMENT_DROP -> "수강 취소";
+            case CONTENT_VIEW -> "콘텐츠 조회";
+            case CONTENT_COMPLETE -> "콘텐츠 완료";
+            case SETTINGS_UPDATE -> "설정 변경";
+            case TENANT_CREATE -> "테넌트 생성";
+            case TENANT_UPDATE -> "테넌트 수정";
+            case OTHER -> "기타";
+        };
+    }
+
+    // 활동 유형 정보 DTO
+    record ActivityTypeInfo(String type, String description) {}
 }

--- a/src/main/java/com/mzc/lp/domain/analytics/repository/ActivityLogRepository.java
+++ b/src/main/java/com/mzc/lp/domain/analytics/repository/ActivityLogRepository.java
@@ -105,4 +105,44 @@ public interface ActivityLogRepository extends JpaRepository<ActivityLog, Long> 
            "WHERE a.userId = :userId AND a.activityType = 'LOGIN_FAILED' " +
            "AND a.createdAt >= :since")
     long countLoginFailuresSince(@Param("userId") Long userId, @Param("since") Instant since);
+
+    /**
+     * 복합 조건 검색 (유저별 필터 포함)
+     */
+    @Query("SELECT a FROM ActivityLog a WHERE a.tenantId = :tenantId " +
+           "AND (:userId IS NULL OR a.userId = :userId) " +
+           "AND (:activityType IS NULL OR a.activityType = :activityType) " +
+           "AND (:startDate IS NULL OR a.createdAt >= :startDate) " +
+           "AND (:endDate IS NULL OR a.createdAt <= :endDate) " +
+           "AND (:keyword IS NULL OR a.description LIKE %:keyword% " +
+           "     OR a.userEmail LIKE %:keyword% " +
+           "     OR a.userName LIKE %:keyword% " +
+           "     OR a.targetName LIKE %:keyword%) " +
+           "ORDER BY a.createdAt DESC")
+    Page<ActivityLog> searchLogs(
+            @Param("tenantId") Long tenantId,
+            @Param("userId") Long userId,
+            @Param("activityType") ActivityType activityType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    /**
+     * 내보내기용 검색 (페이징 없이)
+     */
+    @Query("SELECT a FROM ActivityLog a WHERE a.tenantId = :tenantId " +
+           "AND (:userId IS NULL OR a.userId = :userId) " +
+           "AND (:activityType IS NULL OR a.activityType = :activityType) " +
+           "AND (:startDate IS NULL OR a.createdAt >= :startDate) " +
+           "AND (:endDate IS NULL OR a.createdAt <= :endDate) " +
+           "ORDER BY a.createdAt DESC")
+    List<ActivityLog> findLogsForExport(
+            @Param("tenantId") Long tenantId,
+            @Param("userId") Long userId,
+            @Param("activityType") ActivityType activityType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate
+    );
 }

--- a/src/main/java/com/mzc/lp/domain/analytics/repository/ActivityLogRepository.java
+++ b/src/main/java/com/mzc/lp/domain/analytics/repository/ActivityLogRepository.java
@@ -107,22 +107,34 @@ public interface ActivityLogRepository extends JpaRepository<ActivityLog, Long> 
     long countLoginFailuresSince(@Param("userId") Long userId, @Param("since") Instant since);
 
     /**
-     * 복합 조건 검색 (유저별 필터 포함)
+     * 복합 조건 검색 (유저별 필터 포함) - Native Query
      */
-    @Query("SELECT a FROM ActivityLog a WHERE a.tenantId = :tenantId " +
-           "AND (:userId IS NULL OR a.userId = :userId) " +
-           "AND (:activityType IS NULL OR a.activityType = :activityType) " +
-           "AND (:startDate IS NULL OR a.createdAt >= :startDate) " +
-           "AND (:endDate IS NULL OR a.createdAt <= :endDate) " +
-           "AND (:keyword IS NULL OR a.description LIKE %:keyword% " +
-           "     OR a.userEmail LIKE %:keyword% " +
-           "     OR a.userName LIKE %:keyword% " +
-           "     OR a.targetName LIKE %:keyword%) " +
-           "ORDER BY a.createdAt DESC")
+    @Query(value = "SELECT * FROM activity_logs a WHERE a.tenant_id = :tenantId " +
+           "AND (:userId IS NULL OR a.user_id = :userId) " +
+           "AND (:activityType IS NULL OR a.activity_type = :activityType) " +
+           "AND (:startDate IS NULL OR a.created_at >= :startDate) " +
+           "AND (:endDate IS NULL OR a.created_at <= :endDate) " +
+           "AND (:keyword IS NULL OR :keyword = '' " +
+           "     OR a.description LIKE CONCAT('%', :keyword, '%') " +
+           "     OR a.user_email LIKE CONCAT('%', :keyword, '%') " +
+           "     OR a.user_name LIKE CONCAT('%', :keyword, '%') " +
+           "     OR a.target_name LIKE CONCAT('%', :keyword, '%')) " +
+           "ORDER BY a.created_at DESC",
+           countQuery = "SELECT COUNT(*) FROM activity_logs a WHERE a.tenant_id = :tenantId " +
+           "AND (:userId IS NULL OR a.user_id = :userId) " +
+           "AND (:activityType IS NULL OR a.activity_type = :activityType) " +
+           "AND (:startDate IS NULL OR a.created_at >= :startDate) " +
+           "AND (:endDate IS NULL OR a.created_at <= :endDate) " +
+           "AND (:keyword IS NULL OR :keyword = '' " +
+           "     OR a.description LIKE CONCAT('%', :keyword, '%') " +
+           "     OR a.user_email LIKE CONCAT('%', :keyword, '%') " +
+           "     OR a.user_name LIKE CONCAT('%', :keyword, '%') " +
+           "     OR a.target_name LIKE CONCAT('%', :keyword, '%'))",
+           nativeQuery = true)
     Page<ActivityLog> searchLogs(
             @Param("tenantId") Long tenantId,
             @Param("userId") Long userId,
-            @Param("activityType") ActivityType activityType,
+            @Param("activityType") String activityType,
             @Param("startDate") Instant startDate,
             @Param("endDate") Instant endDate,
             @Param("keyword") String keyword,
@@ -130,18 +142,19 @@ public interface ActivityLogRepository extends JpaRepository<ActivityLog, Long> 
     );
 
     /**
-     * 내보내기용 검색 (페이징 없이)
+     * 내보내기용 검색 (페이징 없이) - Native Query
      */
-    @Query("SELECT a FROM ActivityLog a WHERE a.tenantId = :tenantId " +
-           "AND (:userId IS NULL OR a.userId = :userId) " +
-           "AND (:activityType IS NULL OR a.activityType = :activityType) " +
-           "AND (:startDate IS NULL OR a.createdAt >= :startDate) " +
-           "AND (:endDate IS NULL OR a.createdAt <= :endDate) " +
-           "ORDER BY a.createdAt DESC")
+    @Query(value = "SELECT * FROM activity_logs a WHERE a.tenant_id = :tenantId " +
+           "AND (:userId IS NULL OR a.user_id = :userId) " +
+           "AND (:activityType IS NULL OR a.activity_type = :activityType) " +
+           "AND (:startDate IS NULL OR a.created_at >= :startDate) " +
+           "AND (:endDate IS NULL OR a.created_at <= :endDate) " +
+           "ORDER BY a.created_at DESC",
+           nativeQuery = true)
     List<ActivityLog> findLogsForExport(
             @Param("tenantId") Long tenantId,
             @Param("userId") Long userId,
-            @Param("activityType") ActivityType activityType,
+            @Param("activityType") String activityType,
             @Param("startDate") Instant startDate,
             @Param("endDate") Instant endDate
     );

--- a/src/main/java/com/mzc/lp/domain/analytics/service/ActivityLogService.java
+++ b/src/main/java/com/mzc/lp/domain/analytics/service/ActivityLogService.java
@@ -3,9 +3,11 @@ package com.mzc.lp.domain.analytics.service;
 import com.mzc.lp.domain.analytics.constant.ActivityType;
 import com.mzc.lp.domain.analytics.dto.response.ActivityLogResponse;
 import com.mzc.lp.domain.analytics.dto.response.ActivityStatsResponse;
+import com.mzc.lp.domain.analytics.entity.ActivityLog;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -54,4 +56,33 @@ public interface ActivityLogService {
      * 최근 활동 조회 (SA용)
      */
     List<ActivityLogResponse> getAllRecentActivities();
+
+    /**
+     * 활동 로그 검색 (유저별, 유형별, 기간별 필터)
+     */
+    Page<ActivityLogResponse> searchLogs(
+            Long tenantId,
+            Long userId,
+            ActivityType activityType,
+            Instant startDate,
+            Instant endDate,
+            String keyword,
+            Pageable pageable
+    );
+
+    /**
+     * 내보내기용 로그 조회 (페이징 없이)
+     */
+    List<ActivityLog> getLogsForExport(
+            Long tenantId,
+            Long userId,
+            ActivityType activityType,
+            Instant startDate,
+            Instant endDate
+    );
+
+    /**
+     * 특정 사용자의 활동 로그 조회
+     */
+    Page<ActivityLogResponse> getActivityLogsByUser(Long tenantId, Long userId, Pageable pageable);
 }

--- a/src/main/java/com/mzc/lp/domain/analytics/service/ActivityLogServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/analytics/service/ActivityLogServiceImpl.java
@@ -257,4 +257,38 @@ public class ActivityLogServiceImpl implements ActivityLogService {
                 .map(ActivityLogResponse::from)
                 .collect(Collectors.toList());
     }
+
+    @Override
+    public Page<ActivityLogResponse> searchLogs(
+            Long tenantId,
+            Long userId,
+            ActivityType activityType,
+            Instant startDate,
+            Instant endDate,
+            String keyword,
+            Pageable pageable
+    ) {
+        return activityLogRepository.searchLogs(
+                tenantId, userId, activityType, startDate, endDate, keyword, pageable
+        ).map(ActivityLogResponse::from);
+    }
+
+    @Override
+    public List<ActivityLog> getLogsForExport(
+            Long tenantId,
+            Long userId,
+            ActivityType activityType,
+            Instant startDate,
+            Instant endDate
+    ) {
+        return activityLogRepository.findLogsForExport(
+                tenantId, userId, activityType, startDate, endDate
+        );
+    }
+
+    @Override
+    public Page<ActivityLogResponse> getActivityLogsByUser(Long tenantId, Long userId, Pageable pageable) {
+        return activityLogRepository.findByTenantIdAndUserIdOrderByCreatedAtDesc(tenantId, userId, pageable)
+                .map(ActivityLogResponse::from);
+    }
 }

--- a/src/main/java/com/mzc/lp/domain/analytics/service/ActivityLogServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/analytics/service/ActivityLogServiceImpl.java
@@ -12,6 +12,7 @@ import com.mzc.lp.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.core.Authentication;
@@ -268,8 +269,12 @@ public class ActivityLogServiceImpl implements ActivityLogService {
             String keyword,
             Pageable pageable
     ) {
+        // Native query를 위해 ActivityType을 String으로 변환
+        String activityTypeStr = activityType != null ? activityType.name() : null;
+        // Native query는 ORDER BY를 쿼리 내부에서 처리하므로 정렬 없는 Pageable 사용
+        Pageable unsortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
         return activityLogRepository.searchLogs(
-                tenantId, userId, activityType, startDate, endDate, keyword, pageable
+                tenantId, userId, activityTypeStr, startDate, endDate, keyword, unsortedPageable
         ).map(ActivityLogResponse::from);
     }
 
@@ -281,8 +286,10 @@ public class ActivityLogServiceImpl implements ActivityLogService {
             Instant startDate,
             Instant endDate
     ) {
+        // Native query를 위해 ActivityType을 String으로 변환
+        String activityTypeStr = activityType != null ? activityType.name() : null;
         return activityLogRepository.findLogsForExport(
-                tenantId, userId, activityType, startDate, endDate
+                tenantId, userId, activityTypeStr, startDate, endDate
         );
     }
 

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
@@ -1,5 +1,7 @@
 package com.mzc.lp.domain.course.service;
 
+import com.mzc.lp.domain.analytics.constant.ActivityType;
+import com.mzc.lp.domain.analytics.service.ActivityLogService;
 import com.mzc.lp.domain.course.constant.CourseStatus;
 import com.mzc.lp.domain.course.dto.request.CreateCourseRequest;
 import com.mzc.lp.domain.course.dto.request.UpdateCourseRequest;
@@ -42,6 +44,7 @@ public class CourseServiceImpl implements CourseService {
     private final UserRepository userRepository;
     private final CategoryRepository categoryRepository;
     private final CourseTimeRepository courseTimeRepository;
+    private final ActivityLogService activityLogService;
 
     @Override
     @Transactional
@@ -62,6 +65,15 @@ public class CourseServiceImpl implements CourseService {
 
         Course savedCourse = courseRepository.save(course);
         log.info("Course created: id={}, title={}", savedCourse.getId(), savedCourse.getTitle());
+
+        // 활동 로그 기록
+        activityLogService.log(
+                ActivityType.COURSE_CREATE,
+                String.format("강좌 생성: %s", savedCourse.getTitle()),
+                "Course",
+                savedCourse.getId(),
+                savedCourse.getTitle()
+        );
 
         return CourseResponse.from(savedCourse);
     }
@@ -189,6 +201,15 @@ public class CourseServiceImpl implements CourseService {
             handleStatusTransition(course, request.status());
         }
 
+        // 활동 로그 기록
+        activityLogService.log(
+                ActivityType.COURSE_UPDATE,
+                String.format("강좌 수정: %s", course.getTitle()),
+                "Course",
+                courseId,
+                course.getTitle()
+        );
+
         log.info("Course updated: id={}", courseId);
         return CourseResponse.from(course, course.getItems().size());
     }
@@ -206,7 +227,18 @@ public class CourseServiceImpl implements CourseService {
             throw new CourseOwnershipException("본인이 생성한 강의만 삭제할 수 있습니다");
         }
 
+        String courseTitle = course.getTitle();
         courseRepository.delete(course);
+
+        // 활동 로그 기록
+        activityLogService.log(
+                ActivityType.COURSE_DELETE,
+                String.format("강좌 삭제: %s", courseTitle),
+                "Course",
+                courseId,
+                courseTitle
+        );
+
         log.info("Course deleted: id={}", courseId);
     }
 


### PR DESCRIPTION
## Summary

활동 로그 검색/내보내기 API 추가 및 회원가입 시 서브도메인 기반 테넌트 연결을 지원합니다.

## Related Issue

- Closes #406

## Changes

- 활동 로그 검색 API 추가 (GET /api/admin/analytics/logs/search)
- 활동 로그 CSV 내보내기 API 추가 (GET /api/admin/analytics/logs/export)
- EnrollmentServiceImpl에 활동 로그 기록 추가 (수강 신청/완료/취소)
- CourseServiceImpl에 활동 로그 기록 추가 (강좌 생성/수정/삭제)
- TenantFilter에서 회원가입 시 X-Subdomain 헤더 처리 추가

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 회원가입 시 X-Subdomain 헤더가 있으면 해당 테넌트, 없으면 기본 테넌트(default)로 가입됩니다
- CSV 내보내기는 UTF-8 BOM을 포함하여 Excel에서 한글이 깨지지 않습니다
