### PR TITLE
fix: SA 로그인 문제, TENANT_ADMIN 검증, 공지 알림, INSTRUCTOR 권한 추가

### DIFF
--- a/src/main/java/com/mzc/lp/domain/course/controller/CourseController.java
+++ b/src/main/java/com/mzc/lp/domain/course/controller/CourseController.java
@@ -64,7 +64,7 @@ public class CourseController {
      * GET /api/courses/my
      */
     @GetMapping("/my")
-    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'INSTRUCTOR', 'OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<Page<CourseResponse>>> getMyCourses(
             @PageableDefault(size = 20) Pageable pageable,
             @AuthenticationPrincipal UserPrincipal principal
@@ -91,7 +91,7 @@ public class CourseController {
      * PUT /api/courses/{courseId}
      */
     @PutMapping("/{courseId:\\d+}")
-    @PreAuthorize("hasAnyRole('DESIGNER', 'OPERATOR', 'TENANT_ADMIN')")
+    @PreAuthorize("hasAnyRole('DESIGNER', 'INSTRUCTOR', 'OPERATOR', 'TENANT_ADMIN')")
     public ResponseEntity<ApiResponse<CourseResponse>> updateCourse(
             @PathVariable @Positive Long courseId,
             @Valid @RequestBody UpdateCourseRequest request,

--- a/src/main/java/com/mzc/lp/domain/tenantnotice/service/TenantNoticeServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/tenantnotice/service/TenantNoticeServiceImpl.java
@@ -179,7 +179,7 @@ public class TenantNoticeServiceImpl implements TenantNoticeService {
 
             String title = "새 공지사항";
             String message = notice.getTitle();
-            String link = "/tu/b2c/notifications?tab=SYSTEM";  // 알림 페이지 공지사항 탭으로 이동
+            String link = "/tu/b2c/notifications?tab=NOTICE";  // 알림 페이지 공지사항 탭으로 이동
 
             for (Long userId : userIds) {
                 try {
@@ -190,7 +190,7 @@ public class TenantNoticeServiceImpl implements TenantNoticeService {
                             message,
                             link,
                             notice.getId(),
-                            "TENANT_NOTICE",
+                            "NOTICE",  // NOTICE로 설정하여 프론트엔드에서 '공지' 탭으로 분류
                             null,  // actorId (시스템 발송)
                             null   // actorName
                     );

--- a/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
@@ -656,6 +656,7 @@ public class UserServiceImpl implements UserService {
         }
 
         user.setRoles(request.roles());
+        userRepository.save(user);  // 명시적으로 저장하여 DB 반영 보장
         log.info("User roles updated: userId={}, newRoles={}", userId, user.getRoles());
 
         // 감사 로그 기록
@@ -678,6 +679,7 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() -> new UserNotFoundException(userId));
 
         user.addRole(role);
+        userRepository.save(user);  // 명시적으로 저장하여 DB 반영 보장
 
         // 감사 로그 기록
         activityLogService.log(
@@ -710,6 +712,7 @@ public class UserServiceImpl implements UserService {
         }
 
         user.removeRole(role);
+        userRepository.save(user);  // 명시적으로 저장하여 DB 반영 보장
 
         // 감사 로그 기록
         activityLogService.log(

--- a/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/mzc/lp/domain/user/service/UserServiceImpl.java
@@ -644,6 +644,17 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() -> new UserNotFoundException(userId));
 
         Set<TenantRole> oldRoles = new java.util.HashSet<>(user.getRoles());
+
+        // 최소 1명 TENANT_ADMIN 유지 검증
+        // 기존에 TENANT_ADMIN 역할이 있었는데 새 역할 목록에 TENANT_ADMIN이 없는 경우
+        if (oldRoles.contains(TenantRole.TENANT_ADMIN) && !request.roles().contains(TenantRole.TENANT_ADMIN)) {
+            long taCount = userRoleRepository.countByRoleAndTenantId(TenantRole.TENANT_ADMIN, user.getTenantId());
+            if (taCount <= 1) {
+                log.warn("Cannot remove last TENANT_ADMIN via role update: userId={}, tenantId={}", userId, user.getTenantId());
+                throw new LastTenantAdminException();
+            }
+        }
+
         user.setRoles(request.roles());
         log.info("User roles updated: userId={}, newRoles={}", userId, user.getRoles());
 


### PR DESCRIPTION
## Summary

SA/TA/INSTRUCTOR 관련 버그 수정 및 권한 추가

## Related Issue

- N/A

## Changes

- SA가 서브도메인 로그인 페이지에서 로그인 가능하도록 TenantFilter 수정
- TENANT_ADMIN 역할 최소 1명 유지 검증 추가
- 공지사항 알림이 '공지' 탭에 표시되도록 referenceType 수정 (TENANT_NOTICE → NOTICE)
- 역할 변경 시 명시적 save() 호출로 DB 반영 보장
- INSTRUCTOR 역할에 강의 조회/수정 권한 추가 (getMyCourses, updateCourse)

## Type of Change

- [x] Fix: 버그 수정

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

프론트엔드 PR과 함께 머지해야 합니다.