### PR TITLE
fix: EnrollmentResponse에 actualEndDate 추가 및 계산 로직 구현

### DIFF
--- a/src/main/java/com/mzc/lp/domain/student/dto/response/EnrollmentResponse.java
+++ b/src/main/java/com/mzc/lp/domain/student/dto/response/EnrollmentResponse.java
@@ -5,6 +5,7 @@ import com.mzc.lp.domain.student.constant.EnrollmentType;
 import com.mzc.lp.domain.student.entity.Enrollment;
 
 import java.time.Instant;
+import java.time.LocalDate;
 
 public record EnrollmentResponse(
         Long id,
@@ -17,7 +18,8 @@ public record EnrollmentResponse(
         EnrollmentStatus status,
         Integer progressPercent,
         Integer score,
-        Instant completedAt
+        Instant completedAt,
+        LocalDate actualEndDate
 ) {
     public static EnrollmentResponse from(Enrollment enrollment) {
         return new EnrollmentResponse(
@@ -31,7 +33,8 @@ public record EnrollmentResponse(
                 enrollment.getStatus(),
                 enrollment.getProgressPercent(),
                 enrollment.getScore(),
-                enrollment.getCompletedAt()
+                enrollment.getCompletedAt(),
+                null
         );
     }
 
@@ -47,7 +50,42 @@ public record EnrollmentResponse(
                 enrollment.getStatus(),
                 enrollment.getProgressPercent(),
                 enrollment.getScore(),
-                enrollment.getCompletedAt()
+                enrollment.getCompletedAt(),
+                null
+        );
+    }
+
+    public static EnrollmentResponse from(Enrollment enrollment, LocalDate actualEndDate) {
+        return new EnrollmentResponse(
+                enrollment.getId(),
+                enrollment.getUserId(),
+                null,
+                null,
+                enrollment.getCourseTimeId(),
+                enrollment.getEnrolledAt(),
+                enrollment.getType(),
+                enrollment.getStatus(),
+                enrollment.getProgressPercent(),
+                enrollment.getScore(),
+                enrollment.getCompletedAt(),
+                actualEndDate
+        );
+    }
+
+    public static EnrollmentResponse from(Enrollment enrollment, String userName, String userEmail, LocalDate actualEndDate) {
+        return new EnrollmentResponse(
+                enrollment.getId(),
+                enrollment.getUserId(),
+                userName,
+                userEmail,
+                enrollment.getCourseTimeId(),
+                enrollment.getEnrolledAt(),
+                enrollment.getType(),
+                enrollment.getStatus(),
+                enrollment.getProgressPercent(),
+                enrollment.getScore(),
+                enrollment.getCompletedAt(),
+                actualEndDate
         );
     }
 }

--- a/src/main/resources/migration/V20260119__add_duration_days_to_course_times.sql
+++ b/src/main/resources/migration/V20260119__add_duration_days_to_course_times.sql
@@ -1,0 +1,8 @@
+-- ============================================
+-- CourseTime에 duration_days 컬럼 추가
+-- 날짜: 2026-01-19
+-- ============================================
+
+-- duration_days 컬럼 추가 (FIXED: 자동 계산, RELATIVE: 필수, UNLIMITED: null)
+ALTER TABLE course_times
+ADD COLUMN duration_days INT NULL;


### PR DESCRIPTION
## Summary
- EnrollmentResponse에 `actualEndDate` (LocalDate) 필드 추가
- CourseTime의 `durationType`에 따른 실제 종료일 계산 로직 구현
- `course_times` 테이블에 `duration_days` 컬럼 추가

## Changes
### API Response
- `actualEndDate` 필드 추가로 프론트엔드에서 정확한 종료일 표시 가능

### 계산 로직
- **FIXED**: `classEndDate` 그대로 반환
- **RELATIVE**: `classStartDate + durationDays` 계산하여 반환
- **UNLIMITED**: `null` 반환 (기간 제한 없음)

### 데이터베이스
- `course_times` 테이블에 `duration_days INT NULL` 컬럼 추가
- Flyway 마이그레이션 파일 생성 (V20260119)

### 최적화
- EnrollmentServiceImpl에서 CourseTime 배치 조회로 N+1 문제 방지

## Test plan
- [ ] FIXED 타입 차수의 수강 내역 조회 시 `classEndDate` 반환 확인
- [ ] RELATIVE 타입 차수의 수강 내역 조회 시 계산된 종료일 반환 확인
- [ ] UNLIMITED 타입 차수의 수강 내역 조회 시 `null` 반환 확인
- [ ] 마이그레이션 정상 실행 확인

Closes #409