### PR TITLE
feat: 사용자 부서명 입력 시 부서 자동 생성 기능 추가

### DIFF
--- a/src/main/java/com/mzc/lp/domain/department/repository/DepartmentRepository.java
+++ b/src/main/java/com/mzc/lp/domain/department/repository/DepartmentRepository.java
@@ -45,4 +45,10 @@ public interface DepartmentRepository extends JpaRepository<Department, Long> {
 
     // 매니저별 부서 조회
     List<Department> findByTenantIdAndManagerId(Long tenantId, Long managerId);
+
+    // 테넌트별 부서명으로 조회
+    Optional<Department> findByTenantIdAndName(Long tenantId, String name);
+
+    // 테넌트별 부서명 존재 여부 확인
+    boolean existsByTenantIdAndName(Long tenantId, String name);
 }

--- a/src/main/java/com/mzc/lp/domain/department/service/DepartmentInitializer.java
+++ b/src/main/java/com/mzc/lp/domain/department/service/DepartmentInitializer.java
@@ -1,0 +1,54 @@
+package com.mzc.lp.domain.department.service;
+
+import com.mzc.lp.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 애플리케이션 시작 시 기존 사용자들의 부서 정보를 기반으로 부서를 자동 생성하는 초기화 컴포넌트
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DepartmentInitializer implements ApplicationRunner {
+
+    private final UserRepository userRepository;
+    private final DepartmentService departmentService;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        log.info("Starting department initialization from existing user data...");
+
+        try {
+            // 테넌트별 고유 부서명 목록 조회
+            List<Object[]> tenantDepartments = userRepository.findDistinctDepartmentsByTenant();
+
+            int createdCount = 0;
+            for (Object[] row : tenantDepartments) {
+                Long tenantId = (Long) row[0];
+                String departmentName = (String) row[1];
+
+                if (tenantId != null && departmentName != null && !departmentName.isBlank()) {
+                    try {
+                        departmentService.getOrCreateByName(tenantId, departmentName);
+                        createdCount++;
+                    } catch (Exception e) {
+                        log.warn("Failed to create department: tenantId={}, name={}, error={}",
+                                tenantId, departmentName, e.getMessage());
+                    }
+                }
+            }
+
+            log.info("Department initialization completed. Processed {} tenant-department pairs.", createdCount);
+        } catch (Exception e) {
+            log.error("Department initialization failed", e);
+        }
+    }
+}

--- a/src/main/java/com/mzc/lp/domain/department/service/DepartmentService.java
+++ b/src/main/java/com/mzc/lp/domain/department/service/DepartmentService.java
@@ -64,4 +64,10 @@ public interface DepartmentService {
      * 부서에 인원 추가 (사용자의 부서를 변경)
      */
     void addMemberToDepartment(Long tenantId, Long departmentId, Long userId);
+
+    /**
+     * 부서명으로 부서 조회 또는 자동 생성
+     * 부서명이 존재하면 해당 부서 반환, 없으면 자동 생성 후 반환
+     */
+    DepartmentResponse getOrCreateByName(Long tenantId, String departmentName);
 }

--- a/src/main/java/com/mzc/lp/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/mzc/lp/domain/user/repository/UserRepository.java
@@ -299,4 +299,14 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     List<User> findByTenantIdAndDepartmentNot(
             @Param("tenantId") Long tenantId,
             @Param("departmentName") String departmentName);
+
+    /**
+     * 테넌트별 고유 부서명 목록 조회 (부서 자동 생성 초기화용)
+     * 반환: [tenantId, departmentName]
+     * Native Query로 Hibernate 테넌트 필터 우회
+     */
+    @Query(value = "SELECT DISTINCT tenant_id, department FROM users " +
+            "WHERE department IS NOT NULL AND department != ''",
+            nativeQuery = true)
+    List<Object[]> findDistinctDepartmentsByTenant();
 }


### PR DESCRIPTION
## Summary

사용자의 부서명 입력 시 부서가 자동으로 생성되도록 기능 추가

## Related Issue

- Closes #

## Changes

- DepartmentService에 `getOrCreateByName` 메서드 추가 (부서명으로 조회 또는 자동 생성)
- DepartmentRepository에 `findByTenantIdAndName`, `existsByTenantIdAndName` 메서드 추가
- UserServiceImpl의 `updateMe`, `updateUser`, `fileBulkCreateUsers` 메서드에서 부서 자동 생성 호출
- UserRepository에 `findDistinctDepartmentsByTenant` 메서드 추가 (초기화용)
- DepartmentInitializer 컴포넌트 추가 (애플리케이션 시작 시 기존 사용자 부서 기반 부서 자동 생성)

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 사용자 생성/수정 시 부서명이 입력되면 해당 부서가 없을 경우 자동 생성
- 부서 코드는 부서명에서 공백 제거 후 대문자로 변환하여 자동 생성
- 애플리케이션 시작 시 기존 사용자들의 부서 정보를 기반으로 부서 자동 초기화
