### PR TITLE
feat: TA/SA 기능 및 테넌트별 분석 지원 추가

### DIFF
--- a/src/main/java/com/mzc/lp/domain/analytics/controller/SaAnalyticsController.java
+++ b/src/main/java/com/mzc/lp/domain/analytics/controller/SaAnalyticsController.java
@@ -76,11 +76,20 @@ public class SaAnalyticsController {
     /**
      * 최근 활동 목록 조회 (전체 시스템)
      * GET /api/sa/analytics/recent
+     *
+     * @param tenantId 테넌트 ID (null이면 전체 테넌트)
      */
     @GetMapping("/recent")
     @PreAuthorize("hasRole('SYSTEM_ADMIN')")
-    public ResponseEntity<ApiResponse<List<ActivityLogResponse>>> getAllRecentActivities() {
-        List<ActivityLogResponse> activities = activityLogService.getAllRecentActivities();
+    public ResponseEntity<ApiResponse<List<ActivityLogResponse>>> getAllRecentActivities(
+            @RequestParam(required = false) Long tenantId
+    ) {
+        List<ActivityLogResponse> activities;
+        if (tenantId != null) {
+            activities = activityLogService.getRecentActivities(tenantId);
+        } else {
+            activities = activityLogService.getAllRecentActivities();
+        }
         return ResponseEntity.ok(ApiResponse.success(activities));
     }
 }

--- a/src/main/java/com/mzc/lp/domain/department/controller/DepartmentController.java
+++ b/src/main/java/com/mzc/lp/domain/department/controller/DepartmentController.java
@@ -4,6 +4,7 @@ import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.common.security.UserPrincipal;
 import com.mzc.lp.domain.department.dto.request.CreateDepartmentRequest;
 import com.mzc.lp.domain.department.dto.request.UpdateDepartmentRequest;
+import com.mzc.lp.domain.department.dto.response.DepartmentMemberResponse;
 import com.mzc.lp.domain.department.dto.response.DepartmentResponse;
 import com.mzc.lp.domain.department.service.DepartmentService;
 import jakarta.validation.Valid;
@@ -69,6 +70,37 @@ public class DepartmentController {
     ) {
         DepartmentResponse response = departmentService.getById(principal.tenantId(), departmentId);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{departmentId}/members")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<DepartmentMemberResponse>>> getMembers(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long departmentId
+    ) {
+        List<DepartmentMemberResponse> response = departmentService.getMembersByDepartmentId(principal.tenantId(), departmentId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{departmentId}/available-members")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<ApiResponse<List<DepartmentMemberResponse>>> getAvailableMembers(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long departmentId
+    ) {
+        List<DepartmentMemberResponse> response = departmentService.getAvailableMembersForDepartment(principal.tenantId(), departmentId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/{departmentId}/members/{userId}")
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    public ResponseEntity<Void> addMemberToDepartment(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long departmentId,
+            @PathVariable Long userId
+    ) {
+        departmentService.addMemberToDepartment(principal.tenantId(), departmentId, userId);
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping

--- a/src/main/java/com/mzc/lp/domain/department/dto/response/DepartmentMemberResponse.java
+++ b/src/main/java/com/mzc/lp/domain/department/dto/response/DepartmentMemberResponse.java
@@ -1,0 +1,23 @@
+package com.mzc.lp.domain.department.dto.response;
+
+import com.mzc.lp.domain.user.entity.User;
+
+public record DepartmentMemberResponse(
+        Long id,
+        String name,
+        String email,
+        String phone,
+        String position,
+        String role
+) {
+    public static DepartmentMemberResponse from(User user) {
+        return new DepartmentMemberResponse(
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getPhone(),
+                user.getPosition(),
+                user.getRole() != null ? user.getRole().name() : null
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/department/dto/response/DepartmentResponse.java
+++ b/src/main/java/com/mzc/lp/domain/department/dto/response/DepartmentResponse.java
@@ -4,6 +4,7 @@ import com.mzc.lp.domain.department.entity.Department;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.function.Function;
 
 public record DepartmentResponse(
         Long id,
@@ -49,6 +50,41 @@ public record DepartmentResponse(
     public static DepartmentResponse fromWithChildren(Department department, String managerName, int memberCount) {
         List<DepartmentResponse> childResponses = department.getChildren().stream()
                 .map(child -> fromWithChildren(child, null, 0))
+                .toList();
+
+        return new DepartmentResponse(
+                department.getId(),
+                department.getName(),
+                department.getCode(),
+                department.getDescription(),
+                department.getParent() != null ? department.getParent().getId() : null,
+                department.getParent() != null ? department.getParent().getName() : null,
+                department.getManagerId(),
+                managerName,
+                department.getSortOrder(),
+                department.getIsActive(),
+                memberCount,
+                childResponses,
+                department.getCreatedAt(),
+                department.getUpdatedAt()
+        );
+    }
+
+    /**
+     * Entity -> Response (계층 구조 포함, 인원수 계산 함수 사용)
+     * @param department 부서 엔티티
+     * @param managerName 매니저 이름
+     * @param memberCountCalculator 부서별 인원수 계산 함수
+     */
+    public static DepartmentResponse fromWithChildren(
+            Department department,
+            String managerName,
+            Function<Department, Integer> memberCountCalculator) {
+
+        int memberCount = memberCountCalculator.apply(department);
+
+        List<DepartmentResponse> childResponses = department.getChildren().stream()
+                .map(child -> fromWithChildren(child, null, memberCountCalculator))
                 .toList();
 
         return new DepartmentResponse(

--- a/src/main/java/com/mzc/lp/domain/department/service/DepartmentService.java
+++ b/src/main/java/com/mzc/lp/domain/department/service/DepartmentService.java
@@ -2,6 +2,7 @@ package com.mzc.lp.domain.department.service;
 
 import com.mzc.lp.domain.department.dto.request.CreateDepartmentRequest;
 import com.mzc.lp.domain.department.dto.request.UpdateDepartmentRequest;
+import com.mzc.lp.domain.department.dto.response.DepartmentMemberResponse;
 import com.mzc.lp.domain.department.dto.response.DepartmentResponse;
 
 import java.util.List;
@@ -47,4 +48,20 @@ public interface DepartmentService {
      * 활성 부서 목록 조회
      */
     List<DepartmentResponse> getActiveDepartments(Long tenantId);
+
+    /**
+     * 부서별 소속 인원 목록 조회
+     */
+    List<DepartmentMemberResponse> getMembersByDepartmentId(Long tenantId, Long departmentId);
+
+    /**
+     * 부서에 추가 가능한 인원 목록 조회
+     * (해당 부서에 소속되지 않은 활성 사용자)
+     */
+    List<DepartmentMemberResponse> getAvailableMembersForDepartment(Long tenantId, Long departmentId);
+
+    /**
+     * 부서에 인원 추가 (사용자의 부서를 변경)
+     */
+    void addMemberToDepartment(Long tenantId, Long departmentId, Long userId);
 }

--- a/src/main/java/com/mzc/lp/domain/department/service/DepartmentServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/department/service/DepartmentServiceImpl.java
@@ -5,19 +5,23 @@ import com.mzc.lp.common.context.TenantContext;
 import com.mzc.lp.common.exception.BusinessException;
 import com.mzc.lp.domain.department.dto.request.CreateDepartmentRequest;
 import com.mzc.lp.domain.department.dto.request.UpdateDepartmentRequest;
+import com.mzc.lp.domain.department.dto.response.DepartmentMemberResponse;
 import com.mzc.lp.domain.department.dto.response.DepartmentResponse;
 import com.mzc.lp.domain.department.entity.Department;
 import com.mzc.lp.domain.department.exception.DepartmentCodeDuplicateException;
 import com.mzc.lp.domain.department.exception.DepartmentNotFoundException;
 import com.mzc.lp.domain.department.repository.DepartmentRepository;
 import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.exception.UserNotFoundException;
 import com.mzc.lp.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -27,6 +31,31 @@ public class DepartmentServiceImpl implements DepartmentService {
 
     private final DepartmentRepository departmentRepository;
     private final UserRepository userRepository;
+
+    /**
+     * 테넌트별 부서명->인원수 맵 조회
+     */
+    private Map<String, Integer> getDepartmentMemberCounts(Long tenantId) {
+        Map<String, Integer> countMap = new HashMap<>();
+        List<Object[]> results = userRepository.countByTenantIdGroupByDepartment(tenantId);
+        for (Object[] row : results) {
+            String deptName = (String) row[0];
+            Long count = (Long) row[1];
+            countMap.put(deptName, count.intValue());
+        }
+        return countMap;
+    }
+
+    /**
+     * 특정 부서의 인원수 조회 (하위 부서 포함)
+     */
+    private int getMemberCountWithChildren(Department department, Map<String, Integer> countMap) {
+        int count = countMap.getOrDefault(department.getName(), 0);
+        for (Department child : department.getChildren()) {
+            count += getMemberCountWithChildren(child, countMap);
+        }
+        return count;
+    }
 
     @Override
     @Transactional
@@ -67,8 +96,10 @@ public class DepartmentServiceImpl implements DepartmentService {
 
             Department saved = departmentRepository.save(department);
 
+            Map<String, Integer> countMap = getDepartmentMemberCounts(tenantId);
+            int memberCount = getMemberCountWithChildren(saved, countMap);
             String managerName = getManagerName(saved.getManagerId());
-            return DepartmentResponse.from(saved, managerName, 0);
+            return DepartmentResponse.from(saved, managerName, memberCount);
         } finally {
             TenantContext.clear();
         }
@@ -113,8 +144,10 @@ public class DepartmentServiceImpl implements DepartmentService {
             department.setSortOrder(request.sortOrder());
         }
 
+        Map<String, Integer> countMap = getDepartmentMemberCounts(tenantId);
+        int memberCount = getMemberCountWithChildren(department, countMap);
         String managerName = getManagerName(department.getManagerId());
-        return DepartmentResponse.from(department, managerName, 0);
+        return DepartmentResponse.from(department, managerName, memberCount);
     }
 
     @Override
@@ -140,39 +173,49 @@ public class DepartmentServiceImpl implements DepartmentService {
         Department department = departmentRepository.findByIdAndTenantId(departmentId, tenantId)
                 .orElseThrow(() -> new DepartmentNotFoundException(departmentId));
 
+        Map<String, Integer> countMap = getDepartmentMemberCounts(tenantId);
         String managerName = getManagerName(department.getManagerId());
-        return DepartmentResponse.fromWithChildren(department, managerName, 0);
+        return DepartmentResponse.fromWithChildren(department, managerName,
+                d -> getMemberCountWithChildren(d, countMap));
     }
 
     @Override
     public List<DepartmentResponse> getAll(Long tenantId) {
         List<Department> departments = departmentRepository.findByTenantIdOrderBySortOrderAsc(tenantId);
+        Map<String, Integer> countMap = getDepartmentMemberCounts(tenantId);
         return departments.stream()
-                .map(d -> DepartmentResponse.from(d, getManagerName(d.getManagerId()), 0))
+                .map(d -> DepartmentResponse.from(d, getManagerName(d.getManagerId()),
+                        getMemberCountWithChildren(d, countMap)))
                 .toList();
     }
 
     @Override
     public List<DepartmentResponse> getRootDepartments(Long tenantId) {
         List<Department> rootDepartments = departmentRepository.findByTenantIdAndParentIsNullOrderBySortOrderAsc(tenantId);
+        Map<String, Integer> countMap = getDepartmentMemberCounts(tenantId);
         return rootDepartments.stream()
-                .map(d -> DepartmentResponse.fromWithChildren(d, getManagerName(d.getManagerId()), 0))
+                .map(d -> DepartmentResponse.fromWithChildren(d, getManagerName(d.getManagerId()),
+                        dept -> getMemberCountWithChildren(dept, countMap)))
                 .toList();
     }
 
     @Override
     public List<DepartmentResponse> search(Long tenantId, String keyword) {
         List<Department> departments = departmentRepository.searchByKeyword(tenantId, keyword);
+        Map<String, Integer> countMap = getDepartmentMemberCounts(tenantId);
         return departments.stream()
-                .map(d -> DepartmentResponse.from(d, getManagerName(d.getManagerId()), 0))
+                .map(d -> DepartmentResponse.from(d, getManagerName(d.getManagerId()),
+                        getMemberCountWithChildren(d, countMap)))
                 .toList();
     }
 
     @Override
     public List<DepartmentResponse> getActiveDepartments(Long tenantId) {
         List<Department> departments = departmentRepository.findByTenantIdAndIsActiveTrueOrderBySortOrderAsc(tenantId);
+        Map<String, Integer> countMap = getDepartmentMemberCounts(tenantId);
         return departments.stream()
-                .map(d -> DepartmentResponse.from(d, getManagerName(d.getManagerId()), 0))
+                .map(d -> DepartmentResponse.from(d, getManagerName(d.getManagerId()),
+                        getMemberCountWithChildren(d, countMap)))
                 .toList();
     }
 
@@ -183,5 +226,46 @@ public class DepartmentServiceImpl implements DepartmentService {
         return userRepository.findById(managerId)
                 .map(User::getName)
                 .orElse(null);
+    }
+
+    @Override
+    public List<DepartmentMemberResponse> getMembersByDepartmentId(Long tenantId, Long departmentId) {
+        Department department = departmentRepository.findByIdAndTenantId(departmentId, tenantId)
+                .orElseThrow(() -> new DepartmentNotFoundException(departmentId));
+
+        List<User> members = userRepository.findByTenantIdAndDepartment(tenantId, department.getName());
+        return members.stream()
+                .map(DepartmentMemberResponse::from)
+                .toList();
+    }
+
+    @Override
+    public List<DepartmentMemberResponse> getAvailableMembersForDepartment(Long tenantId, Long departmentId) {
+        Department department = departmentRepository.findByIdAndTenantId(departmentId, tenantId)
+                .orElseThrow(() -> new DepartmentNotFoundException(departmentId));
+
+        List<User> availableUsers = userRepository.findByTenantIdAndDepartmentNot(tenantId, department.getName());
+        return availableUsers.stream()
+                .map(DepartmentMemberResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public void addMemberToDepartment(Long tenantId, Long departmentId, Long userId) {
+        Department department = departmentRepository.findByIdAndTenantId(departmentId, tenantId)
+                .orElseThrow(() -> new DepartmentNotFoundException(departmentId));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        // 테넌트 검증
+        if (!user.getTenantId().equals(tenantId)) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED, "해당 사용자에 대한 접근 권한이 없습니다");
+        }
+
+        user.updateDepartment(department.getName());
+        log.info("Added user to department: userId={}, departmentId={}, departmentName={}",
+                userId, departmentId, department.getName());
     }
 }

--- a/src/main/java/com/mzc/lp/domain/sa/controller/SaUserController.java
+++ b/src/main/java/com/mzc/lp/domain/sa/controller/SaUserController.java
@@ -1,0 +1,56 @@
+package com.mzc.lp.domain.sa.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.domain.sa.dto.request.CreateSystemAdminRequest;
+import com.mzc.lp.domain.sa.dto.response.SystemAdminUserResponse;
+import com.mzc.lp.domain.sa.service.SaUserService;
+import com.mzc.lp.domain.user.constant.UserStatus;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/sa/users")
+@RequiredArgsConstructor
+public class SaUserController {
+
+    private final SaUserService saUserService;
+
+    /**
+     * SYSTEM_ADMIN 역할을 가진 사용자 목록 조회
+     * GET /api/sa/users
+     */
+    @GetMapping
+    @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+    public ResponseEntity<ApiResponse<Page<SystemAdminUserResponse>>> getSystemAdmins(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) UserStatus status,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        log.debug("Getting system admin users: keyword={}, status={}", keyword, status);
+        Page<SystemAdminUserResponse> response = saUserService.getSystemAdmins(keyword, status, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * SYSTEM_ADMIN 사용자 생성
+     * POST /api/sa/users
+     */
+    @PostMapping
+    @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+    public ResponseEntity<ApiResponse<SystemAdminUserResponse>> createSystemAdmin(
+            @Valid @RequestBody CreateSystemAdminRequest request
+    ) {
+        log.info("Creating system admin: email={}", request.email());
+        SystemAdminUserResponse response = saUserService.createSystemAdmin(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/sa/dto/request/CreateSystemAdminRequest.java
+++ b/src/main/java/com/mzc/lp/domain/sa/dto/request/CreateSystemAdminRequest.java
@@ -1,0 +1,26 @@
+package com.mzc.lp.domain.sa.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateSystemAdminRequest(
+        @NotBlank(message = "이메일은 필수입니다")
+        @Email(message = "올바른 이메일 형식이 아닙니다")
+        String email,
+
+        @NotBlank(message = "이름은 필수입니다")
+        @Size(min = 2, max = 50, message = "이름은 2-50자 사이여야 합니다")
+        String name,
+
+        @NotBlank(message = "비밀번호는 필수입니다")
+        @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다")
+        String password,
+
+        String phone,
+
+        String department,
+
+        String position
+) {
+}

--- a/src/main/java/com/mzc/lp/domain/sa/dto/response/SystemAdminUserResponse.java
+++ b/src/main/java/com/mzc/lp/domain/sa/dto/response/SystemAdminUserResponse.java
@@ -1,0 +1,39 @@
+package com.mzc.lp.domain.sa.dto.response;
+
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.constant.UserStatus;
+import com.mzc.lp.domain.user.entity.User;
+
+import java.time.Instant;
+
+public record SystemAdminUserResponse(
+        Long userId,
+        String email,
+        String name,
+        String phone,
+        String profileImageUrl,
+        String department,
+        String position,
+        TenantRole role,
+        UserStatus status,
+        Instant lastLoginAt,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static SystemAdminUserResponse from(User user) {
+        return new SystemAdminUserResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getPhone(),
+                user.getProfileImageUrl(),
+                user.getDepartment(),
+                user.getPosition(),
+                user.getRole(),
+                user.getStatus(),
+                user.getLastLoginAt(),
+                user.getCreatedAt(),
+                user.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/sa/service/SaUserService.java
+++ b/src/main/java/com/mzc/lp/domain/sa/service/SaUserService.java
@@ -1,0 +1,20 @@
+package com.mzc.lp.domain.sa.service;
+
+import com.mzc.lp.domain.sa.dto.request.CreateSystemAdminRequest;
+import com.mzc.lp.domain.sa.dto.response.SystemAdminUserResponse;
+import com.mzc.lp.domain.user.constant.UserStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface SaUserService {
+
+    /**
+     * SYSTEM_ADMIN 역할을 가진 사용자 목록 조회
+     */
+    Page<SystemAdminUserResponse> getSystemAdmins(String keyword, UserStatus status, Pageable pageable);
+
+    /**
+     * SYSTEM_ADMIN 사용자 생성
+     */
+    SystemAdminUserResponse createSystemAdmin(CreateSystemAdminRequest request);
+}

--- a/src/main/java/com/mzc/lp/domain/sa/service/SaUserServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/sa/service/SaUserServiceImpl.java
@@ -1,0 +1,74 @@
+package com.mzc.lp.domain.sa.service;
+
+import com.mzc.lp.domain.sa.dto.request.CreateSystemAdminRequest;
+import com.mzc.lp.domain.sa.dto.response.SystemAdminUserResponse;
+import com.mzc.lp.domain.user.constant.TenantRole;
+import com.mzc.lp.domain.user.constant.UserStatus;
+import com.mzc.lp.domain.user.entity.User;
+import com.mzc.lp.domain.user.exception.DuplicateEmailException;
+import com.mzc.lp.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SaUserServiceImpl implements SaUserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public Page<SystemAdminUserResponse> getSystemAdmins(String keyword, UserStatus status, Pageable pageable) {
+        log.debug("Getting system admin users: keyword={}, status={}", keyword, status);
+
+        Page<User> users = userRepository.searchSystemAdmins(keyword, status, pageable);
+
+        return users.map(SystemAdminUserResponse::from);
+    }
+
+    @Override
+    @Transactional
+    public SystemAdminUserResponse createSystemAdmin(CreateSystemAdminRequest request) {
+        log.info("Creating system admin: email={}, name={}", request.email(), request.name());
+
+        // 이메일 중복 확인
+        if (userRepository.existsByEmail(request.email())) {
+            throw new DuplicateEmailException(request.email());
+        }
+
+        // SYSTEM_ADMIN 사용자 생성 (tenantId 없음)
+        User user = User.create(
+                request.email(),
+                request.name(),
+                passwordEncoder.encode(request.password()),
+                request.phone()
+        );
+
+        // 부서, 직책 설정
+        if (request.department() != null || request.position() != null) {
+            user.updateProfile(
+                    user.getName(),
+                    user.getPhone(),
+                    user.getProfileImageUrl(),
+                    request.department(),
+                    request.position()
+            );
+        }
+
+        // SYSTEM_ADMIN 역할 부여
+        user.updateRole(TenantRole.SYSTEM_ADMIN);
+
+        User savedUser = userRepository.save(user);
+
+        log.info("System admin created: userId={}, email={}", savedUser.getId(), savedUser.getEmail());
+
+        return SystemAdminUserResponse.from(savedUser);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/controller/TaDomainSettingsController.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/controller/TaDomainSettingsController.java
@@ -1,0 +1,59 @@
+package com.mzc.lp.domain.tenant.controller;
+
+import com.mzc.lp.common.dto.ApiResponse;
+import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.tenant.dto.request.UpdateCustomDomainRequest;
+import com.mzc.lp.domain.tenant.dto.response.TenantDomainSettingsResponse;
+import com.mzc.lp.domain.tenant.service.DomainSettingsService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/ta/domain-settings")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('TENANT_ADMIN')")
+public class TaDomainSettingsController {
+
+    private final DomainSettingsService domainSettingsService;
+
+    /**
+     * 도메인 설정 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<TenantDomainSettingsResponse>> getDomainSettings(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        TenantDomainSettingsResponse response = domainSettingsService.getDomainSettings(principal.tenantId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 커스텀 도메인 설정/수정
+     */
+    @PutMapping("/custom")
+    public ResponseEntity<ApiResponse<TenantDomainSettingsResponse>> updateCustomDomain(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody UpdateCustomDomainRequest request
+    ) {
+        TenantDomainSettingsResponse response = domainSettingsService.updateCustomDomain(
+                principal.tenantId(),
+                request.customDomain()
+        );
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 커스텀 도메인 삭제
+     */
+    @DeleteMapping("/custom")
+    public ResponseEntity<Void> deleteCustomDomain(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        domainSettingsService.deleteCustomDomain(principal.tenantId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/controller/TenantController.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/controller/TenantController.java
@@ -132,4 +132,17 @@ public class TenantController {
         TenantUserStatsResponse response = tenantService.getTenantUserStats();
         return ResponseEntity.ok(ApiResponse.success(response));
     }
+
+    /**
+     * 커스텀 도메인 삭제
+     * DELETE /api/tenants/{tenantId}/custom-domain
+     */
+    @DeleteMapping("/{tenantId}/custom-domain")
+    @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+    public ResponseEntity<Void> deleteCustomDomain(
+            @PathVariable @Positive Long tenantId
+    ) {
+        tenantService.deleteCustomDomain(tenantId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateCustomDomainRequest.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/request/UpdateCustomDomainRequest.java
@@ -1,0 +1,19 @@
+package com.mzc.lp.domain.tenant.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record UpdateCustomDomainRequest(
+        @NotBlank(message = "커스텀 도메인은 필수입니다")
+        @Pattern(
+                regexp = "^(?!-)[A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*\\.[A-Za-z]{2,}$",
+                message = "올바른 도메인 형식이 아닙니다 (예: learn.example.com)"
+        )
+        String customDomain
+) {
+    public UpdateCustomDomainRequest {
+        if (customDomain != null) {
+            customDomain = customDomain.trim().toLowerCase();
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/dto/response/TenantDomainSettingsResponse.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/dto/response/TenantDomainSettingsResponse.java
@@ -1,0 +1,39 @@
+package com.mzc.lp.domain.tenant.dto.response;
+
+import com.mzc.lp.domain.tenant.entity.Tenant;
+
+public record TenantDomainSettingsResponse(
+        String subdomain,
+        String fullSubdomainUrl,
+        String customDomain,
+        boolean customDomainEnabled,
+        DnsInstructions dnsInstructions
+) {
+    public record DnsInstructions(
+            String recordType,
+            String recordName,
+            String recordValue
+    ) {}
+
+    public static TenantDomainSettingsResponse from(Tenant tenant, String baseDomain) {
+        String fullUrl = tenant.getSubdomain() + "." + baseDomain;
+        boolean hasCustomDomain = tenant.getCustomDomain() != null && !tenant.getCustomDomain().isBlank();
+
+        DnsInstructions dns = null;
+        if (hasCustomDomain) {
+            dns = new DnsInstructions(
+                    "CNAME",
+                    tenant.getCustomDomain(),
+                    fullUrl
+            );
+        }
+
+        return new TenantDomainSettingsResponse(
+                tenant.getSubdomain(),
+                fullUrl,
+                tenant.getCustomDomain(),
+                hasCustomDomain,
+                dns
+        );
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/service/DomainSettingsService.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/DomainSettingsService.java
@@ -1,0 +1,21 @@
+package com.mzc.lp.domain.tenant.service;
+
+import com.mzc.lp.domain.tenant.dto.response.TenantDomainSettingsResponse;
+
+public interface DomainSettingsService {
+
+    /**
+     * 테넌트의 도메인 설정 조회
+     */
+    TenantDomainSettingsResponse getDomainSettings(Long tenantId);
+
+    /**
+     * 커스텀 도메인 설정/수정
+     */
+    TenantDomainSettingsResponse updateCustomDomain(Long tenantId, String customDomain);
+
+    /**
+     * 커스텀 도메인 삭제
+     */
+    void deleteCustomDomain(Long tenantId);
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/service/DomainSettingsServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/DomainSettingsServiceImpl.java
@@ -1,0 +1,65 @@
+package com.mzc.lp.domain.tenant.service;
+
+import com.mzc.lp.domain.tenant.dto.response.TenantDomainSettingsResponse;
+import com.mzc.lp.domain.tenant.entity.Tenant;
+import com.mzc.lp.domain.tenant.exception.DuplicateCustomDomainException;
+import com.mzc.lp.common.exception.TenantNotFoundException;
+import com.mzc.lp.domain.tenant.repository.TenantRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DomainSettingsServiceImpl implements DomainSettingsService {
+
+    private final TenantRepository tenantRepository;
+
+    @Value("${app.domain.base:mzc-lp.com}")
+    private String baseDomain;
+
+    @Override
+    public TenantDomainSettingsResponse getDomainSettings(Long tenantId) {
+        Tenant tenant = tenantRepository.findById(tenantId)
+                .orElseThrow(() -> new TenantNotFoundException("Tenant not found: " + tenantId));
+
+        return TenantDomainSettingsResponse.from(tenant, baseDomain);
+    }
+
+    @Override
+    @Transactional
+    public TenantDomainSettingsResponse updateCustomDomain(Long tenantId, String customDomain) {
+        log.info("Updating custom domain: tenantId={}, customDomain={}", tenantId, customDomain);
+
+        Tenant tenant = tenantRepository.findById(tenantId)
+                .orElseThrow(() -> new TenantNotFoundException("Tenant not found: " + tenantId));
+
+        // 다른 테넌트가 이미 사용 중인지 확인 (자기 자신 제외)
+        if (!customDomain.equals(tenant.getCustomDomain()) &&
+                tenantRepository.existsByCustomDomain(customDomain)) {
+            throw new DuplicateCustomDomainException(customDomain);
+        }
+
+        tenant.update(tenant.getName(), customDomain, tenant.getPlan());
+
+        log.info("Custom domain updated: tenantId={}, customDomain={}", tenantId, customDomain);
+        return TenantDomainSettingsResponse.from(tenant, baseDomain);
+    }
+
+    @Override
+    @Transactional
+    public void deleteCustomDomain(Long tenantId) {
+        log.info("Deleting custom domain: tenantId={}", tenantId);
+
+        Tenant tenant = tenantRepository.findById(tenantId)
+                .orElseThrow(() -> new TenantNotFoundException("Tenant not found: " + tenantId));
+
+        tenant.update(tenant.getName(), null, tenant.getPlan());
+
+        log.info("Custom domain deleted: tenantId={}", tenantId);
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantService.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantService.java
@@ -50,4 +50,9 @@ public interface TenantService {
      * 테넌트별 사용자 수 통계
      */
     TenantUserStatsResponse getTenantUserStats();
+
+    /**
+     * 커스텀 도메인 삭제 (SA용)
+     */
+    void deleteCustomDomain(Long tenantId);
 }

--- a/src/main/java/com/mzc/lp/domain/tenant/service/TenantServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/service/TenantServiceImpl.java
@@ -240,4 +240,22 @@ public class TenantServiceImpl implements TenantService {
 
         return TenantUserStatsResponse.of(tenantUserCounts, totalUsers);
     }
+
+    @Override
+    @Transactional
+    public void deleteCustomDomain(Long tenantId) {
+        log.info("Deleting custom domain for tenant: tenantId={}", tenantId);
+
+        Tenant tenant = findTenantById(tenantId);
+
+        if (tenant.getCustomDomain() == null) {
+            log.warn("Tenant has no custom domain: tenantId={}", tenantId);
+            return;
+        }
+
+        String oldDomain = tenant.getCustomDomain();
+        tenant.update(tenant.getName(), null, tenant.getPlan());
+
+        log.info("Custom domain deleted: tenantId={}, oldDomain={}", tenantId, oldDomain);
+    }
 }

--- a/src/main/java/com/mzc/lp/domain/user/dto/response/UserListResponse.java
+++ b/src/main/java/com/mzc/lp/domain/user/dto/response/UserListResponse.java
@@ -33,8 +33,8 @@ public record UserListResponse(
                 user.getRole().name(),
                 roleNames,
                 user.getStatus().name(),
-                null,
-                null,
+                user.getDepartment(),
+                user.getLastLoginAt(),
                 user.getCreatedAt()
         );
     }

--- a/src/main/java/com/mzc/lp/domain/user/entity/User.java
+++ b/src/main/java/com/mzc/lp/domain/user/entity/User.java
@@ -51,6 +51,8 @@ public class User extends TenantEntity {
     @Column(nullable = false, length = 20)
     private UserStatus status;
 
+    private java.time.Instant lastLoginAt;  // 마지막 로그인 시간
+
     // 정적 팩토리 메서드
     public static User create(String email, String name, String encodedPassword) {
         User user = new User();
@@ -175,6 +177,14 @@ public class User extends TenantEntity {
                 .min((r1, r2) -> r1.ordinal() - r2.ordinal())
                 .orElse(TenantRole.USER);
         this.role = highestRole;
+    }
+
+    public void updateDepartment(String department) {
+        this.department = department;
+    }
+
+    public void updateLastLoginAt() {
+        this.lastLoginAt = java.time.Instant.now();
     }
 
     public void suspend() {

--- a/src/main/java/com/mzc/lp/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/mzc/lp/domain/user/repository/UserRepository.java
@@ -249,4 +249,54 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
             @Param("tenantId") Long tenantId,
             @Param("startDate") Instant startDate,
             Pageable pageable);
+
+    // ===== 부서별 인원수 조회 =====
+
+    /**
+     * 테넌트별 특정 부서명의 인원수 카운트
+     */
+    @Query("SELECT COUNT(u) FROM User u " +
+            "WHERE u.tenantId = :tenantId " +
+            "AND u.department = :departmentName " +
+            "AND u.status = 'ACTIVE'")
+    int countByTenantIdAndDepartment(
+            @Param("tenantId") Long tenantId,
+            @Param("departmentName") String departmentName);
+
+    /**
+     * 테넌트별 부서별 인원수 집계 (전체)
+     * 반환: [departmentName, count]
+     */
+    @Query("SELECT u.department AS department, COUNT(u) AS count " +
+            "FROM User u " +
+            "WHERE u.tenantId = :tenantId " +
+            "AND u.department IS NOT NULL " +
+            "AND u.status = 'ACTIVE' " +
+            "GROUP BY u.department")
+    List<Object[]> countByTenantIdGroupByDepartment(@Param("tenantId") Long tenantId);
+
+    /**
+     * 테넌트별 특정 부서의 사용자 목록 조회
+     */
+    @Query("SELECT u FROM User u " +
+            "WHERE u.tenantId = :tenantId " +
+            "AND u.department = :departmentName " +
+            "AND u.status = 'ACTIVE' " +
+            "ORDER BY u.position, u.name")
+    List<User> findByTenantIdAndDepartment(
+            @Param("tenantId") Long tenantId,
+            @Param("departmentName") String departmentName);
+
+    /**
+     * 테넌트별 특정 부서에 소속되지 않은 활성 사용자 목록 조회
+     * (부서 미배정 또는 다른 부서 소속 사용자)
+     */
+    @Query("SELECT u FROM User u " +
+            "WHERE u.tenantId = :tenantId " +
+            "AND u.status = 'ACTIVE' " +
+            "AND (u.department IS NULL OR u.department != :departmentName) " +
+            "ORDER BY u.department NULLS FIRST, u.name")
+    List<User> findByTenantIdAndDepartmentNot(
+            @Param("tenantId") Long tenantId,
+            @Param("departmentName") String departmentName);
 }

--- a/src/main/java/com/mzc/lp/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/mzc/lp/domain/user/repository/UserRepositoryCustom.java
@@ -9,4 +9,9 @@ import org.springframework.data.domain.Pageable;
 public interface UserRepositoryCustom {
 
     Page<User> searchUsers(Long tenantId, String keyword, TenantRole role, UserStatus status, Boolean hasCourseRole, Pageable pageable);
+
+    /**
+     * SYSTEM_ADMIN 역할을 가진 사용자 조회 (테넌트 필터 무시)
+     */
+    Page<User> searchSystemAdmins(String keyword, UserStatus status, Pageable pageable);
 }

--- a/src/main/java/com/mzc/lp/domain/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/AuthServiceImpl.java
@@ -104,6 +104,9 @@ public class AuthServiceImpl implements AuthService {
             throw new InvalidCredentialsException();
         }
 
+        // 마지막 로그인 시간 업데이트
+        user.updateLastLoginAt();
+
         // 토큰 생성 (tenantId, 다중 역할 포함)
         Set<String> roleNames = user.getRoles().stream()
                 .map(TenantRole::name)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,6 +48,11 @@ cors:
 tenant:
   default-id: ${TENANT_DEFAULT_ID:1}
 
+# App 설정
+app:
+  domain:
+    base: ${APP_DOMAIN_BASE:mzc-lp.com}
+
 # H2 Console (개발 환경에서만 활성화)
 spring.h2.console:
   enabled: ${H2_CONSOLE_ENABLED:false}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -108,202 +108,245 @@ DELETE FROM cm_course_tags WHERE course_id IN (SELECT id FROM cm_courses WHERE t
 DELETE FROM cm_courses WHERE tenant_id IN (1, 2, 3);
 DELETE FROM cm_categories WHERE tenant_id IN (1, 2, 3);
 DELETE FROM users WHERE tenant_id IN (1, 2, 3);
+DELETE FROM departments WHERE tenant_id IN (1, 2, 3);
 
 -- =============================================
--- 3. 사용자 데이터 INSERT
+-- 3. 부서 데이터 INSERT (테넌트별)
+-- =============================================
+
+-- ===== 테넌트 1 (기본 테넌트) 부서들 =====
+INSERT INTO departments (tenant_id, name, code, description, parent_id, sort_order, is_active, created_at, updated_at) VALUES
+(1, '개발팀', 'DEV', '소프트웨어 개발 부서', NULL, 1, true, NOW(), NOW()),
+(1, '마케팅팀', 'MKT', '마케팅 및 홍보 부서', NULL, 2, true, NOW(), NOW()),
+(1, '인사팀', 'HR', '인사 관리 부서', NULL, 3, true, NOW(), NOW()),
+(1, '영업팀', 'SALES', '영업 및 고객 관리 부서', NULL, 4, true, NOW(), NOW()),
+(1, '디자인팀', 'DESIGN', 'UI/UX 및 그래픽 디자인 부서', NULL, 5, true, NOW(), NOW()),
+(1, '경영지원팀', 'BIZ', '경영 지원 부서', NULL, 6, true, NOW(), NOW());
+
+-- ===== 테넌트 2 (A사) 부서들 =====
+INSERT INTO departments (tenant_id, name, code, description, parent_id, sort_order, is_active, created_at, updated_at) VALUES
+(2, '개발팀', 'DEV', '소프트웨어 개발 부서', NULL, 1, true, NOW(), NOW()),
+(2, '기획팀', 'PLAN', '서비스 기획 부서', NULL, 2, true, NOW(), NOW()),
+(2, '인사팀', 'HR', '인사 관리 부서', NULL, 3, true, NOW(), NOW()),
+(2, '재무팀', 'FIN', '재무 관리 부서', NULL, 4, true, NOW(), NOW()),
+(2, '품질관리팀', 'QA', '품질 보증 부서', NULL, 5, true, NOW(), NOW());
+
+-- ===== 테넌트 3 (B사) 부서들 =====
+INSERT INTO departments (tenant_id, name, code, description, parent_id, sort_order, is_active, created_at, updated_at) VALUES
+(3, '개발팀', 'DEV', '소프트웨어 개발 부서', NULL, 1, true, NOW(), NOW()),
+(3, '마케팅팀', 'MKT', '마케팅 부서', NULL, 2, true, NOW(), NOW()),
+(3, '운영팀', 'OPS', '서비스 운영 부서', NULL, 3, true, NOW(), NOW()),
+(3, '고객지원팀', 'CS', '고객 지원 부서', NULL, 4, true, NOW(), NOW());
+
+-- =============================================
+-- 4. 사용자 데이터 INSERT
 -- 비밀번호: 1q2w3e4r! (BCrypt 암호화)
 -- =============================================
- 
+
 -- ===== 시스템 관리자 (전체 1명) =====
-INSERT INTO users (tenant_id, email, password, name, phone, role, status, created_at, updated_at) VALUES
-(1, 'sysadmin@mzc.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '시스템관리자', '010-0000-0001', 'SYSTEM_ADMIN', 'ACTIVE', NOW(), NOW());
+INSERT INTO users (tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES
+(1, 'sysadmin@mzc.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '시스템관리자', '010-0000-0001', NULL, NULL, 'SYSTEM_ADMIN', 'ACTIVE', NOW(), NOW());
 
 -- ===== 테넌트 1 (기본 테넌트) 사용자들 =====
-INSERT INTO users (tenant_id, email, password, name, phone, role, status, created_at, updated_at) VALUES
+INSERT INTO users (tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES
 -- 테넌트 관리자
-(1, 'admin@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '기본테넌트관리자', '010-1000-0001', 'TENANT_ADMIN', 'ACTIVE', NOW(), NOW()),
+(1, 'admin@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '기본테넌트관리자', '010-1000-0001', '경영지원팀', '부장', 'TENANT_ADMIN', 'ACTIVE', NOW(), NOW()),
 -- 운영자
-(1, 'operator1@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '운영자1', '010-1000-0002', 'OPERATOR', 'ACTIVE', NOW(), NOW()),
-(1, 'operator2@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '운영자2', '010-1000-0003', 'OPERATOR', 'ACTIVE', NOW(), NOW()),
+(1, 'operator1@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '운영자1', '010-1000-0002', '경영지원팀', '과장', 'OPERATOR', 'ACTIVE', NOW(), NOW()),
+(1, 'operator2@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '운영자2', '010-1000-0003', '경영지원팀', '대리', 'OPERATOR', 'ACTIVE', NOW(), NOW()),
 -- 설계자
-(1, 'designer1@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '설계자1', '010-1000-0004', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
-(1, 'designer2@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '설계자2', '010-1000-0005', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
-(1, 'designer3@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '설계자3', '010-1000-0006', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
+(1, 'designer1@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '설계자1', '010-1000-0004', '개발팀', '과장', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
+(1, 'designer2@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '설계자2', '010-1000-0005', '개발팀', '대리', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
+(1, 'designer3@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '설계자3', '010-1000-0006', '디자인팀', '대리', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
 -- 강의 개설자 (테스트용)
-(1, 'creator@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '강의개설자', '010-1000-0007', 'USER', 'ACTIVE', NOW(), NOW()),
--- 일반 사용자 50명 (user1 ~ user50)
-(1, 'user1@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '김민준', '010-1001-0001', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user2@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '이서연', '010-1001-0002', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user3@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '박지호', '010-1001-0003', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user4@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '최수아', '010-1001-0004', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user5@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '정우진', '010-1001-0005', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user6@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '강하은', '010-1001-0006', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user7@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '윤준서', '010-1001-0007', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user8@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '장예은', '010-1001-0008', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user9@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '임도현', '010-1001-0009', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user10@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '한소희', '010-1001-0010', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user11@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '오시우', '010-1001-0011', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user12@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '서유진', '010-1001-0012', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user13@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '신현우', '010-1001-0013', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user14@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '권민서', '010-1001-0014', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user15@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '황지안', '010-1001-0015', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user16@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '안서준', '010-1001-0016', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user17@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '송예린', '010-1001-0017', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user18@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '전민재', '010-1001-0018', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user19@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '홍수빈', '010-1001-0019', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user20@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '유하준', '010-1001-0020', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user21@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '조아린', '010-1001-0021', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user22@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '백승민', '010-1001-0022', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user23@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '노지원', '010-1001-0023', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user24@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '하태민', '010-1001-0024', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user25@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '문채원', '010-1001-0025', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user26@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '양현준', '010-1001-0026', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user27@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '배나은', '010-1001-0027', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user28@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '남지훈', '010-1001-0028', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user29@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '심유나', '010-1001-0029', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user30@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '곽동현', '010-1001-0030', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user31@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '탁서영', '010-1001-0031', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user32@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '엄재윤', '010-1001-0032', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user33@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '표다인', '010-1001-0033', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user34@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '채성호', '010-1001-0034', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user35@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '원미래', '010-1001-0035', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user36@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '길준혁', '010-1001-0036', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user37@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '방소율', '010-1001-0037', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user38@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '추건우', '010-1001-0038', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user39@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '봉하늘', '010-1001-0039', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user40@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '석진우', '010-1001-0040', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user41@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '편가영', '010-1001-0041', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user42@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '선우혁', '010-1001-0042', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user43@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '독고윤', '010-1001-0043', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user44@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '빈세라', '010-1001-0044', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user45@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '피태양', '010-1001-0045', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user46@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '공보람', '010-1001-0046', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user47@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '국승리', '010-1001-0047', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user48@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '도경민', '010-1001-0048', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user49@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '류다온', '010-1001-0049', 'USER', 'ACTIVE', NOW(), NOW()),
-(1, 'user50@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '마준영', '010-1001-0050', 'USER', 'ACTIVE', NOW(), NOW());
+(1, 'creator@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '강의개설자', '010-1000-0007', '개발팀', '팀장', 'USER', 'ACTIVE', NOW(), NOW()),
+-- 일반 사용자 50명 (user1 ~ user50) - 부서/직급 분배
+-- 개발팀 (15명)
+(1, 'user1@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '김민준', '010-1001-0001', '개발팀', '차장', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user2@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '이서연', '010-1001-0002', '개발팀', '과장', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user3@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '박지호', '010-1001-0003', '개발팀', '과장', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user4@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '최수아', '010-1001-0004', '개발팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user5@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '정우진', '010-1001-0005', '개발팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user6@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '강하은', '010-1001-0006', '개발팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user7@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '윤준서', '010-1001-0007', '개발팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user8@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '장예은', '010-1001-0008', '개발팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user9@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '임도현', '010-1001-0009', '개발팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user10@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '한소희', '010-1001-0010', '개발팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user11@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '오시우', '010-1001-0011', '개발팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user12@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '서유진', '010-1001-0012', '개발팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user13@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '신현우', '010-1001-0013', '개발팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user14@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '권민서', '010-1001-0014', '개발팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user15@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '황지안', '010-1001-0015', '개발팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+-- 마케팅팀 (10명)
+(1, 'user16@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '안서준', '010-1001-0016', '마케팅팀', '팀장', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user17@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '송예린', '010-1001-0017', '마케팅팀', '과장', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user18@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '전민재', '010-1001-0018', '마케팅팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user19@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '홍수빈', '010-1001-0019', '마케팅팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user20@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '유하준', '010-1001-0020', '마케팅팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user21@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '조아린', '010-1001-0021', '마케팅팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user22@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '백승민', '010-1001-0022', '마케팅팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user23@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '노지원', '010-1001-0023', '마케팅팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user24@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '하태민', '010-1001-0024', '마케팅팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user25@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '문채원', '010-1001-0025', '마케팅팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+-- 인사팀 (8명)
+(1, 'user26@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '양현준', '010-1001-0026', '인사팀', '팀장', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user27@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '배나은', '010-1001-0027', '인사팀', '과장', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user28@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '남지훈', '010-1001-0028', '인사팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user29@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '심유나', '010-1001-0029', '인사팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user30@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '곽동현', '010-1001-0030', '인사팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user31@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '탁서영', '010-1001-0031', '인사팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user32@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '엄재윤', '010-1001-0032', '인사팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user33@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '표다인', '010-1001-0033', '인사팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+-- 영업팀 (10명)
+(1, 'user34@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '채성호', '010-1001-0034', '영업팀', '팀장', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user35@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '원미래', '010-1001-0035', '영업팀', '차장', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user36@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '길준혁', '010-1001-0036', '영업팀', '과장', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user37@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '방소율', '010-1001-0037', '영업팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user38@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '추건우', '010-1001-0038', '영업팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user39@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '봉하늘', '010-1001-0039', '영업팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user40@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '석진우', '010-1001-0040', '영업팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user41@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '편가영', '010-1001-0041', '영업팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user42@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '선우혁', '010-1001-0042', '영업팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user43@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '독고윤', '010-1001-0043', '영업팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+-- 디자인팀 (7명)
+(1, 'user44@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '빈세라', '010-1001-0044', '디자인팀', '팀장', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user45@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '피태양', '010-1001-0045', '디자인팀', '과장', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user46@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '공보람', '010-1001-0046', '디자인팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user47@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '국승리', '010-1001-0047', '디자인팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user48@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '도경민', '010-1001-0048', '디자인팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user49@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '류다온', '010-1001-0049', '디자인팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(1, 'user50@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '마준영', '010-1001-0050', '디자인팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW());
 
 -- ===== 테넌트 2 (A사 교육센터) 사용자들 =====
-INSERT INTO users (tenant_id, email, password, name, phone, role, status, created_at, updated_at) VALUES
+INSERT INTO users (tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES
 -- 테넌트 관리자
-(2, 'admin@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A사관리자', '010-2000-0001', 'TENANT_ADMIN', 'ACTIVE', NOW(), NOW()),
+(2, 'admin@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A사관리자', '010-2000-0001', '인사팀', '부장', 'TENANT_ADMIN', 'ACTIVE', NOW(), NOW()),
 -- 운영자
-(2, 'operator1@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A사운영자1', '010-2000-0002', 'OPERATOR', 'ACTIVE', NOW(), NOW()),
+(2, 'operator1@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A사운영자1', '010-2000-0002', '인사팀', '과장', 'OPERATOR', 'ACTIVE', NOW(), NOW()),
 -- 설계자
-(2, 'designer1@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A사설계자1', '010-2000-0003', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
-(2, 'designer2@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A사설계자2', '010-2000-0004', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
--- 일반 사용자 50명
-(2, 'user1@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A김철수', '010-2001-0001', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user2@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A이영희', '010-2001-0002', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user3@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A박민수', '010-2001-0003', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user4@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A최지우', '010-2001-0004', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user5@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A정현아', '010-2001-0005', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user6@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A강태웅', '010-2001-0006', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user7@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A윤서진', '010-2001-0007', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user8@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A장미래', '010-2001-0008', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user9@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A임현수', '010-2001-0009', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user10@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A한소연', '010-2001-0010', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user11@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A오준혁', '010-2001-0011', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user12@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A서다은', '010-2001-0012', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user13@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A신우진', '010-2001-0013', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user14@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A권나라', '010-2001-0014', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user15@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A황민호', '010-2001-0015', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user16@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A안예진', '010-2001-0016', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user17@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A송태현', '010-2001-0017', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user18@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A전수빈', '010-2001-0018', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user19@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A홍지민', '010-2001-0019', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user20@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A유하진', '010-2001-0020', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user21@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A조민석', '010-2001-0021', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user22@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A백수진', '010-2001-0022', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user23@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A노건우', '010-2001-0023', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user24@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A하민지', '010-2001-0024', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user25@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A문성훈', '010-2001-0025', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user26@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A양채린', '010-2001-0026', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user27@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A배현준', '010-2001-0027', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user28@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A남가영', '010-2001-0028', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user29@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A심동우', '010-2001-0029', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user30@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A곽예림', '010-2001-0030', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user31@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A탁승우', '010-2001-0031', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user32@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A엄소영', '010-2001-0032', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user33@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A표재윤', '010-2001-0033', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user34@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A채지안', '010-2001-0034', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user35@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A원태윤', '010-2001-0035', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user36@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A길나윤', '010-2001-0036', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user37@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A방준서', '010-2001-0037', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user38@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A추아린', '010-2001-0038', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user39@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A봉현우', '010-2001-0039', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user40@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A석다인', '010-2001-0040', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user41@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A편성민', '010-2001-0041', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user42@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A선우민', '010-2001-0042', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user43@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A독고연', '010-2001-0043', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user44@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A빈태호', '010-2001-0044', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user45@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A피소라', '010-2001-0045', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user46@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A공민재', '010-2001-0046', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user47@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A국하늘', '010-2001-0047', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user48@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A도영우', '010-2001-0048', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user49@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A류민서', '010-2001-0049', 'USER', 'ACTIVE', NOW(), NOW()),
-(2, 'user50@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A마서연', '010-2001-0050', 'USER', 'ACTIVE', NOW(), NOW());
+(2, 'designer1@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A사설계자1', '010-2000-0003', '개발팀', '과장', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
+(2, 'designer2@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A사설계자2', '010-2000-0004', '기획팀', '대리', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
+-- 일반 사용자 50명 - 부서/직급 분배
+-- 개발팀 (15명)
+(2, 'user1@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A김철수', '010-2001-0001', '개발팀', '팀장', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user2@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A이영희', '010-2001-0002', '개발팀', '차장', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user3@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A박민수', '010-2001-0003', '개발팀', '과장', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user4@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A최지우', '010-2001-0004', '개발팀', '과장', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user5@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A정현아', '010-2001-0005', '개발팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user6@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A강태웅', '010-2001-0006', '개발팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user7@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A윤서진', '010-2001-0007', '개발팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user8@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A장미래', '010-2001-0008', '개발팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user9@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A임현수', '010-2001-0009', '개발팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user10@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A한소연', '010-2001-0010', '개발팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user11@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A오준혁', '010-2001-0011', '개발팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user12@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A서다은', '010-2001-0012', '개발팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user13@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A신우진', '010-2001-0013', '개발팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user14@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A권나라', '010-2001-0014', '개발팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user15@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A황민호', '010-2001-0015', '개발팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+-- 기획팀 (12명)
+(2, 'user16@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A안예진', '010-2001-0016', '기획팀', '팀장', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user17@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A송태현', '010-2001-0017', '기획팀', '과장', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user18@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A전수빈', '010-2001-0018', '기획팀', '과장', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user19@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A홍지민', '010-2001-0019', '기획팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user20@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A유하진', '010-2001-0020', '기획팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user21@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A조민석', '010-2001-0021', '기획팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user22@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A백수진', '010-2001-0022', '기획팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user23@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A노건우', '010-2001-0023', '기획팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user24@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A하민지', '010-2001-0024', '기획팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user25@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A문성훈', '010-2001-0025', '기획팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user26@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A양채린', '010-2001-0026', '기획팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user27@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A배현준', '010-2001-0027', '기획팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+-- 인사팀 (8명)
+(2, 'user28@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A남가영', '010-2001-0028', '인사팀', '팀장', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user29@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A심동우', '010-2001-0029', '인사팀', '과장', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user30@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A곽예림', '010-2001-0030', '인사팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user31@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A탁승우', '010-2001-0031', '인사팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user32@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A엄소영', '010-2001-0032', '인사팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user33@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A표재윤', '010-2001-0033', '인사팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user34@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A채지안', '010-2001-0034', '인사팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user35@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A원태윤', '010-2001-0035', '인사팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+-- 재무팀 (8명)
+(2, 'user36@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A길나윤', '010-2001-0036', '재무팀', '팀장', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user37@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A방준서', '010-2001-0037', '재무팀', '차장', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user38@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A추아린', '010-2001-0038', '재무팀', '과장', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user39@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A봉현우', '010-2001-0039', '재무팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user40@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A석다인', '010-2001-0040', '재무팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user41@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A편성민', '010-2001-0041', '재무팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user42@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A선우민', '010-2001-0042', '재무팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user43@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A독고연', '010-2001-0043', '재무팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+-- 품질관리팀 (7명)
+(2, 'user44@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A빈태호', '010-2001-0044', '품질관리팀', '팀장', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user45@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A피소라', '010-2001-0045', '품질관리팀', '과장', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user46@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A공민재', '010-2001-0046', '품질관리팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user47@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A국하늘', '010-2001-0047', '품질관리팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user48@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A도영우', '010-2001-0048', '품질관리팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user49@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A류민서', '010-2001-0049', '품질관리팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(2, 'user50@company-a.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'A마서연', '010-2001-0050', '품질관리팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW());
 
 -- ===== 테넌트 3 (B사 아카데미) 사용자들 =====
-INSERT INTO users (tenant_id, email, password, name, phone, role, status, created_at, updated_at) VALUES
+INSERT INTO users (tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES
 -- 테넌트 관리자
-(3, 'admin@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B사관리자', '010-3000-0001', 'TENANT_ADMIN', 'ACTIVE', NOW(), NOW()),
+(3, 'admin@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B사관리자', '010-3000-0001', '운영팀', '부장', 'TENANT_ADMIN', 'ACTIVE', NOW(), NOW()),
 -- 운영자
-(3, 'operator1@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B사운영자1', '010-3000-0002', 'OPERATOR', 'ACTIVE', NOW(), NOW()),
+(3, 'operator1@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B사운영자1', '010-3000-0002', '운영팀', '과장', 'OPERATOR', 'ACTIVE', NOW(), NOW()),
 -- 설계자
-(3, 'designer1@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B사설계자1', '010-3000-0003', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
-(3, 'designer2@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B사설계자2', '010-3000-0004', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
--- 일반 사용자 50명
-(3, 'user1@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B박준혁', '010-3001-0001', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user2@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B김서아', '010-3001-0002', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user3@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B이도윤', '010-3001-0003', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user4@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B최하은', '010-3001-0004', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user5@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B정시우', '010-3001-0005', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user6@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B강예은', '010-3001-0006', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user7@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B윤지호', '010-3001-0007', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user8@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B장수아', '010-3001-0008', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user9@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B임우진', '010-3001-0009', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user10@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B한서연', '010-3001-0010', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user11@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B오민준', '010-3001-0011', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user12@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B서지안', '010-3001-0012', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user13@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B신현우', '010-3001-0013', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user14@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B권예린', '010-3001-0014', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user15@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B황태민', '010-3001-0015', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user16@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B안나은', '010-3001-0016', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user17@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B송준서', '010-3001-0017', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user18@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B전아린', '010-3001-0018', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user19@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B홍승민', '010-3001-0019', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user20@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B유지원', '010-3001-0020', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user21@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B조하준', '010-3001-0021', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user22@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B백민서', '010-3001-0022', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user23@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B노태현', '010-3001-0023', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user24@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B하수빈', '010-3001-0024', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user25@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B문지민', '010-3001-0025', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user26@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B양하진', '010-3001-0026', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user27@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B배민석', '010-3001-0027', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user28@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B남수진', '010-3001-0028', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user29@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B심건우', '010-3001-0029', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user30@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B곽민지', '010-3001-0030', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user31@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B탁성훈', '010-3001-0031', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user32@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B엄채린', '010-3001-0032', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user33@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B표현준', '010-3001-0033', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user34@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B채가영', '010-3001-0034', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user35@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B원동우', '010-3001-0035', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user36@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B길예림', '010-3001-0036', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user37@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B방승우', '010-3001-0037', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user38@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B추소영', '010-3001-0038', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user39@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B봉재윤', '010-3001-0039', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user40@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B석지안', '010-3001-0040', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user41@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B편태윤', '010-3001-0041', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user42@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B선우나', '010-3001-0042', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user43@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B독고준', '010-3001-0043', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user44@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B빈아린', '010-3001-0044', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user45@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B피현우', '010-3001-0045', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user46@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B공다인', '010-3001-0046', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user47@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B국성호', '010-3001-0047', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user48@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B도미래', '010-3001-0048', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user49@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B류준영', '010-3001-0049', 'USER', 'ACTIVE', NOW(), NOW()),
-(3, 'user50@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B마다온', '010-3001-0050', 'USER', 'ACTIVE', NOW(), NOW());
+(3, 'designer1@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B사설계자1', '010-3000-0003', '개발팀', '과장', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
+(3, 'designer2@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B사설계자2', '010-3000-0004', '개발팀', '대리', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
+-- 일반 사용자 50명 (4개 부서 분배: 개발팀, 마케팅팀, 운영팀, 고객지원팀)
+-- 개발팀 (15명)
+(3, 'user1@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B박준혁', '010-3001-0001', '개발팀', '팀장', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user2@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B김서아', '010-3001-0002', '개발팀', '차장', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user3@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B이도윤', '010-3001-0003', '개발팀', '과장', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user4@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B최하은', '010-3001-0004', '개발팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user5@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B정시우', '010-3001-0005', '개발팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user6@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B강예은', '010-3001-0006', '개발팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user7@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B윤지호', '010-3001-0007', '개발팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user8@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B장수아', '010-3001-0008', '개발팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user9@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B임우진', '010-3001-0009', '개발팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user10@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B한서연', '010-3001-0010', '개발팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user11@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B오민준', '010-3001-0011', '개발팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user12@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B서지안', '010-3001-0012', '개발팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user13@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B신현우', '010-3001-0013', '개발팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user14@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B권예린', '010-3001-0014', '개발팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user15@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B황태민', '010-3001-0015', '개발팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+-- 마케팅팀 (12명)
+(3, 'user16@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B안나은', '010-3001-0016', '마케팅팀', '팀장', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user17@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B송준서', '010-3001-0017', '마케팅팀', '과장', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user18@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B전아린', '010-3001-0018', '마케팅팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user19@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B홍승민', '010-3001-0019', '마케팅팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user20@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B유지원', '010-3001-0020', '마케팅팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user21@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B조하준', '010-3001-0021', '마케팅팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user22@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B백민서', '010-3001-0022', '마케팅팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user23@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B노태현', '010-3001-0023', '마케팅팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user24@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B하수빈', '010-3001-0024', '마케팅팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user25@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B문지민', '010-3001-0025', '마케팅팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user26@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B양하진', '010-3001-0026', '마케팅팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user27@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B배민석', '010-3001-0027', '마케팅팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+-- 운영팀 (12명)
+(3, 'user28@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B남수진', '010-3001-0028', '운영팀', '팀장', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user29@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B심건우', '010-3001-0029', '운영팀', '차장', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user30@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B곽민지', '010-3001-0030', '운영팀', '과장', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user31@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B탁성훈', '010-3001-0031', '운영팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user32@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B엄채린', '010-3001-0032', '운영팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user33@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B표현준', '010-3001-0033', '운영팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user34@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B채가영', '010-3001-0034', '운영팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user35@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B원동우', '010-3001-0035', '운영팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user36@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B길예림', '010-3001-0036', '운영팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user37@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B방승우', '010-3001-0037', '운영팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user38@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B추소영', '010-3001-0038', '운영팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user39@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B봉재윤', '010-3001-0039', '운영팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+-- 고객지원팀 (11명)
+(3, 'user40@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B석지안', '010-3001-0040', '고객지원팀', '팀장', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user41@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B편태윤', '010-3001-0041', '고객지원팀', '과장', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user42@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B선우나', '010-3001-0042', '고객지원팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user43@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B독고준', '010-3001-0043', '고객지원팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user44@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B빈아린', '010-3001-0044', '고객지원팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user45@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B피현우', '010-3001-0045', '고객지원팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user46@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B공다인', '010-3001-0046', '고객지원팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user47@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B국성호', '010-3001-0047', '고객지원팀', '사원', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user48@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B도미래', '010-3001-0048', '고객지원팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user49@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B류준영', '010-3001-0049', '고객지원팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW()),
+(3, 'user50@company-b.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', 'B마다온', '010-3001-0050', '고객지원팀', '인턴', 'USER', 'ACTIVE', NOW(), NOW());
 
 -- =============================================
 -- 4. 카테고리 데이터 INSERT (프론트엔드와 ID 일치 필요)


### PR DESCRIPTION
## Summary

시스템 관리자(SA) 및 테넌트 관리자(TA) 기능 개선 및 테넌트별 분석 데이터 조회 기능을 추가했습니다.

## Related Issue

- N/A

## Changes

### SA (System Admin) 기능
- SA 시스템 관리자 생성 및 조회 API 추가
  - `POST /api/sa/users` - 시스템 관리자 생성
  - `GET /api/sa/users` - 시스템 관리자 목록 조회
- 테넌트 커스텀 도메인 삭제 기능 추가
  - `DELETE /api/tenants/{tenantId}/custom-domain` - 커스텀 도메인 삭제
- Analytics API에 테넌트별 필터링 지원 추가
  - `/api/sa/analytics/logs?tenantId={id}` - 특정 테넌트 로그 조회
  - `/api/sa/analytics/stats?tenantId={id}` - 특정 테넌트 통계 조회
  - `/api/sa/analytics/recent?tenantId={id}` - 특정 테넌트 최근 활동 조회
- UserRepository에 시스템 관리자 조회를 위한 Native Query 추가
  - Hibernate 테넌트 필터 우회하여 SYSTEM_ADMIN 역할 사용자 조회

### TA (Tenant Admin) 기능
- 테넌트 도메인 설정 API 추가
  - `GET /api/ta/domain-settings` - 현재 테넌트 도메인 설정 조회
  - `PUT /api/ta/domain-settings/custom-domain` - 커스텀 도메인 업데이트
  - 테넌트별 서브도메인 및 커스텀 도메인 관리

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 테넌트별 분석 데이터 조회를 위해 모든 analytics API에 선택적 tenantId 파라미터 지원
- Native Query를 사용하여 Hibernate 테넌트 필터를 우회하고 SYSTEM_ADMIN 역할 사용자 조회
- TA용 도메인 설정 API를 통해 테넌트 관리자가 자신의 도메인을 관리할 수 있음