### PR TITLE
feat : 브랜딩 템플릿 추가 및 파피콘 생성 API

### DIFF
--- a/src/main/java/com/mzc/lp/domain/tenant/entity/TenantSettings.java
+++ b/src/main/java/com/mzc/lp/domain/tenant/entity/TenantSettings.java
@@ -186,6 +186,9 @@ public class TenantSettings extends BaseTimeEntity {
         settings.headingFont = "Pretendard";
         settings.bodyFont = "Pretendard";
 
+        // 테넌트 이름 첫 글자로 자동 파비콘 생성
+        settings.faviconUrl = generateInitialFavicon(tenant.getName(), settings.primaryColor);
+
         // 기본 헤더 설정
         settings.headerSettings = new HashMap<>();
         settings.headerSettings.put("style", "fixed");
@@ -211,6 +214,46 @@ public class TenantSettings extends BaseTimeEntity {
         settings.contentSettings.put("padding", "normal");
 
         return settings;
+    }
+
+    /**
+     * 테넌트 이름의 첫 글자로 SVG 파비콘 생성
+     * @param tenantName 테넌트 이름
+     * @param primaryColor 주 색상 (hex)
+     * @return SVG data URL
+     */
+    private static String generateInitialFavicon(String tenantName, String primaryColor) {
+        if (tenantName == null || tenantName.isBlank()) {
+            return null;
+        }
+
+        // 첫 글자 추출 (영문 대문자, 한글, 숫자 지원)
+        String initial = tenantName.trim().substring(0, 1).toUpperCase();
+
+        // SVG 파비콘 생성 (32x32, 라운드 사각형 배경 + 흰색 글자)
+        String svg = String.format("""
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+              <rect width="32" height="32" rx="6" fill="%s"/>
+              <text x="16" y="22" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white" text-anchor="middle">%s</text>
+            </svg>
+            """, primaryColor, escapeXml(initial));
+
+        // Base64 인코딩하여 data URL 반환
+        String base64 = java.util.Base64.getEncoder().encodeToString(svg.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        return "data:image/svg+xml;base64," + base64;
+    }
+
+    /**
+     * XML 특수문자 이스케이프
+     */
+    private static String escapeXml(String text) {
+        if (text == null) return "";
+        return text
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
     }
 
     // 브랜딩 업데이트 (확장)


### PR DESCRIPTION
## Summary

테넌트 생성 시 이름의 첫 글자를 이용하여 SVG 파비콘을 자동으로 생성합니다.
예: LG → "L", Samsung → "S", 메가존 → "메"

## Related Issue

- Closes #

## Changes

- `TenantSettings.java`: generateInitialFavicon() 메서드 추가
- `TenantSettings.java`: escapeXml() 유틸리티 메서드 추가
- `TenantSettings.createDefault()`: 파비콘 자동 생성 로직 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

## Additional Notes

- 파비콘은 32x32 SVG로 생성되며 Base64 인코딩된 data URL로 저장됩니다
- primaryColor를 배경색으로, 흰색 텍스트로 첫 글자를 표시합니다
- 한글, 영문, 숫자 모두 지원합니다
