### PR TITLE
fix: 역할 일괄 변경 시 활동 로그 기록 누락 수정

### DIFF
--- a/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
@@ -579,8 +579,18 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findByIdWithRoles(userId)
                 .orElseThrow(() -> new UserNotFoundException(userId));
 
+        Set<TenantRole> oldRoles = new java.util.HashSet<>(user.getRoles());
         user.setRoles(request.roles());
         log.info("User roles updated: userId={}, newRoles={}", userId, user.getRoles());
+
+        // 감사 로그 기록
+        activityLogService.log(
+                ActivityType.ROLE_CHANGE,
+                String.format("역할 일괄 변경: %s (%s → %s)", user.getEmail(), oldRoles, request.roles()),
+                "USER",
+                userId,
+                user.getName()
+        );
 
         return UserRolesResponse.from(user);
     }


### PR DESCRIPTION
## Summary

사용자 역할 일괄 변경 시 활동 로그가 기록되지 않아 SA 활동 분석 페이지에서 확인할 수 없던 문제를 수정했습니다.

`UserServiceImpl.updateUserRoles()` 메서드에 활동 로그 기록 로직을 추가하여, 역할 변경 시 SA 분석 페이지의 실시간 활동 및 로그 관리에서 확인할 수 있도록 개선했습니다.

## Related Issue

- Closes # (관련 이슈 번호가 있다면 입력)

## Changes

- `UserServiceImpl.updateUserRoles()`에 `activityLogService.log()` 호출 추가
- 역할 변경 전후 비교를 위해 `oldRoles` 저장 로직 추가
- `ActivityType.ROLE_CHANGE` 사용하여 SA 분석 페이지에 표시
- `addUserRole`, `removeUserRole`과 동일한 로깅 패턴 적용

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

<!-- 역할 변경 후 SA 활동 분석 페이지에서 로그가 표시되는 스크린샷 첨부 가능 -->

## Additional Notes

**변경 전:**
- `updateUserRoles()` 호출 시 활동 로그 미기록
- SA 분석 페이지에서 역할 변경 내역 확인 불가

**변경 후:**
- 역할 일괄 변경 시 활동 로그 자동 기록
- SA 분석 페이지의 "실시간 활동" 및 "로그 관리"에서 확인 가능
- 변경 전후 역할 정보를 포함한 상세 로그 제공

기존에 구현된 `addUserRole()`, `removeUserRole()` 메서드와 동일한 패턴으로 로깅 로직을 추가했으며, `@Async` 처리로 성능에 영향 없습니다.