### PR TITLE
fix(seed): employees FK 제약조건 해결을 위한 누락 사용자 추가

### DIFF
--- a/src/main/resources/db/seed/V004__users.sql
+++ b/src/main/resources/db/seed/V004__users.sql
@@ -103,7 +103,9 @@ INSERT INTO users (id, tenant_id, email, password, name, phone, department, posi
 (13, 2, 'designer1@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '이태영(강의 개설자)', '010-2000-0003', '개발팀', '과장', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
 (14, 2, 'creator@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '박준혁(강의 개설자)', '010-2000-0004', '개발팀', '차장', 'USER', 'ACTIVE', NOW(), NOW()),
 -- 전문 강사
-(15, 2, 'instructor1@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '최동훈(강사)', '010-2000-0005', '교육팀', '차장', 'INSTRUCTOR', 'ACTIVE', NOW(), NOW());
+(15, 2, 'instructor1@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '최동훈(강사)', '010-2000-0005', '교육팀', '차장', 'INSTRUCTOR', 'ACTIVE', NOW(), NOW()),
+-- 추가 설계자
+(16, 2, 'designer2@samsung.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '황민수(강의 개설자)', '010-2000-0006', '개발팀', '차장', 'DESIGNER', 'ACTIVE', NOW(), NOW());
 
 -- ===== 테넌트 2 일반 사용자 30명 =====
 INSERT INTO users (id, tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES
@@ -145,7 +147,9 @@ INSERT INTO users (id, tenant_id, email, password, name, phone, department, posi
 (23, 3, 'designer1@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '나현수(강의 개설자)', '010-3000-0003', '개발팀', '과장', 'DESIGNER', 'ACTIVE', NOW(), NOW()),
 (24, 3, 'creator@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '류승범(강의 개설자)', '010-3000-0004', '개발팀', '차장', 'USER', 'ACTIVE', NOW(), NOW()),
 -- 전문 강사
-(25, 3, 'instructor1@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '김재민(강사)', '010-3000-0005', '교육팀', '차장', 'INSTRUCTOR', 'ACTIVE', NOW(), NOW());
+(25, 3, 'instructor1@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '김재민(강사)', '010-3000-0005', '교육팀', '차장', 'INSTRUCTOR', 'ACTIVE', NOW(), NOW()),
+-- 추가 설계자
+(26, 3, 'designer2@naver.com', '$2a$10$4hFhr508/iEYj4.XDJ4DQOf6nq.vW6eWbUP4NQFD0yUhV8sWHYQWa', '이서진(강의 개설자)', '010-3000-0006', '개발팀', '차장', 'DESIGNER', 'ACTIVE', NOW(), NOW());
 
 -- ===== 테넌트 3 일반 사용자 30명 =====
 INSERT INTO users (id, tenant_id, email, password, name, phone, department, position, role, status, created_at, updated_at) VALUES


### PR DESCRIPTION
## Summary

employees 시드 데이터에서 참조하는 user_id 16, 26이 users 시드 데이터에 누락되어 발생하던 FK 제약조건 위반 오류를 해결합니다.

## Related Issue

- N/A

## Changes

- 테넌트 2에 user_id 16 (황민수, 설계자) 추가
- 테넌트 3에 user_id 26 (이서진, 설계자) 추가
- V004_5__employees.sql의 FK 참조 무결성 확보

## Type of Change

- [x] Fix: 버그 수정

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

`ddl-auto: create` 설정으로 서버 재시작 시 테이블이 재생성되면서 시드 데이터가 순차적으로 실행될 때 FK 제약조건 위반이 발생했습니다. V004__users.sql에 누락된 사용자 2명을 추가하여 해결했습니다.