### PR TITLE
feat : SYSTEM_ADMIN 테넌트 브랜딩 격리 및 사용자 데이터 개선

### DIFF
--- a/src/main/java/com/mzc/lp/common/entity/TenantEntity.java
+++ b/src/main/java/com/mzc/lp/common/entity/TenantEntity.java
@@ -19,7 +19,7 @@ import org.hibernate.annotations.ParamDef;
 @Filter(name = "tenantFilter")
 public abstract class TenantEntity extends BaseTimeEntity {
 
-    @Column(name = "tenant_id", nullable = false)
+    @Column(name = "tenant_id", nullable = true)  // SYSTEM_ADMIN은 tenantId가 null일 수 있음
     private Long tenantId;
 
     @PrePersist

--- a/src/main/resources/db/migration/V009__update_system_admin_tenant_id.sql
+++ b/src/main/resources/db/migration/V009__update_system_admin_tenant_id.sql
@@ -1,0 +1,18 @@
+-- =============================================
+-- V009: SYSTEM_ADMIN 사용자의 tenant_id를 NULL로 업데이트
+-- =============================================
+-- SYSTEM_ADMIN은 특정 테넌트에 속하지 않으므로 tenant_id가 NULL이어야 함
+-- 다른 역할은 반드시 tenant_id를 가져야 함
+
+-- 1. 먼저 users 테이블의 tenant_id 컬럼을 nullable로 변경
+ALTER TABLE users MODIFY COLUMN tenant_id BIGINT NULL;
+
+-- 2. SYSTEM_ADMIN 역할을 가진 사용자의 tenant_id를 NULL로 업데이트
+UPDATE users
+SET tenant_id = NULL
+WHERE role = 'SYSTEM_ADMIN';
+
+-- 3. SYSTEM_ADMIN이 아닌 사용자는 반드시 tenant_id를 가져야 한다는 체크 제약조건 추가
+ALTER TABLE users
+ADD CONSTRAINT chk_tenant_id_required_unless_system_admin
+CHECK (role = 'SYSTEM_ADMIN' OR tenant_id IS NOT NULL);

--- a/src/main/resources/db/seed/V002__tenants.sql
+++ b/src/main/resources/db/seed/V002__tenants.sql
@@ -13,6 +13,6 @@ SELECT 2, 'samsung', '삼성전자 인재개발원', 'B2B', 'ACTIVE', 'PRO', 'sa
 WHERE NOT EXISTS (SELECT 1 FROM tenants WHERE id = 2);
 
 -- 테넌트 3: 네이버 (IT 기업 교육)
-INSERT INTO tenants (id, code, name, type, status, plan, subdomain, created_at, updated_at)
-SELECT 3, 'naver', '네이버 커넥트', 'B2B', 'ACTIVE', 'BASIC', 'naver', NOW(), NOW()
+INSERT INTO tenants (id, code, name, type, status, plan, subdomain, custom_domain, created_at, updated_at)
+SELECT 3, 'naver', '네이버 커넥트', 'B2B', 'ACTIVE', 'BASIC', 'naver', 'naver-lms.com', NOW(), NOW()
 WHERE NOT EXISTS (SELECT 1 FROM tenants WHERE id = 3);

--- a/src/main/resources/db/seed/V004__users.sql
+++ b/src/main/resources/db/seed/V004__users.sql
@@ -13,21 +13,21 @@
 
 -- ===== 시스템 관리자 (전체 1명) =====
 INSERT INTO users (id, tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES
-(1, NULL, 'sysadmin@mzc.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '김태호(시스템관리자)', '010-0000-0001', NULL, NULL, 'SYSTEM_ADMIN', 'ACTIVE', NOW(), NOW());
+(1, NULL, 'sysadmin@mzc.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '김태호(시스템 관리자)', '010-0000-0001', NULL, NULL, 'SYSTEM_ADMIN', 'ACTIVE', NOW(), NOW());
 
 -- ===== 테넌트 1 (기본 테넌트) 관리자/운영자/설계자 =====
 INSERT INTO users (id, tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES
 -- 테넌트 관리자
-(2, 1, 'admin@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '이정훈(테넌트관리자)', '010-1000-0001', '경영지원팀', '부장', 'TENANT_ADMIN', 'ACTIVE', NOW(), NOW()),
+(2, 1, 'admin@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '이정훈(테넌트 관리자)', '010-1000-0001', '경영지원팀', '부장', 'TENANT_ADMIN', 'ACTIVE', NOW(), NOW()),
 -- 운영자
 (3, 1, 'operator1@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '박성민(운영자)', '010-1000-0002', '경영지원팀', '과장', 'OPERATOR', 'ACTIVE', NOW(), NOW()),
 (4, 1, 'operator2@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '최유진(운영자)', '010-1000-0003', '경영지원팀', '대리', 'OPERATOR', 'ACTIVE', NOW(), NOW()),
--- 설계자
-(5, 1, 'designer1@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '정동욱(설계자)', '010-1000-0004', '개발팀', '과장', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
-(6, 1, 'designer2@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '한소영(설계자)', '010-1000-0005', '개발팀', '대리', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
-(7, 1, 'designer3@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '오민지(설계자)', '010-1000-0006', '디자인팀', '대리', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
--- 강의 개설자 (테스트용)
-(8, 1, 'creator@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '송재현(강의개설자)', '010-1000-0007', '개발팀', '팀장', 'USER', 'ACTIVE', NOW(), NOW()),
+-- 강의 개설자 (설계자/디자이너)
+(5, 1, 'designer1@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '정동욱(강의 개설자)', '010-1000-0004', '개발팀', '과장', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
+(6, 1, 'designer2@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '한소영(강의 개설자)', '010-1000-0005', '개발팀', '대리', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
+(7, 1, 'designer3@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '오민지(강의 개설자)', '010-1000-0006', '디자인팀', '대리', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
+-- 일반 사용자 (테스트용)
+(8, 1, 'creator@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '송재현(강의 개설자)', '010-1000-0007', '개발팀', '팀장', 'USER', 'ACTIVE', NOW(), NOW()),
 -- 멀티롤 테스트 사용자 (운영자 + 설계자)
 (9, 1, 'multi1@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '강현우(멀티롤)', '010-1000-0010', '개발팀', '차장', 'OPERATOR', 'ACTIVE', NOW(), NOW()),
 -- 멀티롤 테스트 사용자 (설계자 + 강사)
@@ -94,10 +94,10 @@ INSERT INTO users (id, tenant_id, email, password, name, phone, department, posi
 
 -- ===== 테넌트 2 (삼성전자) 관리자급 =====
 INSERT INTO users (id, tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES
-(11, 2, 'admin@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '장민혁(테넌트관리자)', '010-2000-0001', '인사팀', '부장', 'TENANT_ADMIN', 'ACTIVE', NOW(), NOW()),
+(11, 2, 'admin@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '장민혁(테넌트 관리자)', '010-2000-0001', '인사팀', '부장', 'TENANT_ADMIN', 'ACTIVE', NOW(), NOW()),
 (12, 2, 'operator1@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '김세진(운영자)', '010-2000-0002', '인사팀', '과장', 'OPERATOR', 'ACTIVE', NOW(), NOW()),
-(13, 2, 'designer1@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '이태영(설계자)', '010-2000-0003', '개발팀', '과장', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
-(14, 2, 'creator@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '박준혁(강의개설자)', '010-2000-0004', '개발팀', '차장', 'USER', 'ACTIVE', NOW(), NOW());
+(13, 2, 'designer1@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '이태영(강의 개설자)', '010-2000-0003', '개발팀', '과장', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
+(14, 2, 'creator@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '박준혁(강의 개설자)', '010-2000-0004', '개발팀', '차장', 'USER', 'ACTIVE', NOW(), NOW());
 
 -- ===== 테넌트 2 일반 사용자 30명 =====
 INSERT INTO users (id, tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES
@@ -134,10 +134,10 @@ INSERT INTO users (id, tenant_id, email, password, name, phone, department, posi
 
 -- ===== 테넌트 3 (네이버) 관리자급 =====
 INSERT INTO users (id, tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES
-(21, 3, 'admin@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '조영훈(테넌트관리자)', '010-3000-0001', '운영팀', '부장', 'TENANT_ADMIN', 'ACTIVE', NOW(), NOW()),
+(21, 3, 'admin@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '조영훈(테넌트 관리자)', '010-3000-0001', '운영팀', '부장', 'TENANT_ADMIN', 'ACTIVE', NOW(), NOW()),
 (22, 3, 'operator1@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '서지현(운영자)', '010-3000-0002', '운영팀', '과장', 'OPERATOR', 'ACTIVE', NOW(), NOW()),
-(23, 3, 'designer1@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '나현수(설계자)', '010-3000-0003', '개발팀', '과장', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
-(24, 3, 'creator@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '류승범(강의개설자)', '010-3000-0004', '개발팀', '차장', 'USER', 'ACTIVE', NOW(), NOW());
+(23, 3, 'designer1@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '나현수(강의 개설자)', '010-3000-0003', '개발팀', '과장', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
+(24, 3, 'creator@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '류승범(강의 개설자)', '010-3000-0004', '개발팀', '차장', 'USER', 'ACTIVE', NOW(), NOW());
 
 -- ===== 테넌트 3 일반 사용자 30명 =====
 INSERT INTO users (id, tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES

--- a/src/main/resources/db/seed/V004__users.sql
+++ b/src/main/resources/db/seed/V004__users.sql
@@ -13,7 +13,7 @@
 
 -- ===== 시스템 관리자 (전체 1명) =====
 INSERT INTO users (id, tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES
-(1, 1, 'sysadmin@mzc.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '김태호(시스템관리자)', '010-0000-0001', NULL, NULL, 'SYSTEM_ADMIN', 'ACTIVE', NOW(), NOW());
+(1, NULL, 'sysadmin@mzc.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '김태호(시스템관리자)', '010-0000-0001', NULL, NULL, 'SYSTEM_ADMIN', 'ACTIVE', NOW(), NOW());
 
 -- ===== 테넌트 1 (기본 테넌트) 관리자/운영자/설계자 =====
 INSERT INTO users (id, tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES

--- a/src/main/resources/db/seed/V004__users.sql
+++ b/src/main/resources/db/seed/V004__users.sql
@@ -92,12 +92,18 @@ INSERT INTO users (id, tenant_id, email, password, name, phone, department, posi
 (149, 1, 'user49@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '아채아', '010-1001-0049', '경영지원팀', '대리', 'USER', 'ACTIVE', NOW(), NOW()),
 (150, 1, 'user50@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '자은우', '010-1001-0050', '경영지원팀', '사원', 'USER', 'ACTIVE', NOW(), NOW());
 
+-- ===== 테넌트 1 전문 강사 =====
+INSERT INTO users (id, tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES
+(151, 1, 'instructor1@default.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '차은성(강사)', '010-1001-0051', '교육팀', '차장', 'INSTRUCTOR', 'ACTIVE', NOW(), NOW());
+
 -- ===== 테넌트 2 (삼성전자) 관리자급 =====
 INSERT INTO users (id, tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES
 (11, 2, 'admin@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '장민혁(테넌트 관리자)', '010-2000-0001', '인사팀', '부장', 'TENANT_ADMIN', 'ACTIVE', NOW(), NOW()),
 (12, 2, 'operator1@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '김세진(운영자)', '010-2000-0002', '인사팀', '과장', 'OPERATOR', 'ACTIVE', NOW(), NOW()),
 (13, 2, 'designer1@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '이태영(강의 개설자)', '010-2000-0003', '개발팀', '과장', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
-(14, 2, 'creator@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '박준혁(강의 개설자)', '010-2000-0004', '개발팀', '차장', 'USER', 'ACTIVE', NOW(), NOW());
+(14, 2, 'creator@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '박준혁(강의 개설자)', '010-2000-0004', '개발팀', '차장', 'USER', 'ACTIVE', NOW(), NOW()),
+-- 전문 강사
+(15, 2, 'instructor1@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '최동훈(강사)', '010-2000-0005', '교육팀', '차장', 'INSTRUCTOR', 'ACTIVE', NOW(), NOW());
 
 -- ===== 테넌트 2 일반 사용자 30명 =====
 INSERT INTO users (id, tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES
@@ -137,7 +143,9 @@ INSERT INTO users (id, tenant_id, email, password, name, phone, department, posi
 (21, 3, 'admin@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '조영훈(테넌트 관리자)', '010-3000-0001', '운영팀', '부장', 'TENANT_ADMIN', 'ACTIVE', NOW(), NOW()),
 (22, 3, 'operator1@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '서지현(운영자)', '010-3000-0002', '운영팀', '과장', 'OPERATOR', 'ACTIVE', NOW(), NOW()),
 (23, 3, 'designer1@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '나현수(강의 개설자)', '010-3000-0003', '개발팀', '과장', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
-(24, 3, 'creator@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '류승범(강의 개설자)', '010-3000-0004', '개발팀', '차장', 'USER', 'ACTIVE', NOW(), NOW());
+(24, 3, 'creator@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '류승범(강의 개설자)', '010-3000-0004', '개발팀', '차장', 'USER', 'ACTIVE', NOW(), NOW()),
+-- 전문 강사
+(25, 3, 'instructor1@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '김재민(강사)', '010-3000-0005', '교육팀', '차장', 'INSTRUCTOR', 'ACTIVE', NOW(), NOW());
 
 -- ===== 테넌트 3 일반 사용자 30명 =====
 INSERT INTO users (id, tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES

--- a/src/main/resources/db/seed/V005__user_roles.sql
+++ b/src/main/resources/db/seed/V005__user_roles.sql
@@ -88,7 +88,9 @@ INSERT INTO user_roles (id, user_id, role, created_at) VALUES
 (152, 116, 'INSTRUCTOR', NOW()),  -- 안서준 (마케팅팀 팀장)
 (153, 126, 'INSTRUCTOR', NOW()),  -- 양현준 (인사팀 팀장)
 (154, 134, 'INSTRUCTOR', NOW()),  -- 추성훈 (영업팀 팀장)
-(155, 144, 'INSTRUCTOR', NOW());  -- 두시현 (디자인팀 팀장)
+(155, 144, 'INSTRUCTOR', NOW()),  -- 두시현 (디자인팀 팀장)
+-- 전문 강사
+(156, 151, 'INSTRUCTOR', NOW());  -- 차은성 (전문 강사)
 
 -- ===== 테넌트 2 역할 =====
 INSERT INTO user_roles (id, user_id, role, created_at) VALUES
@@ -97,41 +99,43 @@ INSERT INTO user_roles (id, user_id, role, created_at) VALUES
 (1002, 12, 'OPERATOR', NOW()),
 (1003, 13, 'DESIGNER', NOW()),
 (1004, 14, 'USER', NOW()),
+-- 전문 강사
+(1005, 15, 'INSTRUCTOR', NOW()),
 -- 일반 사용자
-(1005, 1001, 'USER', NOW()),
-(1006, 1002, 'USER', NOW()),
-(1007, 1003, 'USER', NOW()),
-(1008, 1004, 'USER', NOW()),
-(1009, 1005, 'USER', NOW()),
-(1010, 1006, 'USER', NOW()),
-(1011, 1007, 'USER', NOW()),
-(1012, 1008, 'USER', NOW()),
-(1013, 1009, 'USER', NOW()),
-(1014, 1010, 'USER', NOW()),
-(1015, 1011, 'USER', NOW()),
-(1016, 1012, 'USER', NOW()),
-(1017, 1013, 'USER', NOW()),
-(1018, 1014, 'USER', NOW()),
-(1019, 1015, 'USER', NOW()),
-(1020, 1016, 'USER', NOW()),
-(1021, 1017, 'USER', NOW()),
-(1022, 1018, 'USER', NOW()),
-(1023, 1019, 'USER', NOW()),
-(1024, 1020, 'USER', NOW()),
-(1025, 1021, 'USER', NOW()),
-(1026, 1022, 'USER', NOW()),
-(1027, 1023, 'USER', NOW()),
-(1028, 1024, 'USER', NOW()),
-(1029, 1025, 'USER', NOW()),
-(1030, 1026, 'USER', NOW()),
-(1031, 1027, 'USER', NOW()),
-(1032, 1028, 'USER', NOW()),
-(1033, 1029, 'USER', NOW()),
-(1034, 1030, 'USER', NOW()),
+(1006, 1001, 'USER', NOW()),
+(1007, 1002, 'USER', NOW()),
+(1008, 1003, 'USER', NOW()),
+(1009, 1004, 'USER', NOW()),
+(1010, 1005, 'USER', NOW()),
+(1011, 1006, 'USER', NOW()),
+(1012, 1007, 'USER', NOW()),
+(1013, 1008, 'USER', NOW()),
+(1014, 1009, 'USER', NOW()),
+(1015, 1010, 'USER', NOW()),
+(1016, 1011, 'USER', NOW()),
+(1017, 1012, 'USER', NOW()),
+(1018, 1013, 'USER', NOW()),
+(1019, 1014, 'USER', NOW()),
+(1020, 1015, 'USER', NOW()),
+(1021, 1016, 'USER', NOW()),
+(1022, 1017, 'USER', NOW()),
+(1023, 1018, 'USER', NOW()),
+(1024, 1019, 'USER', NOW()),
+(1025, 1020, 'USER', NOW()),
+(1026, 1021, 'USER', NOW()),
+(1027, 1022, 'USER', NOW()),
+(1028, 1023, 'USER', NOW()),
+(1029, 1024, 'USER', NOW()),
+(1030, 1025, 'USER', NOW()),
+(1031, 1026, 'USER', NOW()),
+(1032, 1027, 'USER', NOW()),
+(1033, 1028, 'USER', NOW()),
+(1034, 1029, 'USER', NOW()),
+(1035, 1030, 'USER', NOW()),
 -- INSTRUCTOR + USER 복합롤
-(1035, 1024, 'INSTRUCTOR', NOW()),  -- 하지원 (개발팀 차장)
-(1036, 1025, 'INSTRUCTOR', NOW()),  -- 문재현 (기획팀 팀장)
-(1037, 1028, 'INSTRUCTOR', NOW());  -- 남지현 (개발팀 팀장)
+(1036, 1024, 'INSTRUCTOR', NOW()),  -- 하지원 (개발팀 차장)
+(1037, 1025, 'INSTRUCTOR', NOW()),  -- 문재현 (기획팀 팀장)
+(1038, 1028, 'INSTRUCTOR', NOW());  -- 남지현 (개발팀 팀장)
 
 -- ===== 테넌트 3 역할 =====
 INSERT INTO user_roles (id, user_id, role, created_at) VALUES
@@ -140,38 +144,40 @@ INSERT INTO user_roles (id, user_id, role, created_at) VALUES
 (2002, 22, 'OPERATOR', NOW()),
 (2003, 23, 'DESIGNER', NOW()),
 (2004, 24, 'USER', NOW()),
+-- 전문 강사
+(2005, 25, 'INSTRUCTOR', NOW()),
 -- 일반 사용자
-(2005, 2001, 'USER', NOW()),
-(2006, 2002, 'USER', NOW()),
-(2007, 2003, 'USER', NOW()),
-(2008, 2004, 'USER', NOW()),
-(2009, 2005, 'USER', NOW()),
-(2010, 2006, 'USER', NOW()),
-(2011, 2007, 'USER', NOW()),
-(2012, 2008, 'USER', NOW()),
-(2013, 2009, 'USER', NOW()),
-(2014, 2010, 'USER', NOW()),
-(2015, 2011, 'USER', NOW()),
-(2016, 2012, 'USER', NOW()),
-(2017, 2013, 'USER', NOW()),
-(2018, 2014, 'USER', NOW()),
-(2019, 2015, 'USER', NOW()),
-(2020, 2016, 'USER', NOW()),
-(2021, 2017, 'USER', NOW()),
-(2022, 2018, 'USER', NOW()),
-(2023, 2019, 'USER', NOW()),
-(2024, 2020, 'USER', NOW()),
-(2025, 2021, 'USER', NOW()),
-(2026, 2022, 'USER', NOW()),
-(2027, 2023, 'USER', NOW()),
-(2028, 2024, 'USER', NOW()),
-(2029, 2025, 'USER', NOW()),
-(2030, 2026, 'USER', NOW()),
-(2031, 2027, 'USER', NOW()),
-(2032, 2028, 'USER', NOW()),
-(2033, 2029, 'USER', NOW()),
-(2034, 2030, 'USER', NOW()),
+(2006, 2001, 'USER', NOW()),
+(2007, 2002, 'USER', NOW()),
+(2008, 2003, 'USER', NOW()),
+(2009, 2004, 'USER', NOW()),
+(2010, 2005, 'USER', NOW()),
+(2011, 2006, 'USER', NOW()),
+(2012, 2007, 'USER', NOW()),
+(2013, 2008, 'USER', NOW()),
+(2014, 2009, 'USER', NOW()),
+(2015, 2010, 'USER', NOW()),
+(2016, 2011, 'USER', NOW()),
+(2017, 2012, 'USER', NOW()),
+(2018, 2013, 'USER', NOW()),
+(2019, 2014, 'USER', NOW()),
+(2020, 2015, 'USER', NOW()),
+(2021, 2016, 'USER', NOW()),
+(2022, 2017, 'USER', NOW()),
+(2023, 2018, 'USER', NOW()),
+(2024, 2019, 'USER', NOW()),
+(2025, 2020, 'USER', NOW()),
+(2026, 2021, 'USER', NOW()),
+(2027, 2022, 'USER', NOW()),
+(2028, 2023, 'USER', NOW()),
+(2029, 2024, 'USER', NOW()),
+(2030, 2025, 'USER', NOW()),
+(2031, 2026, 'USER', NOW()),
+(2032, 2027, 'USER', NOW()),
+(2033, 2028, 'USER', NOW()),
+(2034, 2029, 'USER', NOW()),
+(2035, 2030, 'USER', NOW()),
 -- INSTRUCTOR + USER 복합롤
-(2035, 2019, 'INSTRUCTOR', NOW()),  -- 홍현우 (개발팀 팀장)
-(2036, 2022, 'INSTRUCTOR', NOW()),  -- 백도윤 (개발팀 차장)
-(2037, 2024, 'INSTRUCTOR', NOW());  -- 하준서 (운영팀 팀장)
+(2036, 2019, 'INSTRUCTOR', NOW()),  -- 홍현우 (개발팀 팀장)
+(2037, 2022, 'INSTRUCTOR', NOW()),  -- 백도윤 (개발팀 차장)
+(2038, 2024, 'INSTRUCTOR', NOW());  -- 하준서 (운영팀 팀장)


### PR DESCRIPTION
## Summary

SYSTEM_ADMIN이 테넌트 브랜딩 페이지에 접근할 때 발생하던 격리 문제를 해결했습니다. SA 사용자는 tenant_id가 NULL이어야 하지만, 기존 구조에서는 테네트 브랜딩 컨텍스트에서 SA 정보를 가져올 수 없었습니다. 이를 해결하기 위해 데이터베이스 스키마를 수정하고, UserService의 getMe 메서드에서 Hibernate 필터를 우회하는 네이티브 쿼리를 구현했습니다.

또한 사용자 데이터의 역할 용어를 통일하고, 전문 강사(INSTRUCTOR) 역할 사용자를 추가했습니다.

## Related Issue

- Closes #

## Changes

### 데이터베이스 스키마 수정
- **V009__update_system_admin_tenant_id.sql**: SYSTEM_ADMIN의 tenant_id를 NULL로 허용하도록 마이그레이션 추가
  - `users.tenant_id` 컬럼을 nullable로 변경
  - SYSTEM_ADMIN 사용자의 tenant_id를 NULL로 업데이트
  - CHECK 제약조건 추가: SYSTEM_ADMIN이 아닌 경우 tenant_id 필수

### 엔티티 수정
- **TenantEntity.java**: `tenantId` 필드를 nullable로 변경 (`nullable = true`)
  - SYSTEM_ADMIN은 tenantId가 null일 수 있도록 허용

### UserService 수정
- **UserServiceImpl.java**: `getMe` 메서드에 Hibernate 필터 우회 로직 추가
  - EntityManager 주입
  - 네이티브 쿼리를 사용하여 tenant 필터를 완전히 우회
  - SYSTEM_ADMIN 사용자 조회 시에도 정상 동작 보장
  - 필터 상태를 저장하고 finally 블록에서 복원하여 안정성 확보

### 사용자 데이터 개선
- **V004__users.sql**: 사용자 역할 용어 통일
  - DESIGNER 역할: "설계자" → "강의 개설자" (공백 포함)
  - 모든 역할명에 일관된 띄어쓰기 적용 (예: "테넌트관리자" → "테넌트 관리자")
  - 전문 강사(INSTRUCTOR) 역할 사용자 추가:
    - 테넌트 1: 차은성 (ID 151)
    - 테넌트 2: 최동훈 (ID 15)
    - 테넌트 3: 김재민 (ID 25)

- **V005__user_roles.sql**: 새로운 INSTRUCTOR 역할 데이터 추가
  - 전문 강사 역할 매핑 추가
  - 기존 복합 롤(INSTRUCTOR + USER) 유지
  - ID 충돌 해결을 위한 순차적 ID 조정

### 커스텀 도메인 지원
- **CustomDomainFilter.java**: 커스텀 도메인 → subdomain 변환 로직 추가
- **application.yml**: 커스텀 도메인 매핑 설정 추가

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [ ] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### 테스트 필요 사항
1. **데이터베이스 마이그레이션 적용 후 시드 데이터 리셋 필요**
   - V009 마이그레이션이 적용되어야 SYSTEM_ADMIN의 tenant_id가 NULL로 설정됩니다
   - 기존 개발 DB를 초기화하고 새로운 시드 데이터로 재구성해야 합니다

2. **SYSTEM_ADMIN 테넌트 브랜딩 페이지 접근 테스트**
   - SA로 로그인 → 테넌트 관리 → 특정 테넌트의 브랜딩 설정 접근
   - `/ta/branding` 경로에서 SA 사용자 정보가 정상적으로 로드되는지 확인

3. **역할 표시 확인**
   - RoleBadge 컴포넌트에서 "강의 개설자", "강사" 등이 올바르게 표시되는지 확인
   - 사용자 목록에서 역할명 일관성 확인

### 주의사항
- **Hibernate 필터 우회는 보안상 민감한 작업**이므로, `getMe` 메서드에서만 제한적으로 사용
- 다른 서비스 메서드에서는 기존 tenant 필터가 정상적으로 동작
- SYSTEM_ADMIN 이외의 역할에서는 tenant_id가 반드시 필요하며, CHECK 제약조건으로 강제됨
