### PR TITLE
fix: 차수 복제 API 확장 및 과정 목록 API 필터링 수정

### DIFF
--- a/src/main/java/com/mzc/lp/domain/course/controller/CourseController.java
+++ b/src/main/java/com/mzc/lp/domain/course/controller/CourseController.java
@@ -2,6 +2,7 @@ package com.mzc.lp.domain.course.controller;
 
 import com.mzc.lp.common.dto.ApiResponse;
 import com.mzc.lp.common.security.UserPrincipal;
+import com.mzc.lp.domain.course.constant.CourseStatus;
 import com.mzc.lp.domain.course.dto.request.CreateCourseRequest;
 import com.mzc.lp.domain.course.dto.request.UpdateCourseRequest;
 import com.mzc.lp.domain.course.dto.response.CourseDetailResponse;
@@ -43,17 +44,18 @@ public class CourseController {
     }
 
     /**
-     * 강의 목록 조회 (페이징, 키워드 검색, 카테고리 필터)
+     * 강의 목록 조회 (페이징, 키워드 검색, 카테고리 필터, 상태 필터)
      * GET /api/courses
      */
     @GetMapping
     public ResponseEntity<ApiResponse<Page<CourseResponse>>> getCourses(
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) Long categoryId,
+            @RequestParam(required = false) CourseStatus status,
             @PageableDefault(size = 20) Pageable pageable,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Page<CourseResponse> response = courseService.getCourses(keyword, categoryId, pageable);
+        Page<CourseResponse> response = courseService.getCourses(keyword, categoryId, status, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/mzc/lp/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/mzc/lp/domain/course/repository/CourseRepository.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.course.repository;
 
+import com.mzc.lp.domain.course.constant.CourseStatus;
 import com.mzc.lp.domain.course.entity.Course;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -37,4 +38,16 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 
     @Query("SELECT c.id FROM Course c WHERE c.createdBy = :createdBy AND c.tenantId = :tenantId")
     List<Long> findIdsByCreatedByAndTenantId(@Param("createdBy") Long createdBy, @Param("tenantId") Long tenantId);
+
+    @Query("SELECT c FROM Course c WHERE c.tenantId = :tenantId " +
+            "AND (:keyword IS NULL OR c.title LIKE %:keyword%) " +
+            "AND (:categoryId IS NULL OR c.categoryId = :categoryId) " +
+            "AND (:status IS NULL OR c.status = :status)")
+    Page<Course> findByFilters(
+            @Param("tenantId") Long tenantId,
+            @Param("keyword") String keyword,
+            @Param("categoryId") Long categoryId,
+            @Param("status") CourseStatus status,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseService.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseService.java
@@ -1,5 +1,6 @@
 package com.mzc.lp.domain.course.service;
 
+import com.mzc.lp.domain.course.constant.CourseStatus;
 import com.mzc.lp.domain.course.dto.request.CreateCourseRequest;
 import com.mzc.lp.domain.course.dto.request.UpdateCourseRequest;
 import com.mzc.lp.domain.course.dto.response.CourseDetailResponse;
@@ -18,13 +19,14 @@ public interface CourseService {
     CourseResponse createCourse(CreateCourseRequest request, Long createdBy);
 
     /**
-     * 강의 목록 조회 (페이징, 키워드 검색, 카테고리 필터)
+     * 강의 목록 조회 (페이징, 키워드 검색, 카테고리 필터, 상태 필터)
      * @param keyword 검색 키워드 (제목)
      * @param categoryId 카테고리 ID (필터)
+     * @param status 상태 필터 (DRAFT, READY, REGISTERED)
      * @param pageable 페이징 정보
      * @return 강의 목록 페이지
      */
-    Page<CourseResponse> getCourses(String keyword, Long categoryId, Pageable pageable);
+    Page<CourseResponse> getCourses(String keyword, Long categoryId, CourseStatus status, Pageable pageable);
 
     /**
      * 강의 상세 조회 (아이템 포함)

--- a/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/course/service/CourseServiceImpl.java
@@ -80,25 +80,17 @@ public class CourseServiceImpl implements CourseService {
     }
 
     @Override
-    public Page<CourseResponse> getCourses(String keyword, Long categoryId, Pageable pageable) {
-        log.debug("Getting courses: keyword={}, categoryId={}", keyword, categoryId);
-
-        Page<Course> courses;
-
-        if (keyword != null && !keyword.isBlank() && categoryId != null) {
-            courses = courseRepository.findByTenantIdAndTitleContainingAndCategoryId(
-                    TenantContext.getCurrentTenantId(), keyword, categoryId, pageable);
-        } else if (keyword != null && !keyword.isBlank()) {
-            courses = courseRepository.findByTenantIdAndTitleContaining(
-                    TenantContext.getCurrentTenantId(), keyword, pageable);
-        } else if (categoryId != null) {
-            courses = courseRepository.findByTenantIdAndCategoryId(
-                    TenantContext.getCurrentTenantId(), categoryId, pageable);
-        } else {
-            courses = courseRepository.findByTenantId(TenantContext.getCurrentTenantId(), pageable);
-        }
+    public Page<CourseResponse> getCourses(String keyword, Long categoryId, CourseStatus status, Pageable pageable) {
+        log.debug("Getting courses: keyword={}, categoryId={}, status={}", keyword, categoryId, status);
 
         Long tenantId = TenantContext.getCurrentTenantId();
+        Page<Course> courses = courseRepository.findByFilters(
+                tenantId,
+                keyword != null && !keyword.isBlank() ? keyword : null,
+                categoryId,
+                status,
+                pageable
+        );
 
         // creatorId 목록 추출 및 User 일괄 조회 (N+1 방지)
         List<Long> creatorIds = courses.getContent().stream()

--- a/src/main/java/com/mzc/lp/domain/ts/dto/request/CloneCourseTimeRequest.java
+++ b/src/main/java/com/mzc/lp/domain/ts/dto/request/CloneCourseTimeRequest.java
@@ -4,15 +4,18 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record CloneCourseTimeRequest(
+        // 기본 정보 (필수)
         @NotBlank(message = "제목은 필수입니다")
         @Size(max = 200, message = "제목은 200자 이하여야 합니다")
         String title,
 
         String description,
 
+        // 기간 설정 (필수)
         @NotNull(message = "모집 시작일은 필수입니다")
         LocalDate enrollStartDate,
 
@@ -22,7 +25,16 @@ public record CloneCourseTimeRequest(
         @NotNull(message = "학습 시작일은 필수입니다")
         LocalDate classStartDate,
 
-        @NotNull(message = "학습 종료일은 필수입니다")
-        LocalDate classEndDate
+        // FIXED: 필수 (서비스에서 검증), RELATIVE/UNLIMITED: null
+        LocalDate classEndDate,
+
+        // 운영 설정 (선택 - null이면 원본 복사)
+        Integer capacity,
+        BigDecimal price,
+        Boolean isFree,
+        String locationInfo,
+
+        // 정기 일정 (true: 원본 일정 복사, false/null: 일정 없이)
+        Boolean copyRecurringSchedule
 ) {
 }

--- a/src/main/java/com/mzc/lp/domain/ts/entity/CourseTime.java
+++ b/src/main/java/com/mzc/lp/domain/ts/entity/CourseTime.java
@@ -128,22 +128,42 @@ public class CourseTime extends TenantEntity {
             LocalDate enrollEndDate,
             LocalDate classStartDate,
             LocalDate classEndDate,
+            // 운영 설정 (선택 - null이면 원본 복사)
+            Integer capacity,
+            BigDecimal price,
+            Boolean isFree,
+            String locationInfo,
+            Boolean copyRecurringSchedule,
             Long createdBy
     ) {
         CourseTime courseTime = new CourseTime();
-        // 복제 대상 필드
+
+        // 원본 그대로 복사 (프론트에서 수정 불가)
         courseTime.course = source.course;
         courseTime.deliveryType = source.deliveryType;
         courseTime.durationType = source.durationType;
-        courseTime.capacity = source.capacity;
         courseTime.maxWaitingCount = source.maxWaitingCount;
         courseTime.enrollmentMethod = source.enrollmentMethod;
         courseTime.minProgressForCompletion = source.minProgressForCompletion;
-        courseTime.price = source.price;
-        courseTime.free = source.free;
-        courseTime.locationInfo = source.locationInfo;
         courseTime.allowLateEnrollment = source.allowLateEnrollment;
-        courseTime.recurringSchedule = source.recurringSchedule;
+
+        // 운영 설정 - 요청값 있으면 사용, 없으면 원본 복사
+        courseTime.capacity = capacity != null ? capacity : source.capacity;
+        courseTime.locationInfo = locationInfo != null ? locationInfo : source.locationInfo;
+
+        // 가격 설정 - isFree 처리
+        if (isFree != null) {
+            courseTime.free = isFree;
+            courseTime.price = isFree ? BigDecimal.ZERO : (price != null ? price : source.price);
+        } else {
+            courseTime.free = source.free;
+            courseTime.price = price != null ? price : source.price;
+        }
+
+        // 정기 일정 - 복사 여부에 따라
+        courseTime.recurringSchedule = Boolean.TRUE.equals(copyRecurringSchedule)
+                ? source.recurringSchedule
+                : null;
 
         // 새로 지정하는 필드
         courseTime.title = newTitle;


### PR DESCRIPTION
## Summary

차수 복제 API 확장 및 Course 목록 API status 필터링 버그 수정

## Related Issue

- Closes #

## Changes

### 1. 차수 복제 API 확장
- `CloneCourseTimeRequest`: classEndDate `@NotNull` 제거 (RELATIVE/UNLIMITED 지원)
- `CloneCourseTimeRequest`: 운영 설정 필드 추가 (capacity, price, isFree, locationInfo, copyRecurringSchedule)
- `CourseTime.cloneFrom()`: 선택 필드 처리 (요청값 있으면 사용, 없으면 원본 복사)
- `CourseTimeServiceImpl`: durationType별 classEndDate 검증 추가 (FIXED만 필수)

### 2. Course 목록 API status 필터링 버그 수정
- `CourseController`: status 쿼리 파라미터 추가 (DRAFT, READY, REGISTERED)
- `CourseService`: getCourses 메서드 시그니처에 CourseStatus 추가
- `CourseRepository`: 동적 필터링 JPQL 쿼리 findByFilters 추가
- `CourseServiceImpl`: 기존 조건 분기 로직을 findByFilters 단일 쿼리로 통합

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

## Additional Notes

**Course API 사용 예시:**

GET /api/courses?status=REGISTERED GET /api/courses?keyword=Spring&status=READY

`**Clone API 운영 설정 필드:**
- `capacity`: 정원 (null이면 원본 복사)
- `price`: 가격 (null이면 원본 복사)
- `isFree`: 무료 여부 (null이면 원본 복사)
- `locationInfo`: 장소 정보 (null이면 원본 복사)
- `copyRecurringSchedule`: 정기 일정 복사 여부 (true면 복사, false/null이면 일정 없음)