### PR TITLE
fix: 부서 중복 생성 방지 및 초기화 트랜잭션 오류 수정

### DIFF
--- a/src/main/java/com/mzc/lp/domain/department/entity/Department.java
+++ b/src/main/java/com/mzc/lp/domain/department/entity/Department.java
@@ -15,7 +15,8 @@ import java.util.List;
  */
 @Entity
 @Table(name = "departments", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"tenant_id", "code"})
+        @UniqueConstraint(columnNames = {"tenant_id", "code"}),
+        @UniqueConstraint(columnNames = {"tenant_id", "name"})
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/mzc/lp/domain/department/service/DepartmentInitializer.java
+++ b/src/main/java/com/mzc/lp/domain/department/service/DepartmentInitializer.java
@@ -7,7 +7,6 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -24,7 +23,6 @@ public class DepartmentInitializer implements ApplicationRunner {
     private final DepartmentService departmentService;
 
     @Override
-    @Transactional
     public void run(ApplicationArguments args) {
         log.info("Starting department initialization from existing user data...");
 


### PR DESCRIPTION
## Summary
- 부서 중복 생성으로 인한 `NonUniqueResultException` 오류 수정
- `DepartmentInitializer` 트랜잭션 롤백 오류 수정

## Changes
### Department 엔티티
- `tenant_id + name` UNIQUE 제약조건 추가
- 동일 테넌트 내 같은 이름의 부서 중복 생성 방지

### DepartmentInitializer
- `@Transactional` 어노테이션 제거
- 각 부서 생성이 독립적인 트랜잭션으로 처리
- 하나의 부서 생성 실패 시 전체 초기화가 롤백되지 않도록 개선

## Test plan
- [ ] 앱 정상 시작 확인
- [ ] 사용자 권한 수정 시 부서 관련 오류 없음 확인
- [ ] 동일 이름 부서 중복 생성 시도 시 적절한 에러 처리 확인