### PR TITLE
[Feat] 과정 발행 완성도 검증 에러 메시지 상세화 (CM017)

### DIFF
--- a/src/main/java/com/mzc/lp/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mzc/lp/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.mzc.lp.common.exception;
 
 import com.mzc.lp.common.constant.ErrorCode;
 import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.domain.course.exception.CourseIncompleteException;
 import com.mzc.lp.domain.iis.dto.response.ScheduleConflictResponse;
 import com.mzc.lp.domain.iis.exception.InstructorScheduleConflictException;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +26,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(new ApiResponse<>(false, e.getConflicts(),
+                        ApiResponse.ErrorInfo.of(errorCode, e.getMessage())));
+    }
+
+    @ExceptionHandler(CourseIncompleteException.class)
+    protected ResponseEntity<ApiResponse<List<String>>> handleCourseIncompleteException(
+            CourseIncompleteException e) {
+        log.error("CourseIncompleteException: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(new ApiResponse<>(false, e.getMissingFields(),
                         ApiResponse.ErrorInfo.of(errorCode, e.getMessage())));
     }
 

--- a/src/main/java/com/mzc/lp/domain/course/exception/CourseIncompleteException.java
+++ b/src/main/java/com/mzc/lp/domain/course/exception/CourseIncompleteException.java
@@ -2,14 +2,38 @@ package com.mzc.lp.domain.course.exception;
 
 import com.mzc.lp.common.constant.ErrorCode;
 import com.mzc.lp.common.exception.BusinessException;
+import lombok.Getter;
 
+import java.util.List;
+import java.util.Map;
+
+@Getter
 public class CourseIncompleteException extends BusinessException {
+
+    private static final Map<String, String> FIELD_LABELS = Map.of(
+            "title", "제목",
+            "description", "설명",
+            "categoryId", "카테고리",
+            "items", "차시"
+    );
+
+    private final List<String> missingFields;
 
     public CourseIncompleteException() {
         super(ErrorCode.CM_COURSE_INCOMPLETE);
+        this.missingFields = List.of();
     }
 
-    public CourseIncompleteException(Long courseId) {
-        super(ErrorCode.CM_COURSE_INCOMPLETE, "완성되지 않은 강의는 발행할 수 없습니다. ID: " + courseId);
+    public CourseIncompleteException(Long courseId, List<String> missingFields) {
+        super(ErrorCode.CM_COURSE_INCOMPLETE, buildMessage(courseId, missingFields));
+        this.missingFields = missingFields;
+    }
+
+    private static String buildMessage(Long courseId, List<String> missingFields) {
+        String labels = missingFields.stream()
+                .map(field -> FIELD_LABELS.getOrDefault(field, field))
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("");
+        return "완성되지 않은 강의입니다. 누락 항목: " + labels + " (ID: " + courseId + ")";
     }
 }

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
@@ -27,6 +27,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -361,13 +362,23 @@ public class CourseServiceImpl implements CourseService {
     }
 
     private void validateCompleteness(Course course) {
-        boolean isComplete = course.getTitle() != null && !course.getTitle().isBlank()
-                && course.getDescription() != null && !course.getDescription().isBlank()
-                && course.getCategoryId() != null
-                && !course.getItems().isEmpty();
+        List<String> missingFields = new ArrayList<>();
 
-        if (!isComplete) {
-            throw new CourseIncompleteException(course.getId());
+        if (course.getTitle() == null || course.getTitle().isBlank()) {
+            missingFields.add("title");
+        }
+        if (course.getDescription() == null || course.getDescription().isBlank()) {
+            missingFields.add("description");
+        }
+        if (course.getCategoryId() == null) {
+            missingFields.add("categoryId");
+        }
+        if (course.getItems().isEmpty()) {
+            missingFields.add("items");
+        }
+
+        if (!missingFields.isEmpty()) {
+            throw new CourseIncompleteException(course.getId(), missingFields);
         }
     }
 }


### PR DESCRIPTION
## Summary
- CM017 에러 응답에 누락 항목(`missingFields`) 정보 포함
- 사용자가 어떤 항목이 누락되었는지 명확히 파악 가능

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `CourseIncompleteException.java` | `missingFields` 필드 추가, 한글 레이블 매핑 |
| `CourseServiceImpl.java` | 누락 항목별 수집 로직으로 변경 |
| `GlobalExceptionHandler.java` | 전용 핸들러 추가 (data에 missingFields 포함) |

## API Response (개선 후)
```json
{
  "success": false,
  "data": ["description", "items"],
  "error": {
    "code": "CM017",
    "message": "완성되지 않은 강의입니다. 누락 항목: 설명, 차시 (ID: 597)"
  }
}
```

## Test plan
- [ ] 설명 미입력 시 CM017 에러에 "description" 포함 확인
- [ ] 차시 미생성 시 CM017 에러에 "items" 포함 확인
- [ ] 여러 항목 누락 시 모두 표시되는지 확인

## Related
- Frontend: mzcATU/mzc-lp-frontend#489

Closes #404