### PR TITLE
feat: CourseTime duration_type, schedule 컬럼 추가 (#415)

### DIFF
--- a/src/main/resources/migration/V20260120__add_duration_type_and_schedule_to_course_times.sql
+++ b/src/main/resources/migration/V20260120__add_duration_type_and_schedule_to_course_times.sql
@@ -1,0 +1,25 @@
+-- ============================================
+-- CourseTime에 duration_type, schedule 관련 컬럼 추가
+-- 날짜: 2026-01-20
+-- 이슈: #415
+-- ============================================
+
+-- duration_type 컬럼 추가 (FIXED, RELATIVE, UNLIMITED)
+ALTER TABLE course_times
+ADD COLUMN duration_type VARCHAR(20) NOT NULL DEFAULT 'FIXED';
+
+-- schedule_days_of_week 컬럼 추가 (수업 요일)
+ALTER TABLE course_times
+ADD COLUMN schedule_days_of_week JSON NULL;
+
+-- schedule_start_time 컬럼 추가 (수업 시작 시간)
+ALTER TABLE course_times
+ADD COLUMN schedule_start_time TIME NULL;
+
+-- schedule_end_time 컬럼 추가 (수업 종료 시간)
+ALTER TABLE course_times
+ADD COLUMN schedule_end_time TIME NULL;
+
+-- class_end_date NULL 허용으로 변경 (UNLIMITED 타입용)
+ALTER TABLE course_times
+MODIFY COLUMN class_end_date DATE NULL;

--- a/src/main/resources/migration/V20260120__add_duration_type_and_schedule_to_course_times.sql
+++ b/src/main/resources/migration/V20260120__add_duration_type_and_schedule_to_course_times.sql
@@ -23,3 +23,7 @@ ADD COLUMN schedule_end_time TIME NULL;
 -- class_end_date NULL 허용으로 변경 (UNLIMITED 타입용)
 ALTER TABLE course_times
 MODIFY COLUMN class_end_date DATE NULL;
+
+-- description 컬럼 추가 (차수 설명)
+ALTER TABLE course_times
+ADD COLUMN description TEXT NULL;


### PR DESCRIPTION
## Summary
- CourseTime 엔티티에 duration_type, schedule 관련 컬럼 추가
- Flyway 마이그레이션 스크립트 추가 (V20260120)
- 차수 복제 API 확장 (CloneCourseTimeRequest에 필드 추가)

## Test plan
- [ ] 서버 시작 후 course_times 테이블에 새 컬럼 확인
- [ ] 차수 생성/복제 API 테스트
- [ ] 학습 기간 유형(FIXED, RELATIVE, UNLIMITED) 동작 확인