### PR TITLE
fix: DepartmentInitializer 조건부 실행으로 서버 시작 오류 해결

### DIFF
--- a/src/main/java/com/mzc/lp/domain/department/service/DepartmentInitializer.java
+++ b/src/main/java/com/mzc/lp/domain/department/service/DepartmentInitializer.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +17,7 @@ import java.util.List;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "spring.sql.init.mode", havingValue = "always")
 public class DepartmentInitializer implements ApplicationRunner {
 
     private final UserRepository userRepository;


### PR DESCRIPTION
## Summary
- `sql.init.mode=never` 설정 시 서버 시작할 때 `UnexpectedRollbackException` 발생하는 문제 해결
- `DepartmentInitializer`에 `@ConditionalOnProperty` 추가하여 `sql.init.mode=always`일 때만 실행되도록 수정

## 배경
서버 재부팅 시 DB 데이터가 초기화되는 문제가 있었습니다. 원인은 `sql.init.mode=always` 설정으로 인해 매번 seed 데이터가 TRUNCATE → 재삽입되기 때문입니다.

데이터 보존을 위해 `sql.init.mode=never`로 변경하면, `DepartmentInitializer`가 seed 데이터 없이 실행되어 트랜잭션 롤백 오류가 발생했습니다.

## 로컬에서 데이터 보존하려면
`application.yml` 또는 환경변수에서 다음과 같이 설정하세요:

```yaml
spring:
  sql:
    init:
      mode: never
```

또는 `.env` 파일에:
```
SQL_INIT_MODE=never
```

> ⚠️ 이 설정은 로컬 개발용입니다. 기본값(`always`)은 seed 데이터 초기화가 필요한 경우를 위해 유지됩니다.

## Test plan
- [x] `sql.init.mode=always`로 서버 시작 → 정상 동작 확인
- [x] `sql.init.mode=never`로 서버 시작 → 오류 없이 시작, 데이터 보존 확인